### PR TITLE
JCLOUDS-37. Fix RAT violations in incubator-jclouds, 1.6.x branch

### DIFF
--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/filters/AddSessionKeyAndJSessionIdToRequest.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/filters/AddSessionKeyAndJSessionIdToRequest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.cloudstack.filters;
 
 import javax.inject.Inject;

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/functions/GetFirewallRulesByVirtualMachine.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/functions/GetFirewallRulesByVirtualMachine.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.cloudstack.functions;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/functions/GetIPForwardingRulesByVirtualMachine.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/functions/GetIPForwardingRulesByVirtualMachine.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.cloudstack.functions;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/functions/ParseLoginResponseFromHttpResponse.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/functions/ParseLoginResponseFromHttpResponse.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.cloudstack.functions;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/apis/ec2/src/main/java/org/jclouds/ec2/xml/IpPermissionHandler.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/xml/IpPermissionHandler.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.ec2.xml;
 
 import static org.jclouds.util.SaxUtils.currentOrNull;

--- a/apis/ec2/src/test/java/org/jclouds/ec2/binders/BindResourceIdsToIndexedFormParamsTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/binders/BindResourceIdsToIndexedFormParamsTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.ec2.binders;
 
 import static org.testng.Assert.assertEquals;

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/SubnetApiExpectTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/SubnetApiExpectTest.java
@@ -9,11 +9,11 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unles required by applicable law or agreed to in writing,
+ * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either expres or implied.  See the License for the
- * specific language governing permisions and limitations
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package org.jclouds.ec2.features;

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/TagApiExpectTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/TagApiExpectTest.java
@@ -9,11 +9,11 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unles required by applicable law or agreed to in writing,
+ * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either expres or implied.  See the License for the
- * specific language governing permisions and limitations
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package org.jclouds.ec2.features;

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/WindowsApiExpectTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/WindowsApiExpectTest.java
@@ -9,11 +9,11 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unles required by applicable law or agreed to in writing,
+ * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either expres or implied.  See the License for the
- * specific language governing permisions and limitations
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package org.jclouds.ec2.features;

--- a/apis/ec2/src/test/java/org/jclouds/ec2/internal/BaseEC2ApiLiveTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/internal/BaseEC2ApiLiveTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.ec2.internal;
 
 import org.jclouds.apis.BaseApiLiveTest;

--- a/apis/openstack-cinder/src/main/java/org/jclouds/openstack/cinder/v1/features/SnapshotApi.java
+++ b/apis/openstack-cinder/src/main/java/org/jclouds/openstack/cinder/v1/features/SnapshotApi.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.cinder.v1.features;
 
 import org.jclouds.openstack.cinder.v1.domain.Snapshot;

--- a/apis/openstack-cinder/src/main/java/org/jclouds/openstack/cinder/v1/features/VolumeApi.java
+++ b/apis/openstack-cinder/src/main/java/org/jclouds/openstack/cinder/v1/features/VolumeApi.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.cinder.v1.features;
 
 import org.jclouds.openstack.cinder.v1.domain.Volume;

--- a/apis/openstack-cinder/src/main/java/org/jclouds/openstack/cinder/v1/features/VolumeTypeApi.java
+++ b/apis/openstack-cinder/src/main/java/org/jclouds/openstack/cinder/v1/features/VolumeTypeApi.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.cinder.v1.features;
 
 import org.jclouds.openstack.cinder.v1.domain.VolumeType;

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/functions/RegionToAdminEndpointURI.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/functions/RegionToAdminEndpointURI.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.keystone.v2_0.functions;
 
 import javax.inject.Inject;

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/suppliers/RegionIdToAdminURISupplier.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/suppliers/RegionIdToAdminURISupplier.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.keystone.v2_0.suppliers;
 
 import java.net.URI;

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/KeystoneApiExpectTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/KeystoneApiExpectTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/KeystoneApiLiveTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/KeystoneApiLiveTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/ServiceApiExpectTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/ServiceApiExpectTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/ServiceApiLiveTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/ServiceApiLiveTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/TenantApiExpectTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/TenantApiExpectTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/TenantApiLiveTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/TenantApiLiveTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/TokenApiExpectTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/TokenApiExpectTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/TokenApiLiveTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/TokenApiLiveTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/UserApiExpectTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/UserApiExpectTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/UserApiLiveTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/features/UserApiLiveTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/internal/BaseKeystoneRestApiExpectTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/internal/BaseKeystoneRestApiExpectTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/parse/ParseDevstackApiMetadataTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/parse/ParseDevstackApiMetadataTest.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/parse/ParseRackspaceApiMetadataTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/parse/ParseRackspaceApiMetadataTest.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/functions/ExtensionToNameSpaceTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/functions/ExtensionToNameSpaceTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.v2_0.functions;
 
 import static org.testng.Assert.assertEquals;

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/functions/PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensionsSetTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/functions/PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensionsSetTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.v2_0.functions;
 
 import static org.jclouds.reflect.Reflection2.method;

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/predicates/LinkPredicatesTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/predicates/LinkPredicatesTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.v2_0.predicates;
 
 import static org.jclouds.openstack.v2_0.predicates.LinkPredicates.hrefEquals;

--- a/apis/openstack-nova-ec2/src/test/java/org/jclouds/openstack/nova/ec2/internal/BaseNovaEC2RestClientExpectTest.java
+++ b/apis/openstack-nova-ec2/src/test/java/org/jclouds/openstack/nova/ec2/internal/BaseNovaEC2RestClientExpectTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.nova.ec2.internal;
 
 import java.net.URI;

