### PR TITLE
add ^:dynamic to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ BlobStore Example (Clojure):
 
 ```clojure
 (use 'org.jclouds.blobstore2)
-(def *blobstore* (blobstore "azureblob" account encodedkey))
+(def ^:dynamic *blobstore* (blobstore "azureblob" account encodedkey))
 (create-container *blobstore* "mycontainer")
 (put-blob *blobstore* "mycontainer" (blob "test" :payload "testdata"))
 ```


### PR DESCRIPTION
prevent `Warning: *blobstore* not declared dynamic and thus is not dynamically rebindable, but its name suggests otherwise. Please either indicate ^:dynamic *blobstore* or change the name. (NO_SOURCE_PATH:1)`
