### PR TITLE
JCLOUDS-251: Swift: Delete chunks when deleting a multipart blob

### DIFF
--- a/apis/cloudfiles/src/test/java/org/jclouds/cloudfiles/blobstore/integration/CloudFilesBlobIntegrationLiveTest.java
+++ b/apis/cloudfiles/src/test/java/org/jclouds/cloudfiles/blobstore/integration/CloudFilesBlobIntegrationLiveTest.java
@@ -16,9 +16,14 @@
  */
 package org.jclouds.cloudfiles.blobstore.integration;
 
+import java.io.IOException;
+
+import org.jclouds.blobstore.BlobStore;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.openstack.swift.blobstore.integration.SwiftBlobIntegrationLiveTest;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
 
 /**
  * 
@@ -38,4 +43,22 @@ public class CloudFilesBlobIntegrationLiveTest extends SwiftBlobIntegrationLiveT
                .getMetadata().getContentMetadata().getContentDisposition();
    }
 
+   @Test(groups = { "integration", "live" })
+   public void testChunksAreDeletedWhenMultipartBlobIsDeleted() throws IOException, InterruptedException {
+      String containerName = getContainerName();
+      try {
+         BlobStore blobStore = view.getBlobStore();
+
+         long countBefore = blobStore.countBlobs(containerName);
+         String blobName = "deleteme.txt";
+         addMultipartBlobToContainer(containerName, blobName);
+
+         blobStore.removeBlob(containerName, blobName);
+         long countAfter = blobStore.countBlobs(containerName);
+
+         assertEquals(countAfter, countBefore);
+      } finally {
+          returnContainer(containerName);
+      }
+   }
 }

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/domain/MutableObjectInfoWithMetadata.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/domain/MutableObjectInfoWithMetadata.java
@@ -48,4 +48,7 @@ public interface MutableObjectInfoWithMetadata extends ObjectInfo {
 
    Map<String, String> getMetadata();
 
+   String getObjectManifest();
+
+   void setObjectManifest(String objectManifest);
 }

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/domain/internal/DelegatingMutableObjectInfoWithMetadata.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/domain/internal/DelegatingMutableObjectInfoWithMetadata.java
@@ -147,4 +147,14 @@ public class DelegatingMutableObjectInfoWithMetadata extends BaseMutableContentM
    public URI getUri() {
       return delegate.getUri();
    }
+
+   @Override
+   public void setObjectManifest(String objectManifest) {
+      delegate.setObjectManifest(objectManifest);
+   }
+
+   @Override
+   public String getObjectManifest() {
+      return delegate.getObjectManifest();
+   }
 }

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/domain/internal/MutableObjectInfoWithMetadataImpl.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/domain/internal/MutableObjectInfoWithMetadataImpl.java
@@ -41,6 +41,7 @@ public class MutableObjectInfoWithMetadataImpl implements MutableObjectInfoWithM
    private byte[] hash;
    private String contentType = MediaType.APPLICATION_OCTET_STREAM;
    private Date lastModified;
+   private String objectManifest;
    private final Map<String, String> metadata = Maps.newLinkedHashMap();
 
    /**
@@ -121,6 +122,7 @@ public class MutableObjectInfoWithMetadataImpl implements MutableObjectInfoWithM
       int result = 1;
       result = prime * result + ((container == null) ? 0 : container.hashCode());
       result = prime * result + ((name == null) ? 0 : name.hashCode());
+      result = prime * result + ((objectManifest == null) ? 0 : objectManifest.hashCode());
       return result;
    }
 
@@ -142,6 +144,11 @@ public class MutableObjectInfoWithMetadataImpl implements MutableObjectInfoWithM
          if (other.name != null)
             return false;
       } else if (!name.equals(other.name))
+         return false;
+      if (objectManifest == null) {
+         if (other.objectManifest != null)
+            return false;
+      } else if (!objectManifest.equals(other.objectManifest))
          return false;
       return true;
    }
@@ -197,9 +204,19 @@ public class MutableObjectInfoWithMetadataImpl implements MutableObjectInfoWithM
    }
 
    @Override
+   public String getObjectManifest() {
+      return objectManifest;
+   }
+
+   @Override
+   public void setObjectManifest(String objectManifest) {
+      this.objectManifest = objectManifest;
+   }
+
+   @Override
    public String toString() {
-      return String.format("[name=%s, container=%s, uri=%s, bytes=%s, contentType=%s, lastModified=%s, hash=%s]", name,
-               container, uri, bytes, contentType, lastModified, Arrays.toString(hash));
+      return String.format("[name=%s, container=%s, uri=%s, bytes=%s, contentType=%s, lastModified=%s, hash=%s, objectManifest=%s]",
+               name, container, uri, bytes, contentType, lastModified, Arrays.toString(hash), objectManifest);
    }
 
 }

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/functions/ParseObjectInfoFromHeaders.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/functions/ParseObjectInfoFromHeaders.java
@@ -65,6 +65,8 @@ public class ParseObjectInfoFromHeaders implements Function<HttpResponse, Mutabl
       if (eTagHeader != null) {
          to.setHash(ETagUtils.convertHexETagToByteArray(eTagHeader));
       }
+      to.setObjectManifest(from.getFirstHeaderOrNull("X-Object-Manifest"));
+
       return to;
    }
 

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/blobstore/SwiftBlobStoreTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/blobstore/SwiftBlobStoreTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.swift.blobstore;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+@Test(groups = "unit")
+public class SwiftBlobStoreTest {
+   @Test
+   public void testSplitContainerAndKey() {
+      String container = "test-container";
+      String key = "key/with/some/slashes/in/it/and/a/trailing/slash/";
+
+      String containerAndKey = container + "/" + key;
+
+      String[] split = SwiftBlobStore.splitContainerAndKey(containerAndKey);
+      String actualContainer = split[0];
+      String actualKey = split[1];
+
+      assertEquals(actualContainer, container);
+      assertEquals(actualKey, key);
+   }
+
+   @Test(expectedExceptions = IllegalArgumentException.class,
+         expectedExceptionsMessageRegExp = "No / separator found in \"not-a-container-and-key\"")
+   public void testSplitContainerAndKeyWithNoSeparator() {
+      SwiftBlobStore.splitContainerAndKey("not-a-container-and-key");
+   }
+}

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
@@ -119,6 +119,13 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
       return temp;
    }
 
+   public static long getOneHundredOneConstitutionsLength() throws IOException {
+      if (oneHundredOneConstitutionsLength == 0) {
+         getTestDataSupplier();
+      }
+      return oneHundredOneConstitutionsLength;
+   }
+
    /**
     * Attempt to capture the issue detailed in
     * http://groups.google.com/group/jclouds/browse_thread/thread/4a7c8d58530b287f


### PR DESCRIPTION
https://issues.apache.org/jira/browse/JCLOUDS-251

I'm trying to implement support for deleting chunks when deleting a multipart blob and I'd appreciate some help if anyone has time to help out...

1) The approach I've taken is to just automatically delete the chunks with no option to leave them, is this OK?

2) There are no tests for my new code. I found the existing tests for the code I've changed quite hard to understand, can anyone help out (either by writing some tests or helping me to understand them)? One thing to note is that I'm not familiar with Guice and there seems to be quite a bit of Guice magic going on in this project!

Note that I do have some test code in another project: https://github.com/brightinteractive/jclouds-prototype/blob/1cfa515b15658b3b7f74b2714dbf5b47fb4e14f2/src/test/java/com/brightinteractive/jclouds/PutGetDeleteMultiPartTest.java. This test passes when run against the 'bright' branch of jclouds, which has this JCLOUDS-251 branch and some other fixes merged into it.

3) General code review.