--- a/apis/openstack-nova-ec2/src/test/java/org/jclouds/openstack/nova/ec2/services/NovaEC2InstanceClientExpectTest.java
+++ b/apis/openstack-nova-ec2/src/test/java/org/jclouds/openstack/nova/ec2/services/NovaEC2InstanceClientExpectTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.nova.ec2.services;
 
 import static org.testng.Assert.assertEquals;

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/functions/FieldValueResponseParsers.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/functions/FieldValueResponseParsers.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.nova.v2_0.functions;
 
 import org.jclouds.http.HttpResponse;

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/functions/internal/ParseDiagnostics.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/functions/internal/ParseDiagnostics.java
@@ -1,17 +1,20 @@
-/*
- * Copyright 2012 jclouds.
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.jclouds.openstack.nova.v2_0.functions.internal;
 

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/NovaApiMetadataTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/NovaApiMetadataTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.nova.v2_0;
 
 import org.jclouds.compute.internal.BaseComputeServiceApiMetadataTest;

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/compute/NovaComputeServiceLiveTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/compute/NovaComputeServiceLiveTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.nova.v2_0.compute;
 
 import static java.util.logging.Logger.getAnonymousLogger;

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/parse/ParseServerDetailsEssexTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/parse/ParseServerDetailsEssexTest.java
@@ -7,9 +7,9 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing)
+ * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/parse/ParseServerDiagnostics.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/parse/ParseServerDiagnostics.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 /*
  * To change this template, choose Tools | Templates
  * and open the template in the editor.

--- a/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/domain/CreateDomain.java
+++ b/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/domain/CreateDomain.java
@@ -3,7 +3,7 @@
  * contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership. jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  * 

--- a/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/domain/CreateSubdomain.java
+++ b/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/domain/CreateSubdomain.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/domain/DomainChange.java
+++ b/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/domain/DomainChange.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/domain/Job.java
+++ b/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/domain/Job.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.rackspace.clouddns.v1.domain;
 
 import static com.google.common.base.Objects.toStringHelper;

--- a/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/domain/Subdomain.java
+++ b/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/domain/Subdomain.java
@@ -3,7 +3,7 @@
  * contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership. jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  * 

--- a/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/domain/UpdateDomain.java
+++ b/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/domain/UpdateDomain.java
@@ -3,7 +3,7 @@
  * contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership. jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  * 

--- a/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/features/DomainApi.java
+++ b/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/features/DomainApi.java
@@ -3,7 +3,7 @@
  * contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership. jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  * 

--- a/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/features/LimitApi.java
+++ b/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/features/LimitApi.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/features/ReverseDNSApi.java
+++ b/apis/rackspace-clouddns/src/main/java/org/jclouds/rackspace/clouddns/v1/features/ReverseDNSApi.java
@@ -3,7 +3,7 @@
  * contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership. jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  * 

--- a/apis/rackspace-cloudidentity/src/test/java/org/jclouds/rackspace/cloudidentity/v2_0/CloudIdentityApiLiveTest.java
+++ b/apis/rackspace-cloudidentity/src/test/java/org/jclouds/rackspace/cloudidentity/v2_0/CloudIdentityApiLiveTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/rackspace-cloudidentity/src/test/java/org/jclouds/rackspace/cloudidentity/v2_0/features/CloudIdentityServiceApiLiveTest.java
+++ b/apis/rackspace-cloudidentity/src/test/java/org/jclouds/rackspace/cloudidentity/v2_0/features/CloudIdentityServiceApiLiveTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/rackspace-cloudidentity/src/test/java/org/jclouds/rackspace/cloudidentity/v2_0/features/CloudIdentityTenantApiLiveTest.java
+++ b/apis/rackspace-cloudidentity/src/test/java/org/jclouds/rackspace/cloudidentity/v2_0/features/CloudIdentityTenantApiLiveTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/rackspace-cloudidentity/src/test/java/org/jclouds/rackspace/cloudidentity/v2_0/features/CloudIdentityTokenApiLiveTest.java
+++ b/apis/rackspace-cloudidentity/src/test/java/org/jclouds/rackspace/cloudidentity/v2_0/features/CloudIdentityTokenApiLiveTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/rackspace-cloudidentity/src/test/java/org/jclouds/rackspace/cloudidentity/v2_0/features/CloudIdentityUserApiLiveTest.java
+++ b/apis/rackspace-cloudidentity/src/test/java/org/jclouds/rackspace/cloudidentity/v2_0/features/CloudIdentityUserApiLiveTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/v1/domain/SessionPersistence.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/v1/domain/SessionPersistence.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.rackspace.cloudloadbalancers.v1.domain;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/apis/route53/src/test/java/org/jclouds/route53/Route53ApiExpectTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/Route53ApiExpectTest.java
@@ -9,11 +9,11 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unles required by applicable law or agreed to in writing,
+ * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either expres or implied.  See the License for the
- * specific language governing permisions and limitations
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package org.jclouds.route53;

--- a/apis/route53/src/test/java/org/jclouds/route53/features/HostedZoneApiExpectTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/features/HostedZoneApiExpectTest.java
@@ -9,11 +9,11 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unles required by applicable law or agreed to in writing,
+ * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either expres or implied.  See the License for the
- * specific language governing permisions and limitations
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package org.jclouds.route53.features;

--- a/apis/route53/src/test/java/org/jclouds/route53/features/ResourceRecordSetApiExpectTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/features/ResourceRecordSetApiExpectTest.java
@@ -9,11 +9,11 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unles required by applicable law or agreed to in writing,
+ * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either expres or implied.  See the License for the
- * specific language governing permisions and limitations
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package org.jclouds.route53.features;

--- a/apis/route53/src/test/java/org/jclouds/route53/features/ResourceRecordSetApiLiveTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/features/ResourceRecordSetApiLiveTest.java
@@ -9,11 +9,11 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unles required by applicable law or agreed to in writing,
+ * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either expres or implied.  See the License for the
- * specific language governing permisions and limitations
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package org.jclouds.route53.features;

--- a/apis/sqs/src/test/java/org/jclouds/sqs/options/CreateQueueOptionsTest.java
+++ b/apis/sqs/src/test/java/org/jclouds/sqs/options/CreateQueueOptionsTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.sqs.options;
 
 import static org.jclouds.sqs.options.CreateQueueOptions.Builder.attribute;

--- a/apis/sqs/src/test/java/org/jclouds/sqs/options/ReceiveMessageOptionsTest.java
+++ b/apis/sqs/src/test/java/org/jclouds/sqs/options/ReceiveMessageOptionsTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.sqs.options;
 
 import static org.jclouds.sqs.options.ReceiveMessageOptions.Builder.attribute;

--- a/apis/sts/src/test/java/org/jclouds/sts/STSApiExpectTest.java
+++ b/apis/sts/src/test/java/org/jclouds/sts/STSApiExpectTest.java
@@ -9,11 +9,11 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unles required by applicable law or agreed to in writing,
+ * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either expres or implied.  See the License for the
- * specific language governing permisions and limitations
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package org.jclouds.sts;

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/binders/BindMapToHeadersWithContainerMetadataPrefix.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/binders/BindMapToHeadersWithContainerMetadataPrefix.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.swift.binders;
 
 import org.jclouds.blobstore.binders.BindMapToHeadersWithPrefix;

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/blobstore/strategy/internal/AsyncMultipartUploadStrategy.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/blobstore/strategy/internal/AsyncMultipartUploadStrategy.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.swift.blobstore.strategy.internal;
 
 import com.google.common.util.concurrent.ListenableFuture;

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/blobstore/strategy/internal/ParallelMultipartUploadStrategy.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/blobstore/strategy/internal/ParallelMultipartUploadStrategy.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.swift.blobstore.strategy.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/config/SwiftKeystoneRestClientModule.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/config/SwiftKeystoneRestClientModule.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.swift.config;
 
 import static org.jclouds.reflect.Reflection2.typeToken;

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/internal/BaseSwiftKeystoneExpectTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/internal/BaseSwiftKeystoneExpectTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.swift.internal;
 
 import java.util.Properties;

--- a/apis/vcloud/src/test/java/org/jclouds/vcloud/compute/strategy/VCloudComputeServiceAdapterTest.java
+++ b/apis/vcloud/src/test/java/org/jclouds/vcloud/compute/strategy/VCloudComputeServiceAdapterTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.vcloud.compute.strategy;
 
 import static org.testng.Assert.assertEquals;

--- a/archetypes/compute-service-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/compute-service-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <archetype-descriptor name="jclouds-compute-service-archetype" partial="true">
   <requiredProperties>
     <requiredProperty key="groupId">

--- a/archetypes/rest-client-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/rest-client-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <archetype-descriptor name="jclouds-rest-client-archetype">
   <requiredProperties>
     <requiredProperty key="groupId">

--- a/archetypes/rest-client-archetype/src/main/resources/archetype-resources/src/test/java/features/KeyApiExpectTest.java
+++ b/archetypes/rest-client-archetype/src/main/resources/archetype-resources/src/test/java/features/KeyApiExpectTest.java
@@ -12,11 +12,11 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unles required by applicable law or agreed to in writing,
+ * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either expres or implied.  See the License for the
- * specific language governing permisions and limitations
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package ${package}.features;

--- a/assemblies/src/main/resources/assemblies/jar-with-dependencies-descriptor.xml
+++ b/assemblies/src/main/resources/assemblies/jar-with-dependencies-descriptor.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly>
     <id>jar-with-dependencies</id>

--- a/assemblies/src/main/resources/assemblies/jar-with-dependencies-no-core-no-apis-descriptor.xml
+++ b/assemblies/src/main/resources/assemblies/jar-with-dependencies-no-core-no-apis-descriptor.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly>
     <id>jar-with-dependencies</id>

--- a/assemblies/src/main/resources/assemblies/package-descriptor.xml
+++ b/assemblies/src/main/resources/assemblies/package-descriptor.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly>
     <id>package</id>

--- a/assemblies/src/main/resources/assemblies/provided-dependencies-descriptor.xml
+++ b/assemblies/src/main/resources/assemblies/provided-dependencies-descriptor.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly>
     <id>provided-dependencies</id>

--- a/assemblies/src/main/resources/assemblies/src-descriptor.xml
+++ b/assemblies/src/main/resources/assemblies/src-descriptor.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly>
     <id>src</id>

--- a/blobstore/src/main/java/org/jclouds/blobstore/options/ListAllOptions.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/options/ListAllOptions.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.blobstore.options;
 
 import com.google.common.annotations.Beta;

--- a/common/openstack/src/main/java/org/jclouds/openstack/keystone/v1_1/functions/PublicURLOrInternalIfNull.java
+++ b/common/openstack/src/main/java/org/jclouds/openstack/keystone/v1_1/functions/PublicURLOrInternalIfNull.java
@@ -1,17 +1,13 @@
 /**
- *
- * Copyright (C) 2009 Global Cloud Specialists, Inc. <info@globalcloudspecialists.com>
- *
- * ====================================================================
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
+ * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -19,7 +15,6 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * ====================================================================
  */
 package org.jclouds.openstack.keystone.v1_1.functions;
 

