### PR TITLE
fixing jclouds-120

### DIFF
--- a/compute/src/main/clojure/org/jclouds/compute2.clj
+++ b/compute/src/main/clojure/org/jclouds/compute2.clj
@@ -362,6 +362,8 @@ Here's an example of creating and running a small linux node in the group webser
          :unmap-device-named
        ;; cloudstack ec2
          :key-pair
+       ;; openstack nova
+         :key-pair-name
        ;; aws-ec2
          :placement-group :subnet-id :spot-price :spot-options
          :iam-instance-profile-name :iam-instance-profile-arn


### PR DESCRIPTION
Having no way to set keyPairName while using pallet to start openstack node. About detailed info, pl. seeing:

https://issues.apache.org/jira/browse/JCLOUDS-120 . 
