### PR TITLE
JCLOUDS-235. Add support for datadisks to CloudStackTemplateOptions

### DIFF
--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/compute/options/CloudStackTemplateOptions.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/compute/options/CloudStackTemplateOptions.java
@@ -60,6 +60,8 @@ public class CloudStackTemplateOptions extends TemplateOptions implements Clonea
    protected String domainId;
    protected boolean generateKeyPair = false;
    protected boolean generateSecurityGroup = false;
+   protected String diskOfferingId;
+   protected int dataDiskSize;
    
    @Override
    public CloudStackTemplateOptions clone() {
@@ -83,7 +85,33 @@ public class CloudStackTemplateOptions extends TemplateOptions implements Clonea
          eTo.account(this.account);
          eTo.domainId(this.domainId);
          eTo.setupStaticNat(setupStaticNat);
+         eTo.diskOfferingId(diskOfferingId);
+         eTo.dataDiskSize(dataDiskSize);
       }
+   }
+
+   /**
+    * @see org.jclouds.cloudstack.options.DeployVirtualMachineOptions#diskOfferingId
+    */
+   public CloudStackTemplateOptions diskOfferingId(String diskOfferingId) {
+      this.diskOfferingId = diskOfferingId;
+      return this;
+   }
+
+   public String getDiskOfferingId() {
+      return diskOfferingId;
+   }
+
+   /**
+    * @see DeployVirtualMachineOptions#dataDiskSize
+    */
+   public CloudStackTemplateOptions dataDiskSize(int dataDiskSize) {
+      this.dataDiskSize = dataDiskSize;
+      return this;
+   }
+
+   public int getDataDiskSize() {
+      return dataDiskSize;
    }
 
    /**
@@ -229,6 +257,22 @@ public class CloudStackTemplateOptions extends TemplateOptions implements Clonea
    public static final CloudStackTemplateOptions NONE = new CloudStackTemplateOptions();
 
    public static class Builder {
+
+      /**
+       * @see CloudStackTemplateOptions#diskOfferingId
+       */
+      public static CloudStackTemplateOptions diskOfferingId(String diskOfferingId) {
+         CloudStackTemplateOptions options = new CloudStackTemplateOptions();
+         return options.diskOfferingId(diskOfferingId);
+      }
+
+      /**
+       * @see CloudStackTemplateOptions#dataDiskSize
+       */
+      public static CloudStackTemplateOptions dataDiskSize(int dataDiskSize) {
+         CloudStackTemplateOptions options = new CloudStackTemplateOptions();
+         return options.dataDiskSize(dataDiskSize);
+      }
 
       /**
        * @see CloudStackTemplateOptions#securityGroupId

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/compute/strategy/CloudStackComputeServiceAdapter.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/compute/strategy/CloudStackComputeServiceAdapter.java
@@ -196,6 +196,13 @@ public class CloudStackComputeServiceAdapter implements
          options.keyPair(keyPair.getName());
       }
 
+      if (templateOptions.getDiskOfferingId() != null) {
+         options.diskOfferingId(templateOptions.getDiskOfferingId());
+         if (templateOptions.getDataDiskSize() > 0) {
+            options.dataDiskSize(templateOptions.getDataDiskSize());
+         }
+      }
+
       if (supportsSecurityGroups().apply(zone)) {
          List<Integer> inboundPorts = Ints.asList(templateOptions.getInboundPorts());
 

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/options/DeployVirtualMachineOptions.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/options/DeployVirtualMachineOptions.java
@@ -199,11 +199,9 @@ public class DeployVirtualMachineOptions extends AccountInDomainOptions {
 
    /**
     * @param dataDiskSize
-    *           the arbitrary size for the DATADISK volume. Mutually exclusive
-    *           with diskOfferingId
+    *           the arbitrary size for the DATADISK volume.
     */
    public DeployVirtualMachineOptions dataDiskSize(long dataDiskSize) {
-      checkArgument(!queryParameters.containsKey("diskofferingid"), "Mutually exclusive with diskOfferingId");
       this.queryParameters.replaceValues("size", ImmutableSet.of(dataDiskSize + ""));
       return this;
    }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/compute/options/CloudStackTemplateOptionsTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/compute/options/CloudStackTemplateOptionsTest.java
@@ -17,6 +17,8 @@
 package org.jclouds.cloudstack.compute.options;
 
 import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.account;
+import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.dataDiskSize;
+import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.diskOfferingId;
 import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.domainId;
 import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.generateKeyPair;
 import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.generateSecurityGroup;
@@ -218,6 +220,24 @@ public class CloudStackTemplateOptionsTest {
    public void testKeyPair() {
       TemplateOptions options = keyPair("test");
       assertEquals(options.as(CloudStackTemplateOptions.class).getKeyPair(), "test");
+   }
+
+   @Test
+   public void testDiskOfferingId() {
+      TemplateOptions options = diskOfferingId("test");
+      assertEquals(options.as(CloudStackTemplateOptions.class).getDiskOfferingId(), "test");
+   }
+
+   @Test
+   public void testDataDiskSizeDefault() {
+      TemplateOptions options = new CloudStackTemplateOptions();
+      assertEquals(options.as(CloudStackTemplateOptions.class).getDataDiskSize(), 0);
+   }
+
+   @Test
+   public void testDataDiskSize() {
+      TemplateOptions options = dataDiskSize(10);
+      assertEquals(options.as(CloudStackTemplateOptions.class).getDataDiskSize(), 10);
    }
 
    @Test


### PR DESCRIPTION
Also adds support for the new options to
CloudStackComputeServiceAdapter, unsurprisingly. Also got rid of the
in fact wrong mutual exclusivity of dataDiskSize and diskOfferingId in
DeployVirtualMachineOptions - that's a misleading bit from the
CloudStack API docs.