--- a/common/openstack/src/test/java/org/jclouds/openstack/keystone/v1_1/internal/BaseKeystoneRestClientExpectTest.java
+++ b/common/openstack/src/test/java/org/jclouds/openstack/keystone/v1_1/internal/BaseKeystoneRestClientExpectTest.java
@@ -3,11 +3,11 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, Version 1.1 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-1.1
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/common/openstack/src/test/java/org/jclouds/openstack/predicates/LinkPredicatesTest.java
+++ b/common/openstack/src/test/java/org/jclouds/openstack/predicates/LinkPredicatesTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.openstack.predicates;
 
 import static org.jclouds.openstack.predicates.LinkPredicates.hrefEquals;

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/internal/TerremarkVCloudApiMetadata.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/internal/TerremarkVCloudApiMetadata.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.trmk.vcloud_0_8.internal;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/common/trmk/src/main/resources/ConfigureInternetService.xml
+++ b/common/trmk/src/main/resources/ConfigureInternetService.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <InternetService xmlns="{ns}"
      xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
     <Id>{id}</Id>{options}

--- a/common/trmk/src/main/resources/CreateInternetService.xml
+++ b/common/trmk/src/main/resources/CreateInternetService.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <CreateInternetServiceRequest
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	xmlns="{ns}">

--- a/common/trmk/src/main/resources/CreateKey.xml
+++ b/common/trmk/src/main/resources/CreateKey.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <CreateKeyRequest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="{ns}">
 	<Name>{name}</Name>

--- a/common/trmk/src/main/resources/CreateNodeService.xml
+++ b/common/trmk/src/main/resources/CreateNodeService.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <CreateNodeServiceRequest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="{ns}">
 	<IpAddress>{ipAddress}</IpAddress>

--- a/common/trmk/src/test/resources/CreateInternetService-options-test.xml
+++ b/common/trmk/src/test/resources/CreateInternetService-options-test.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <CreateInternetServiceRequest
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	xmlns="urn:tmrk:vCloudExpressExtensions-1.6">

--- a/common/trmk/src/test/resources/CreateInternetService-test.xml
+++ b/common/trmk/src/test/resources/CreateInternetService-test.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <CreateInternetServiceRequest
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	xmlns="urn:tmrk:vCloudExpressExtensions-1.6">

--- a/common/trmk/src/test/resources/CreateInternetService-test2.xml
+++ b/common/trmk/src/test/resources/CreateInternetService-test2.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <CreateInternetServiceRequest
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	xmlns="urn:tmrk:vCloudExpressExtensions-1.6">

--- a/common/trmk/src/test/resources/CreateNodeService-options-test.xml
+++ b/common/trmk/src/test/resources/CreateNodeService-options-test.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <CreateNodeServiceRequest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="urn:tmrk:vCloudExpressExtensions-1.6">
 	<IpAddress>10.2.2.2</IpAddress>

--- a/common/trmk/src/test/resources/CreateNodeService-test.xml
+++ b/common/trmk/src/test/resources/CreateNodeService-test.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <CreateNodeServiceRequest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="urn:tmrk:vCloudExpressExtensions-1.6">
 	<IpAddress>172.16.20.3</IpAddress>

--- a/common/trmk/src/test/resources/CreateNodeService-test2.xml
+++ b/common/trmk/src/test/resources/CreateNodeService-test2.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <CreateNodeServiceRequest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="urn:tmrk:vCloudExpressExtensions-1.6">
 	<IpAddress>10.2.2.2</IpAddress>

--- a/compute/src/main/java/org/jclouds/compute/util/OpenSocketFinder.java
+++ b/compute/src/main/java/org/jclouds/compute/util/OpenSocketFinder.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.compute.util;
 
 import java.util.concurrent.TimeUnit;

--- a/compute/src/test/java/org/jclouds/compute/internal/BaseComputeServiceApiMetadataTest.java
+++ b/compute/src/test/java/org/jclouds/compute/internal/BaseComputeServiceApiMetadataTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.compute.internal;
 
 import static org.jclouds.reflect.Reflection2.typeToken;

