### PR TITLE
JCLOUDS-241: Added missing options to ListUsageRecordsOptions

### DIFF
--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/UsageRecord.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/UsageRecord.java
@@ -345,7 +345,7 @@ public class UsageRecord {
                          @Nullable String releaseDate, @Nullable String zoneId, @Nullable String virtualMachineId, @Nullable String virtualMachineName,
                          @Nullable String serviceOfferingId, @Nullable String templateId, @Nullable String ipAddress,
                          boolean isSourceNAT, double rawUsageHours, @Nullable String usage, @Nullable String type, @Nullable UsageType usageType) {
-      this.id = checkNotNull(id, "id");
+      this.id = id;
       this.description = description;
       this.accountId = accountId;
       this.accountName = accountName;

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/options/ListUsageRecordsOptions.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/options/ListUsageRecordsOptions.java
@@ -52,6 +52,22 @@ public class ListUsageRecordsOptions extends AccountInDomainOptions {
          ListUsageRecordsOptions options = new ListUsageRecordsOptions();
          return options.keyword(keyword);
       }
+	  
+      public static ListUsageRecordsOptions type(String type) {
+         ListUsageRecordsOptions options = new ListUsageRecordsOptions();
+         return options.type(type);
+      }
+      
+      public static ListUsageRecordsOptions page(String page) {
+         ListUsageRecordsOptions options = new ListUsageRecordsOptions();
+         return options.page(page);
+      }
+      
+      public static ListUsageRecordsOptions pageSize(String pageSize) {
+         ListUsageRecordsOptions options = new ListUsageRecordsOptions();
+         return options.pageSize(pageSize);
+      }
+
    }
 
    @Override
@@ -78,4 +94,20 @@ public class ListUsageRecordsOptions extends AccountInDomainOptions {
       this.queryParameters.replaceValues("keyword", ImmutableSet.of(keyword));
       return this;
    }
+   
+   public ListUsageRecordsOptions type(String type) {
+      this.queryParameters.replaceValues("type", ImmutableSet.of(type));
+      return this;
+   }
+   
+   public ListUsageRecordsOptions page(String page) {
+      this.queryParameters.replaceValues("page", ImmutableSet.of(page));
+      return this;
+   }
+   
+   public ListUsageRecordsOptions pageSize(String pageSize) {
+      this.queryParameters.replaceValues("pagesize", ImmutableSet.of(pageSize));
+      return this;
+   }
+	
 }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/options/ListUsageRecordsOptionsTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/options/ListUsageRecordsOptionsTest.java
@@ -20,6 +20,9 @@ import static org.jclouds.cloudstack.options.ListUsageRecordsOptions.Builder.acc
 import static org.jclouds.cloudstack.options.ListUsageRecordsOptions.Builder.accountInDomain;
 import static org.jclouds.cloudstack.options.ListUsageRecordsOptions.Builder.domainId;
 import static org.jclouds.cloudstack.options.ListUsageRecordsOptions.Builder.keyword;
+import static org.jclouds.cloudstack.options.ListUsageRecordsOptions.Builder.page;
+import static org.jclouds.cloudstack.options.ListUsageRecordsOptions.Builder.pageSize;
+import static org.jclouds.cloudstack.options.ListUsageRecordsOptions.Builder.type;
 import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
@@ -75,4 +78,20 @@ public class ListUsageRecordsOptionsTest {
       ListUsageRecordsOptions options = keyword("bob");
       assertEquals(ImmutableSet.of("bob"), options.buildQueryParameters().get("keyword"));
    }
+   
+       public void testTypeStatic() {
+        ListUsageRecordsOptions options = type("3");
+        assertEquals(ImmutableSet.of("3"), options.buildQueryParameters().get("type"));
+    }
+
+    public void testPageStatic() {
+        ListUsageRecordsOptions options = page("1");
+        assertEquals(ImmutableSet.of("1"), options.buildQueryParameters().get("page"));
+    }
+
+    public void testPageSizeStatic() {
+        ListUsageRecordsOptions options = pageSize("500");
+        assertEquals(ImmutableSet.of("500"), options.buildQueryParameters().get("pagesize"));
+    }
+	
 }


### PR DESCRIPTION
Added type, page, and pageSize to ListUsageRecordsOptions. These are optional parameters for listUsageRecords http://cloudstack.apache.org/docs/api/apidocs-4.1/root_admin/listUsageRecords.html
