### PR TITLE
JCLOUDS-242: AWSEC2CreateSecurityGroupIfNeeded was using a security group name, instead of an ID, when calling the API

### DIFF
--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/loaders/AWSEC2CreateSecurityGroupIfNeeded.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/loaders/AWSEC2CreateSecurityGroupIfNeeded.java
@@ -117,8 +117,9 @@ public class AWSEC2CreateSecurityGroupIfNeeded extends CacheLoader<RegionAndName
          Set<IpPermission> perms = permissions.build();
 
          if (perms.size() > 0) {
+            String id = Iterables.get(securityClient.describeSecurityGroupsInRegion(region, name), 0).getId();
             logger.debug(">> authorizing securityGroup region(%s) name(%s) IpPermissions(%s)", region, name, perms);
-            securityClient.authorizeSecurityGroupIngressInRegion(region, name, perms);
+            securityClient.authorizeSecurityGroupIngressInRegion(region, id, perms);
             logger.debug("<< authorized securityGroup(%s)", name);
          }            
 


### PR DESCRIPTION
This issue was causing createNodesInGroup to fail if a new security group is needed. See https://issues.apache.org/jira/browse/JCLOUDS-242 for more details.