--- a/compute/src/test/java/org/jclouds/compute/internal/FormatSharedNamesAndAppendUniqueStringToThoseWhichRepeatTest.java
+++ b/compute/src/test/java/org/jclouds/compute/internal/FormatSharedNamesAndAppendUniqueStringToThoseWhichRepeatTest.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE_2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/compute/src/test/resources/initscript_with_java.sh
+++ b/compute/src/test/resources/initscript_with_java.sh
@@ -3,6 +3,22 @@ set +u
 shopt -s xpg_echo
 shopt -s expand_aliases
 unset PATH JAVA_HOME LD_LIBRARY_PATH
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1
@@ -16,6 +32,22 @@ export LOG_DIR="$INSTANCE_HOME"
 function bootstrap {
       return $?
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function findPid {
    unset FOUND_PID;
    [ $# -eq 1 ] || {
@@ -31,6 +63,22 @@ function findPid {
       return 1
    }
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function forget {
    unset FOUND_PID;
    [ $# -eq 3 ] || {
@@ -79,10 +127,42 @@ END_OF_JCLOUDS_SCRIPT
 	export LOG_DIR='$LOG_DIR'
 END_OF_JCLOUDS_SCRIPT
    cat >> $INSTANCE_HOME/bootstrap.sh <<-'END_OF_JCLOUDS_SCRIPT'
-	function abort {
+	#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+function abort {
    echo "aborting: $@" 1>&2
    exit 1
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 alias apt-get-update="apt-get update -qq"
 alias apt-get-install="apt-get install -f -y -qq --force-yes"
 alias yum-install="yum --quiet --nogpgcheck -y install"
@@ -142,6 +222,22 @@ function setupPublicCurl() {
   ensure_can_resolve_public_dns
   return 0  
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # adds JAVA_HOME and into PATH in global and user-specific profiles
 function setupJavaHomeInProfile() {
   PROFILES=(/etc/bashrc $HOME/.bashrc /etc/skel/.bashrc)

--- a/compute/src/test/resources/initscript_with_jetty.sh
+++ b/compute/src/test/resources/initscript_with_jetty.sh
@@ -3,6 +3,22 @@ set +u
 shopt -s xpg_echo
 shopt -s expand_aliases
 unset PATH JAVA_HOME LD_LIBRARY_PATH
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1
@@ -16,6 +32,22 @@ export LOG_DIR="$INSTANCE_HOME"
 function configure-jetty {
       return $?
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function findPid {
    unset FOUND_PID;
    [ $# -eq 1 ] || {
@@ -31,6 +63,22 @@ function findPid {
       return 1
    }
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function forget {
    unset FOUND_PID;
    [ $# -eq 3 ] || {
@@ -79,10 +127,42 @@ END_OF_JCLOUDS_SCRIPT
 	export LOG_DIR='$LOG_DIR'
 END_OF_JCLOUDS_SCRIPT
    cat >> $INSTANCE_HOME/configure-jetty.sh <<-'END_OF_JCLOUDS_SCRIPT'
-	function abort {
+	#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+function abort {
    echo "aborting: $@" 1>&2
    exit 1
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 alias apt-get-update="apt-get update -qq"
 alias apt-get-install="apt-get install -f -y -qq --force-yes"
 alias yum-install="yum --quiet --nogpgcheck -y install"
@@ -142,6 +222,22 @@ function setupPublicCurl() {
   ensure_can_resolve_public_dns
   return 0  
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # adds JAVA_HOME and into PATH in global and user-specific profiles
 function setupJavaHomeInProfile() {
   PROFILES=(/etc/bashrc $HOME/.bashrc /etc/skel/.bashrc)

--- a/compute/src/test/resources/runscript.sh
+++ b/compute/src/test/resources/runscript.sh
@@ -3,6 +3,22 @@ set +u
 shopt -s xpg_echo
 shopt -s expand_aliases
 unset PATH JAVA_HOME LD_LIBRARY_PATH
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1
@@ -16,6 +32,22 @@ export LOG_DIR="$INSTANCE_HOME"
 function runScriptWithCreds {
       return $?
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function findPid {
    unset FOUND_PID;
    [ $# -eq 1 ] || {
@@ -31,6 +63,22 @@ function findPid {
       return 1
    }
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function forget {
    unset FOUND_PID;
    [ $# -eq 3 ] || {
@@ -79,10 +127,42 @@ END_OF_JCLOUDS_SCRIPT
 	export LOG_DIR='$LOG_DIR'
 END_OF_JCLOUDS_SCRIPT
    cat >> $INSTANCE_HOME/runScriptWithCreds.sh <<-'END_OF_JCLOUDS_SCRIPT'
-	function abort {
+	#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+function abort {
    echo "aborting: $@" 1>&2
    exit 1
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 alias apt-get-update="apt-get update -qq"
 alias apt-get-install="apt-get install -f -y -qq --force-yes"
 alias yum-install="yum --quiet --nogpgcheck -y install"
@@ -142,6 +222,22 @@ function setupPublicCurl() {
   ensure_can_resolve_public_dns
   return 0  
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # adds JAVA_HOME and into PATH in global and user-specific profiles
 function setupJavaHomeInProfile() {
   PROFILES=(/etc/bashrc $HOME/.bashrc /etc/skel/.bashrc)

--- a/compute/src/test/resources/runscript_adminUpdate.sh
+++ b/compute/src/test/resources/runscript_adminUpdate.sh
@@ -3,6 +3,22 @@ set +u
 shopt -s xpg_echo
 shopt -s expand_aliases
 unset PATH JAVA_HOME LD_LIBRARY_PATH
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1
@@ -16,6 +32,22 @@ export LOG_DIR="$INSTANCE_HOME"
 function adminUpdate {
       return $?
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function findPid {
    unset FOUND_PID;
    [ $# -eq 1 ] || {
@@ -31,6 +63,22 @@ function findPid {
       return 1
    }
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function forget {
    unset FOUND_PID;
    [ $# -eq 3 ] || {

--- a/core/src/main/java/org/jclouds/concurrent/config/ScheduledExecutorServiceModule.java
+++ b/core/src/main/java/org/jclouds/concurrent/config/ScheduledExecutorServiceModule.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.concurrent.config;
 
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;

--- a/core/src/main/java/org/jclouds/io/ContentMetadataCodec.java
+++ b/core/src/main/java/org/jclouds/io/ContentMetadataCodec.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.io;
 
 import static com.google.common.collect.Iterables.any;

--- a/core/src/main/java/org/jclouds/rest/config/InvocationConfig.java
+++ b/core/src/main/java/org/jclouds/rest/config/InvocationConfig.java
@@ -5,7 +5,7 @@
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy current the License at
+ * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/core/src/main/java/org/jclouds/rest/config/ReadAnnotationsAndProperties.java
+++ b/core/src/main/java/org/jclouds/rest/config/ReadAnnotationsAndProperties.java
@@ -5,7 +5,7 @@
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy current the License at
+ * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/core/src/test/java/org/jclouds/collect/AdvanceUntilEmptyIterableTest.java
+++ b/core/src/test/java/org/jclouds/collect/AdvanceUntilEmptyIterableTest.java
@@ -5,7 +5,7 @@
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy current the License at
+ * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/core/src/test/java/org/jclouds/collect/IterableWithMarkersTest.java
+++ b/core/src/test/java/org/jclouds/collect/IterableWithMarkersTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.collect;
 
 import org.testng.Assert;

--- a/core/src/test/java/org/jclouds/collect/PagedIterablesTest.java
+++ b/core/src/test/java/org/jclouds/collect/PagedIterablesTest.java
@@ -5,7 +5,7 @@
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy current the License at
+ * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/core/src/test/java/org/jclouds/collect/internal/Arg0ToPagedIterableTest.java
+++ b/core/src/test/java/org/jclouds/collect/internal/Arg0ToPagedIterableTest.java
@@ -5,7 +5,7 @@
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy current the License at
+ * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/core/src/test/java/org/jclouds/fallbacks/HeaderToRetryAfterExceptionTest.java
+++ b/core/src/test/java/org/jclouds/fallbacks/HeaderToRetryAfterExceptionTest.java
@@ -5,7 +5,7 @@
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy current the License at
+ * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/core/src/test/java/org/jclouds/rest/config/ReadAnnotationsAndPropertiesTest.java
+++ b/core/src/test/java/org/jclouds/rest/config/ReadAnnotationsAndPropertiesTest.java
@@ -5,7 +5,7 @@
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy current the License at
+ * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/drivers/gae/src/test/java/org/jclouds/gae/GaeSocketOpenTest.java
+++ b/drivers/gae/src/test/java/org/jclouds/gae/GaeSocketOpenTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.gae;
 
 import org.jclouds.Context;

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@ under the License.
           </execution>
         </executions>
         <configuration>
+          <excludeSubProjects>false</excludeSubProjects>
           <excludes>
             <exclude>**/BUILD.txt</exclude>
             <exclude>**/CHANGES.txt</exclude>
@@ -72,6 +73,7 @@ under the License.
             <exclude>**/README.md</exclude>
             <exclude>.git/**</exclude>
             <exclude>**/.gitignore</exclude>
+            <exclude>**/.gitattributes</exclude>
             <exclude>**/*.json</exclude>
             <exclude>**/*.log*</exclude>
             <exclude>**/TODO</exclude>
@@ -83,7 +85,10 @@ under the License.
             <exclude>**/.settings/**</exclude>
             <exclude>**/.checkstyle</exclude>
             <exclude>**/target/**</exclude>
-            <exclude>demos/getpath/src/test/resources/log4j.xml</exclude>
+            <exclude>**/*ProviderMetadata</exclude>
+            <exclude>**/*ApiMetadata</exclude>
+            <exclude>**/src/test/resources/**/*</exclude>
+            <exclude>**/*readme</exclude>
             <exclude>.repository/**</exclude>
             <!-- binary -->
           </excludes>

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/xml/ErrorEntryHandler.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/xml/ErrorEntryHandler.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.aws.s3.xml;
 
 import com.google.common.collect.Maps;

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/CreatePrimaryZone.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/CreatePrimaryZone.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/CreateRecord.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/CreateRecord.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/GeoRegionGroup.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/GeoRegionGroup.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/GeoService.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/GeoService.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/Node.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/Node.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/Record.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/Record.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/RecordId.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/RecordId.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/RecordSet.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/RecordSet.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.dynect.v3.domain;
 
 import static com.google.common.base.Objects.equal;

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/SOARecord.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/SOARecord.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/Session.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/Session.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/SessionCredentials.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/SessionCredentials.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.dynect.v3.domain;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/Zone.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/Zone.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/AAAAData.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/AAAAData.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/AData.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/AData.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/CNAMEData.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/CNAMEData.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/MXData.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/MXData.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/NSData.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/NSData.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/PTRData.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/PTRData.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/SOAData.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/SOAData.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/SPFData.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/SPFData.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.dynect.v3.domain.rdata;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/SRVData.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/SRVData.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/SSHFPData.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/SSHFPData.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.dynect.v3.domain.rdata;
 
 import static com.google.common.base.Preconditions.checkArgument;

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/TXTData.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/domain/rdata/TXTData.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/features/RecordApi.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/features/RecordApi.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/features/ZoneApi.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/features/ZoneApi.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/functions/ExtractLastPathComponent.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/functions/ExtractLastPathComponent.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/functions/ToRecordIds.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/functions/ToRecordIds.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/main/java/org/jclouds/dynect/v3/predicates/RecordPredicates.java
+++ b/providers/dynect/src/main/java/org/jclouds/dynect/v3/predicates/RecordPredicates.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/GeoRegionGroupApiExpectTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/GeoRegionGroupApiExpectTest.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/GeoRegionGroupApiLiveTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/GeoRegionGroupApiLiveTest.java
@@ -1,9 +1,9 @@
 /**
  * Licensed to jclouds, Inc. (jclouds) under one or more
  * contributor license agreements.  See the NOTICE file
- * distributed with this work additional information
+ * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/GeoServiceApiExpectTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/GeoServiceApiExpectTest.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/GeoServiceApiLiveTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/GeoServiceApiLiveTest.java
@@ -1,9 +1,9 @@
 /**
  * Licensed to jclouds, Inc. (jclouds) under one or more
  * contributor license agreements.  See the NOTICE file
- * distributed with this work additional information
+ * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/RecordApiExpectTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/RecordApiExpectTest.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/RecordApiLiveTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/RecordApiLiveTest.java
@@ -1,9 +1,9 @@
 /**
  * Licensed to jclouds, Inc. (jclouds) under one or more
  * contributor license agreements.  See the NOTICE file
- * distributed with this work additional information
+ * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/SessionApiExpectTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/SessionApiExpectTest.java
@@ -9,11 +9,11 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unles required by applicable law or agreed to in writing,
+ * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either expres or implied.  See the License for the
- * specific language governing permisions and limitations
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package org.jclouds.dynect.v3.features;

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/ZoneApiExpectTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/ZoneApiExpectTest.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/ZoneApiLiveTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/features/ZoneApiLiveTest.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/parse/GetAAAARecordResponseTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/parse/GetAAAARecordResponseTest.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/parse/GetARecordResponseTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/parse/GetARecordResponseTest.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/parse/GetCNAMERecordResponseTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/parse/GetCNAMERecordResponseTest.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/parse/GetMXRecordResponseTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/parse/GetMXRecordResponseTest.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/parse/GetPTRRecordResponseTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/parse/GetPTRRecordResponseTest.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/parse/GetTXTRecordResponseTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/parse/GetTXTRecordResponseTest.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
- * to you under the Apache License, String 2.0 (the
+ * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/predicates/RecordPredicatesTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/predicates/RecordPredicatesTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.dynect.v3.predicates;
 
 import static org.jclouds.dynect.v3.domain.RecordId.recordIdBuilder;

--- a/providers/glesys/src/main/java/org/jclouds/glesys/domain/AllowedArguments.java
+++ b/providers/glesys/src/main/java/org/jclouds/glesys/domain/AllowedArguments.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.glesys.domain;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/providers/glesys/src/main/java/org/jclouds/glesys/domain/GleSYSBoolean.java
+++ b/providers/glesys/src/main/java/org/jclouds/glesys/domain/GleSYSBoolean.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.glesys.domain;
 
 /**

--- a/providers/glesys/src/main/java/org/jclouds/glesys/reference/GleSYSConstants.java
+++ b/providers/glesys/src/main/java/org/jclouds/glesys/reference/GleSYSConstants.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.glesys.reference;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/providers/gogrid/src/test/java/org/jclouds/gogrid/services/BaseGoGridRestClientExpectTest.java
+++ b/providers/gogrid/src/test/java/org/jclouds/gogrid/services/BaseGoGridRestClientExpectTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.gogrid.services;
 
 import org.jclouds.date.TimeStamp;

--- a/providers/gogrid/src/test/java/org/jclouds/gogrid/services/GridServerClientExpectTest.java
+++ b/providers/gogrid/src/test/java/org/jclouds/gogrid/services/GridServerClientExpectTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.gogrid.services;
 
 import static org.testng.Assert.assertEquals;

--- a/providers/hpcloud-compute/src/main/java/org/jclouds/hpcloud/compute/HPCloudComputeServiceAdapter.java
+++ b/providers/hpcloud-compute/src/main/java/org/jclouds/hpcloud/compute/HPCloudComputeServiceAdapter.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.hpcloud.compute;
 
 import java.util.Set;

--- a/providers/hpcloud-compute/src/test/java/org/jclouds/hpcloud/compute/HPCloudComputeProviderTest.java
+++ b/providers/hpcloud-compute/src/test/java/org/jclouds/hpcloud/compute/HPCloudComputeProviderTest.java
@@ -4,7 +4,7 @@
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
- * "License"); you may not computee this file except in compliance
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
@@ -21,7 +21,7 @@
  *
  * ====================================================================
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not computee this file except in compliance with the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0

--- a/providers/hpcloud-compute/src/test/java/org/jclouds/hpcloud/compute/compute/HPCloudComputeComputeServiceLiveTest.java
+++ b/providers/hpcloud-compute/src/test/java/org/jclouds/hpcloud/compute/compute/HPCloudComputeComputeServiceLiveTest.java
@@ -4,7 +4,7 @@
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
- * "License"); you may not computee this file except in compliance
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0

--- a/providers/hpcloud-compute/src/test/java/org/jclouds/hpcloud/compute/compute/HPCloudComputeTemplateBuilderLiveTest.java
+++ b/providers/hpcloud-compute/src/test/java/org/jclouds/hpcloud/compute/compute/HPCloudComputeTemplateBuilderLiveTest.java
@@ -4,7 +4,7 @@
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
- * "License"); you may not computee this file except in compliance
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0

--- a/providers/ninefold-compute/src/main/java/org/jclouds/ninefold/compute/NinefoldComputeProviderMetadata.java
+++ b/providers/ninefold-compute/src/main/java/org/jclouds/ninefold/compute/NinefoldComputeProviderMetadata.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.ninefold.compute;
 
 import static org.jclouds.compute.config.ComputeServiceProperties.TEMPLATE;

--- a/providers/rackspace-cloudblockstorage-uk/src/test/java/org/jclouds/rackspace/cloudblockstorage/uk/CloudBlockStorageUKProviderTest.java
+++ b/providers/rackspace-cloudblockstorage-uk/src/test/java/org/jclouds/rackspace/cloudblockstorage/uk/CloudBlockStorageUKProviderTest.java
@@ -4,7 +4,7 @@
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
- * "License"); you may not computee this file except in compliance
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0

--- a/providers/rackspace-cloudblockstorage-us/src/test/java/org/jclouds/rackspace/cloudblockstorage/us/CloudBlockStorageUSProviderTest.java
+++ b/providers/rackspace-cloudblockstorage-us/src/test/java/org/jclouds/rackspace/cloudblockstorage/us/CloudBlockStorageUSProviderTest.java
@@ -4,7 +4,7 @@
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
- * "License"); you may not computee this file except in compliance
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0

--- a/providers/rackspace-cloudservers-uk/src/test/java/org/jclouds/rackspace/cloudservers/uk/CloudServersUKProviderMetadataExpectTest.java
+++ b/providers/rackspace-cloudservers-uk/src/test/java/org/jclouds/rackspace/cloudservers/uk/CloudServersUKProviderMetadataExpectTest.java
@@ -4,7 +4,7 @@
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
- * "License"); you may not uke this file except in compliance
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0

--- a/providers/rackspace-cloudservers-uk/src/test/java/org/jclouds/rackspace/cloudservers/uk/CloudServersUKProviderTest.java
+++ b/providers/rackspace-cloudservers-uk/src/test/java/org/jclouds/rackspace/cloudservers/uk/CloudServersUKProviderTest.java
@@ -4,7 +4,7 @@
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
- * "License"); you may not computee this file except in compliance
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
@@ -21,7 +21,7 @@
  *
  * ====================================================================
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not computee this file except in compliance with the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0

--- a/providers/rackspace-cloudservers-uk/src/test/java/org/jclouds/rackspace/cloudservers/uk/compute/CloudServersUKComputeServiceLiveTest.java
+++ b/providers/rackspace-cloudservers-uk/src/test/java/org/jclouds/rackspace/cloudservers/uk/compute/CloudServersUKComputeServiceLiveTest.java
@@ -4,7 +4,7 @@
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
- * "License"); you may not computee this file except in compliance
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0

--- a/providers/rackspace-cloudservers-uk/src/test/java/org/jclouds/rackspace/cloudservers/uk/compute/CloudServersUKTemplateBuilderLiveTest.java
+++ b/providers/rackspace-cloudservers-uk/src/test/java/org/jclouds/rackspace/cloudservers/uk/compute/CloudServersUKTemplateBuilderLiveTest.java
@@ -4,7 +4,7 @@
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
- * "License"); you may not computee this file except in compliance
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0

--- a/providers/rackspace-cloudservers-us/src/test/java/org/jclouds/rackspace/cloudservers/us/CloudServersUSProviderTest.java
+++ b/providers/rackspace-cloudservers-us/src/test/java/org/jclouds/rackspace/cloudservers/us/CloudServersUSProviderTest.java
@@ -4,7 +4,7 @@
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
- * "License"); you may not computee this file except in compliance
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
@@ -21,7 +21,7 @@
  *
  * ====================================================================
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not computee this file except in compliance with the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0

--- a/providers/rackspace-cloudservers-us/src/test/java/org/jclouds/rackspace/cloudservers/us/compute/CloudServersUSComputeServiceLiveTest.java
+++ b/providers/rackspace-cloudservers-us/src/test/java/org/jclouds/rackspace/cloudservers/us/compute/CloudServersUSComputeServiceLiveTest.java
@@ -4,7 +4,7 @@
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
- * "License"); you may not computee this file except in compliance
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0

--- a/providers/rackspace-cloudservers-us/src/test/java/org/jclouds/rackspace/cloudservers/us/compute/CloudServersUSTemplateBuilderLiveTest.java
+++ b/providers/rackspace-cloudservers-us/src/test/java/org/jclouds/rackspace/cloudservers/us/compute/CloudServersUSTemplateBuilderLiveTest.java
@@ -4,7 +4,7 @@
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
- * "License"); you may not computee this file except in compliance
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0

--- a/providers/trmk-ecloud/src/main/java/org/jclouds/trmk/ecloud/TerremarkECloudApiMetadata.java
+++ b/providers/trmk-ecloud/src/main/java/org/jclouds/trmk/ecloud/TerremarkECloudApiMetadata.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.trmk.ecloud;
 
 import static org.jclouds.trmk.vcloud_0_8.reference.TerremarkConstants.PROPERTY_TERREMARK_EXTENSION_NAME;

--- a/providers/trmk-ecloud/src/test/resources/CreateInternetService-options-test.xml
+++ b/providers/trmk-ecloud/src/test/resources/CreateInternetService-options-test.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <CreateInternetServiceRequest
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	xmlns="urn:tmrk:vCloudExpressExtensions-1.6">

--- a/providers/ultradns-ws/src/main/java/org/jclouds/ultradns/ws/UltraDNSWSExceptions.java
+++ b/providers/ultradns-ws/src/main/java/org/jclouds/ultradns/ws/UltraDNSWSExceptions.java
@@ -4,11 +4,10 @@
  * distributed with this work for additional information
  * regarding copyright ownership.  jclouds licenses this file
  * to you under the Apache License, Version 2.0 (the
- * "License"), you may not use this file except in compliance
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *
-http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/UltraDNSWSApiExpectTest.java
+++ b/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/UltraDNSWSApiExpectTest.java
@@ -9,11 +9,11 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unles required by applicable law or agreed to in writing,
+ * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either expres or implied.  See the License for the
- * specific language governing permisions and limitations
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package org.jclouds.ultradns.ws;

--- a/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/features/DirectionalGroupApiLiveTest.java
+++ b/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/features/DirectionalGroupApiLiveTest.java
@@ -11,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WATCANTIES OR CONDITIONS OF ANY
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.

--- a/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/features/DirectionalPoolApiLiveTest.java
+++ b/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/features/DirectionalPoolApiLiveTest.java
@@ -11,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WATCANTIES OR CONDITIONS OF ANY
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.

--- a/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/features/TrafficControllerPoolApiLiveTest.java
+++ b/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/features/TrafficControllerPoolApiLiveTest.java
@@ -11,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WATCANTIES OR CONDITIONS OF ANY
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.

--- a/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/internal/BaseDirectionalApiLiveTest.java
+++ b/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/internal/BaseDirectionalApiLiveTest.java
@@ -11,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WATCANTIES OR CONDITIONS OF ANY
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.

--- a/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/parse/GetAccountLevelDirectionalGroupsResponseTest.java
+++ b/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/parse/GetAccountLevelDirectionalGroupsResponseTest.java
@@ -11,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WADirectionalANTIES OR CONDITIONS OF ANY
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.

--- a/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/parse/GetAvailableGroupsResponseTest.java
+++ b/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/parse/GetAvailableGroupsResponseTest.java
@@ -11,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WADirectionalANTIES OR CONDITIONS OF ANY
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.

--- a/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/parse/GetDirectionalDNSGroupDetailsResponseTest.java
+++ b/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/parse/GetDirectionalDNSGroupDetailsResponseTest.java
@@ -11,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WADirectionalANTIES OR CONDITIONS OF ANY
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.

--- a/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/parse/GetDirectionalPoolsByZoneResponseTest.java
+++ b/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/parse/GetDirectionalPoolsByZoneResponseTest.java
@@ -11,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WADirectionalANTIES OR CONDITIONS OF ANY
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.

--- a/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/parse/GetTCLoadBalancingPoolsByZoneResponseTest.java
+++ b/providers/ultradns-ws/src/test/java/org/jclouds/ultradns/ws/parse/GetTCLoadBalancingPoolsByZoneResponseTest.java
@@ -11,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WATCANTIES OR CONDITIONS OF ANY
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.

--- a/resources/checkstyle.xml
+++ b/resources/checkstyle.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 

--- a/resources/checkstyle_suppressions.xml
+++ b/resources/checkstyle_suppressions.xml
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <?xml version="1.0"?>
 
 <!DOCTYPE suppressions PUBLIC

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/login/AdminAccessBuilderSpec.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/login/AdminAccessBuilderSpec.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.scriptbuilder.statements.login;
 
 import static com.google.common.base.Objects.equal;

--- a/scriptbuilder/src/main/resources/functions/abort.cmd
+++ b/scriptbuilder/src/main/resources/functions/abort.cmd
@@ -1,3 +1,19 @@
+REM
+REM Licensed to the Apache Software Foundation (ASF) under one or more
+REM contributor license agreements.  See the NOTICE file distributed with
+REM this work for additional information regarding copyright ownership.
+REM The ASF licenses this file to You under the Apache License, Version 2.0
+REM (the "License"); you may not use this file except in compliance with
+REM the License.  You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
 :abort
    echo aborting: %EXCEPTION%
    exit /b 1

--- a/scriptbuilder/src/main/resources/functions/abort.sh
+++ b/scriptbuilder/src/main/resources/functions/abort.sh
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1

--- a/scriptbuilder/src/main/resources/functions/findPid.cmd
+++ b/scriptbuilder/src/main/resources/functions/findPid.cmd
@@ -1,3 +1,19 @@
+REM
+REM Licensed to the Apache Software Foundation (ASF) under one or more
+REM contributor license agreements.  See the NOTICE file distributed with
+REM this work for additional information regarding copyright ownership.
+REM The ASF licenses this file to You under the Apache License, Version 2.0
+REM (the "License"); you may not use this file except in compliance with
+REM the License.  You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
 :findPid
    set FOUND_PID=
    set _expression=%1

--- a/scriptbuilder/src/main/resources/functions/findPid.sh
+++ b/scriptbuilder/src/main/resources/functions/findPid.sh
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function findPid {
    unset FOUND_PID;
    [ $# -eq 1 ] || {

--- a/scriptbuilder/src/main/resources/functions/forget.cmd
+++ b/scriptbuilder/src/main/resources/functions/forget.cmd
@@ -1,3 +1,19 @@
+REM
+REM Licensed to the Apache Software Foundation (ASF) under one or more
+REM contributor license agreements.  See the NOTICE file distributed with
+REM this work for additional information regarding copyright ownership.
+REM The ASF licenses this file to You under the Apache License, Version 2.0
+REM (the "License"); you may not use this file except in compliance with
+REM the License.  You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
 :forget
    SETLOCAL
    set FOUND_PID=

--- a/scriptbuilder/src/main/resources/functions/forget.sh
+++ b/scriptbuilder/src/main/resources/functions/forget.sh
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function forget {
    unset FOUND_PID;
    [ $# -eq 3 ] || {

--- a/scriptbuilder/src/main/resources/functions/installGit.sh
+++ b/scriptbuilder/src/main/resources/functions/installGit.sh
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function installGit() {
   if which dpkg &> /dev/null; then
     ensure_cmd_or_install_package_apt git git-core

--- a/scriptbuilder/src/main/resources/functions/installJDKFromURL.sh
+++ b/scriptbuilder/src/main/resources/functions/installJDKFromURL.sh
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # note this does not work until someone addresses user auth
 # https://issues.jenkins-ci.org/browse/JENKINS-10556
 # https://forums.oracle.com/forums/thread.jspa?messageID=10236239&tstart=0

--- a/scriptbuilder/src/main/resources/functions/installOpenJDK.sh
+++ b/scriptbuilder/src/main/resources/functions/installOpenJDK.sh
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # adds JAVA_HOME and into PATH in global and user-specific profiles
 function setupJavaHomeInProfile() {
   PROFILES=(/etc/bashrc $HOME/.bashrc /etc/skel/.bashrc)

--- a/scriptbuilder/src/main/resources/functions/installRuby.sh
+++ b/scriptbuilder/src/main/resources/functions/installRuby.sh
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function installRuby() {
   if ! hash ruby 2>/dev/null; then
     if which dpkg &> /dev/null; then

--- a/scriptbuilder/src/main/resources/functions/nextMinute.cmd
+++ b/scriptbuilder/src/main/resources/functions/nextMinute.cmd
@@ -1,3 +1,19 @@
+REM
+REM Licensed to the Apache Software Foundation (ASF) under one or more
+REM contributor license agreements.  See the NOTICE file distributed with
+REM this work for additional information regarding copyright ownership.
+REM The ASF licenses this file to You under the Apache License, Version 2.0
+REM (the "License"); you may not use this file except in compliance with
+REM the License.  You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
 :nextMinute
    SETLOCAL
    set HOURS=%TIME:~0,2%

--- a/scriptbuilder/src/main/resources/functions/setupPublicCurl.sh
+++ b/scriptbuilder/src/main/resources/functions/setupPublicCurl.sh
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 alias apt-get-update="apt-get update -qq"
 alias apt-get-install="apt-get install -f -y -qq --force-yes"
 alias yum-install="yum --quiet --nogpgcheck -y install"

--- a/scriptbuilder/src/main/resources/functions/sourceEnvFile.cmd
+++ b/scriptbuilder/src/main/resources/functions/sourceEnvFile.cmd
@@ -1,3 +1,19 @@
+REM
+REM Licensed to the Apache Software Foundation (ASF) under one or more
+REM contributor license agreements.  See the NOTICE file distributed with
+REM this work for additional information regarding copyright ownership.
+REM The ASF licenses this file to You under the Apache License, Version 2.0
+REM (the "License"); you may not use this file except in compliance with
+REM the License.  You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
 :sourceEnvFile
    set ENV_FILE=%1
    shift

--- a/scriptbuilder/src/main/resources/functions/sourceEnvFile.sh
+++ b/scriptbuilder/src/main/resources/functions/sourceEnvFile.sh
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function sourceEnvFile {
    [ $# -eq 1 ] || {
       abort "sourceEnvFile requires a parameter of the file to source"

--- a/scriptbuilder/src/main/resources/functions/stop.cmd
+++ b/scriptbuilder/src/main/resources/functions/stop.cmd
@@ -1,3 +1,19 @@
+REM
+REM Licensed to the Apache Software Foundation (ASF) under one or more
+REM contributor license agreements.  See the NOTICE file distributed with
+REM this work for additional information regarding copyright ownership.
+REM The ASF licenses this file to You under the Apache License, Version 2.0
+REM (the "License"); you may not use this file except in compliance with
+REM the License.  You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
 :abort
    CALL :findProcess %INSTANCE_NAME%
    if defined _pid (

--- a/scriptbuilder/src/main/resources/functions/validateEnvFile.cmd
+++ b/scriptbuilder/src/main/resources/functions/validateEnvFile.cmd
@@ -1,3 +1,19 @@
+REM
+REM Licensed to the Apache Software Foundation (ASF) under one or more
+REM contributor license agreements.  See the NOTICE file distributed with
+REM this work for additional information regarding copyright ownership.
+REM The ASF licenses this file to You under the Apache License, Version 2.0
+REM (the "License"); you may not use this file except in compliance with
+REM the License.  You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
 :validateEnvFile
    set ENV_FILE=%1
    shift

--- a/scriptbuilder/src/main/resources/functions/validateEnvFile.sh
+++ b/scriptbuilder/src/main/resources/functions/validateEnvFile.sh
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function validateEnvFile {
    [ $# -eq 1 ] || {
       abort "validateEnvFile requires a parameter of the file to source"

--- a/scriptbuilder/src/test/resources/test_ebs.sh
+++ b/scriptbuilder/src/test/resources/test_ebs.sh
@@ -3,6 +3,22 @@ set +u
 shopt -s xpg_echo
 shopt -s expand_aliases
 unset PATH JAVA_HOME LD_LIBRARY_PATH
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1
@@ -19,6 +35,22 @@ export EBS_DEVICE="/dev/sdh"
 export EBS_MOUNT_POINT="/mnt/ebs"
    return $?
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function findPid {
    unset FOUND_PID;
    [ $# -eq 1 ] || {
@@ -34,6 +66,22 @@ function findPid {
       return 1
    }
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function forget {
    unset FOUND_PID;
    [ $# -eq 3 ] || {

--- a/scriptbuilder/src/test/resources/test_find_pid.cmd
+++ b/scriptbuilder/src/test/resources/test_find_pid.cmd
@@ -3,9 +3,41 @@ set PATH=
 set JAVA_HOME=
 set PATH=
 GOTO FUNCTION_END
+REM
+REM Licensed to the Apache Software Foundation (ASF) under one or more
+REM contributor license agreements.  See the NOTICE file distributed with
+REM this work for additional information regarding copyright ownership.
+REM The ASF licenses this file to You under the Apache License, Version 2.0
+REM (the "License"); you may not use this file except in compliance with
+REM the License.  You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
 :abort
    echo aborting: %EXCEPTION%
    exit /b 1
+REM
+REM Licensed to the Apache Software Foundation (ASF) under one or more
+REM contributor license agreements.  See the NOTICE file distributed with
+REM this work for additional information regarding copyright ownership.
+REM The ASF licenses this file to You under the Apache License, Version 2.0
+REM (the "License"); you may not use this file except in compliance with
+REM the License.  You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
 :findPid
    set FOUND_PID=
    set _expression=%1

--- a/scriptbuilder/src/test/resources/test_find_pid.sh
+++ b/scriptbuilder/src/test/resources/test_find_pid.sh
@@ -3,10 +3,42 @@ set +u
 shopt -s xpg_echo
 shopt -s expand_aliases
 unset PATH JAVA_HOME LD_LIBRARY_PATH
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function findPid {
    unset FOUND_PID;
    [ $# -eq 1 ] || {

--- a/scriptbuilder/src/test/resources/test_init.sh
+++ b/scriptbuilder/src/test/resources/test_init.sh
@@ -3,6 +3,22 @@ set +u
 shopt -s xpg_echo
 shopt -s expand_aliases
 unset PATH JAVA_HOME LD_LIBRARY_PATH
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1
@@ -17,6 +33,22 @@ function mkebsboot {
    export TMP_DIR="/mnt/tmp"
    return $?
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function findPid {
    unset FOUND_PID;
    [ $# -eq 1 ] || {
@@ -32,6 +64,22 @@ function findPid {
       return 1
    }
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function forget {
    unset FOUND_PID;
    [ $# -eq 3 ] || {

--- a/scriptbuilder/src/test/resources/test_init_script.sh
+++ b/scriptbuilder/src/test/resources/test_init_script.sh
@@ -3,6 +3,22 @@ set +u
 shopt -s xpg_echo
 shopt -s expand_aliases
 unset PATH JAVA_HOME LD_LIBRARY_PATH
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1
@@ -16,6 +32,22 @@ export LOG_DIR="$INSTANCE_HOME"
 function testcall {
       return $?
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function findPid {
    unset FOUND_PID;
    [ $# -eq 1 ] || {
@@ -31,6 +63,22 @@ function findPid {
       return 1
    }
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function forget {
    unset FOUND_PID;
    [ $# -eq 3 ] || {
@@ -80,10 +128,42 @@ END_OF_JCLOUDS_SCRIPT
 	export LOG_DIR='$LOG_DIR'
 END_OF_JCLOUDS_SCRIPT
    cat >> $INSTANCE_HOME/testcall.sh <<-'END_OF_JCLOUDS_SCRIPT'
-	function abort {
+	#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+function abort {
    echo "aborting: $@" 1>&2
    exit 1
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function sourceEnvFile {
    [ $# -eq 1 ] || {
       abort "sourceEnvFile requires a parameter of the file to source"

--- a/scriptbuilder/src/test/resources/test_install_chef_gems_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_chef_gems_scriptbuilder.sh
@@ -3,6 +3,22 @@ set +u
 shopt -s xpg_echo
 shopt -s expand_aliases
 unset PATH JAVA_HOME LD_LIBRARY_PATH
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1
@@ -16,6 +32,22 @@ export LOG_DIR="$INSTANCE_HOME"
 function install_chef_gems {
       return $?
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function findPid {
    unset FOUND_PID;
    [ $# -eq 1 ] || {
@@ -31,6 +63,22 @@ function findPid {
       return 1
    }
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function forget {
    unset FOUND_PID;
    [ $# -eq 3 ] || {

--- a/scriptbuilder/src/test/resources/test_install_git_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_git_scriptbuilder.sh
@@ -3,6 +3,22 @@ set +u
 shopt -s xpg_echo
 shopt -s expand_aliases
 unset PATH JAVA_HOME LD_LIBRARY_PATH
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1
@@ -16,6 +32,22 @@ export LOG_DIR="$INSTANCE_HOME"
 function install_git {
       return $?
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function findPid {
    unset FOUND_PID;
    [ $# -eq 1 ] || {
@@ -31,6 +63,22 @@ function findPid {
       return 1
    }
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function forget {
    unset FOUND_PID;
    [ $# -eq 3 ] || {
@@ -79,10 +127,42 @@ END_OF_JCLOUDS_SCRIPT
 	export LOG_DIR='$LOG_DIR'
 END_OF_JCLOUDS_SCRIPT
    cat >> $INSTANCE_HOME/install_git.sh <<-'END_OF_JCLOUDS_SCRIPT'
-	function abort {
+	#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+function abort {
    echo "aborting: $@" 1>&2
    exit 1
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 alias apt-get-update="apt-get update -qq"
 alias apt-get-install="apt-get install -f -y -qq --force-yes"
 alias yum-install="yum --quiet --nogpgcheck -y install"
@@ -142,6 +222,22 @@ function setupPublicCurl() {
   ensure_can_resolve_public_dns
   return 0  
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function installGit() {
   if which dpkg &> /dev/null; then
     ensure_cmd_or_install_package_apt git git-core

--- a/scriptbuilder/src/test/resources/test_install_jdk_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_jdk_scriptbuilder.sh
@@ -3,6 +3,22 @@ set +u
 shopt -s xpg_echo
 shopt -s expand_aliases
 unset PATH JAVA_HOME LD_LIBRARY_PATH
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1
@@ -16,6 +32,22 @@ export LOG_DIR="$INSTANCE_HOME"
 function install_jdk {
       return $?
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function findPid {
    unset FOUND_PID;
    [ $# -eq 1 ] || {
@@ -31,6 +63,22 @@ function findPid {
       return 1
    }
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function forget {
    unset FOUND_PID;
    [ $# -eq 3 ] || {
@@ -79,10 +127,42 @@ END_OF_JCLOUDS_SCRIPT
 	export LOG_DIR='$LOG_DIR'
 END_OF_JCLOUDS_SCRIPT
    cat >> $INSTANCE_HOME/install_jdk.sh <<-'END_OF_JCLOUDS_SCRIPT'
-	function abort {
+	#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+function abort {
    echo "aborting: $@" 1>&2
    exit 1
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 alias apt-get-update="apt-get update -qq"
 alias apt-get-install="apt-get install -f -y -qq --force-yes"
 alias yum-install="yum --quiet --nogpgcheck -y install"
@@ -142,6 +222,22 @@ function setupPublicCurl() {
   ensure_can_resolve_public_dns
   return 0  
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # adds JAVA_HOME and into PATH in global and user-specific profiles
 function setupJavaHomeInProfile() {
   PROFILES=(/etc/bashrc $HOME/.bashrc /etc/skel/.bashrc)

--- a/scriptbuilder/src/test/resources/test_install_ruby_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_ruby_scriptbuilder.sh
@@ -3,6 +3,22 @@ set +u
 shopt -s xpg_echo
 shopt -s expand_aliases
 unset PATH JAVA_HOME LD_LIBRARY_PATH
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1
@@ -16,6 +32,22 @@ export LOG_DIR="$INSTANCE_HOME"
 function install_ruby {
       return $?
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function findPid {
    unset FOUND_PID;
    [ $# -eq 1 ] || {
@@ -31,6 +63,22 @@ function findPid {
       return 1
    }
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function forget {
    unset FOUND_PID;
    [ $# -eq 3 ] || {
@@ -79,10 +127,42 @@ END_OF_JCLOUDS_SCRIPT
 	export LOG_DIR='$LOG_DIR'
 END_OF_JCLOUDS_SCRIPT
    cat >> $INSTANCE_HOME/install_ruby.sh <<-'END_OF_JCLOUDS_SCRIPT'
-	function abort {
+	#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+function abort {
    echo "aborting: $@" 1>&2
    exit 1
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 alias apt-get-update="apt-get update -qq"
 alias apt-get-install="apt-get install -f -y -qq --force-yes"
 alias yum-install="yum --quiet --nogpgcheck -y install"
@@ -142,6 +222,22 @@ function setupPublicCurl() {
   ensure_can_resolve_public_dns
   return 0  
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function installRuby() {
   if ! hash ruby 2>/dev/null; then
     if which dpkg &> /dev/null; then

--- a/scriptbuilder/src/test/resources/test_install_rubygems_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_rubygems_scriptbuilder.sh
@@ -3,6 +3,22 @@ set +u
 shopt -s xpg_echo
 shopt -s expand_aliases
 unset PATH JAVA_HOME LD_LIBRARY_PATH
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1
@@ -16,6 +32,22 @@ export LOG_DIR="$INSTANCE_HOME"
 function install_rubygems {
       return $?
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function findPid {
    unset FOUND_PID;
    [ $# -eq 1 ] || {
@@ -31,6 +63,22 @@ function findPid {
       return 1
    }
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function forget {
    unset FOUND_PID;
    [ $# -eq 3 ] || {

--- a/scriptbuilder/src/test/resources/test_script.cmd
+++ b/scriptbuilder/src/test/resources/test_script.cmd
@@ -4,6 +4,22 @@ set JAVA_HOME=
 set PATH=
 set RUNTIME=
 GOTO FUNCTION_END
+REM
+REM Licensed to the Apache Software Foundation (ASF) under one or more
+REM contributor license agreements.  See the NOTICE file distributed with
+REM this work for additional information regarding copyright ownership.
+REM The ASF licenses this file to You under the Apache License, Version 2.0
+REM (the "License"); you may not use this file except in compliance with
+REM the License.  You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
 :abort
    echo aborting: %EXCEPTION%
    exit /b 1

--- a/scriptbuilder/src/test/resources/test_script.sh
+++ b/scriptbuilder/src/test/resources/test_script.sh
@@ -3,6 +3,22 @@ set +u
 shopt -s xpg_echo
 shopt -s expand_aliases
 unset PATH JAVA_HOME LD_LIBRARY_PATH RUNTIME
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1

--- a/scriptbuilder/src/test/resources/test_seek_and_destroy.cmd
+++ b/scriptbuilder/src/test/resources/test_seek_and_destroy.cmd
@@ -3,9 +3,41 @@ set PATH=
 set JAVA_HOME=
 set PATH=
 GOTO FUNCTION_END
+REM
+REM Licensed to the Apache Software Foundation (ASF) under one or more
+REM contributor license agreements.  See the NOTICE file distributed with
+REM this work for additional information regarding copyright ownership.
+REM The ASF licenses this file to You under the Apache License, Version 2.0
+REM (the "License"); you may not use this file except in compliance with
+REM the License.  You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
 :abort
    echo aborting: %EXCEPTION%
    exit /b 1
+REM
+REM Licensed to the Apache Software Foundation (ASF) under one or more
+REM contributor license agreements.  See the NOTICE file distributed with
+REM this work for additional information regarding copyright ownership.
+REM The ASF licenses this file to You under the Apache License, Version 2.0
+REM (the "License"); you may not use this file except in compliance with
+REM the License.  You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
 :findPid
    set FOUND_PID=
    set _expression=%1

--- a/scriptbuilder/src/test/resources/test_seek_and_destroy.sh
+++ b/scriptbuilder/src/test/resources/test_seek_and_destroy.sh
@@ -3,10 +3,42 @@ set +u
 shopt -s xpg_echo
 shopt -s expand_aliases
 unset PATH JAVA_HOME LD_LIBRARY_PATH
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function abort {
    echo "aborting: $@" 1>&2
    exit 1
 }
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function findPid {
    unset FOUND_PID;
    [ $# -eq 1 ] || {

--- a/skeletons/standalone-compute/src/main/java/org/jclouds/servermanager/ServerManagerApiMetadata.java
+++ b/skeletons/standalone-compute/src/main/java/org/jclouds/servermanager/ServerManagerApiMetadata.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.servermanager;
 
 import java.net.URI;


### PR DESCRIPTION
later pull requests will correct the license header to the ASF one.  This issue is only to fix RAT.
