### PR TITLE
[JCLOUDS-263] Usage of internalURL services' endpoints

### DIFF
--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/functions/InternalURL.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/functions/InternalURL.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.keystone.v2_0.functions;
+
+import java.net.URI;
+
+import javax.inject.Singleton;
+
+import org.jclouds.openstack.keystone.v2_0.domain.Endpoint;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+
+/**
+ * Select internal URL endpoints services
+ * 
+ * @author Ignacio Mulas
+ */
+@Singleton
+public class InternalURL implements EndpointToSupplierURI {
+   @Override
+   public Supplier<URI> apply(Endpoint input) {
+      return Suppliers.ofInstance(input.getInternalURL());
+   }
+
+   @Override
+   public String toString() {
+      return "supplyInternalURL()";
+   }
+}

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/v2_0/config/InternalUrlModule.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/v2_0/config/InternalUrlModule.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.v2_0.config;
+
+import org.jclouds.openstack.keystone.v2_0.functions.EndpointToSupplierURI;
+import org.jclouds.openstack.keystone.v2_0.functions.InternalURL;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Singleton;
+
+/**
+ * Guice module to configure JClouds in order to use the internal urls to
+ * communicate with the services.
+ * 
+ * @author Ignacio Mulas
+ * 
+ */
+@Singleton
+public class InternalUrlModule extends AbstractModule {
+   @Override
+   protected void configure() {
+      bind(EndpointToSupplierURI.class).to(InternalURL.class);
+   }
+}

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/functions/InternalURLTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/functions/InternalURLTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.keystone.v2_0.functions;
+
+import static org.testng.Assert.assertEquals;
+
+import java.net.URI;
+
+import org.jclouds.openstack.keystone.v2_0.domain.Endpoint;
+import org.testng.annotations.Test;
+
+/**
+ * @author Ignacio Mulas
+ */
+@Test(groups = "unit", testName = "InternalURLTest")
+public class InternalURLTest {
+   private final InternalURL fn = new InternalURL();
+
+   public void testInternalURL() {
+      assertEquals(
+            fn.apply(
+                  Endpoint.builder().region("regionOne").versionId("2.0")
+                        .internalURL(URI.create("https://ericsson.com/v2/1900e98b-7272-4cbd-8e95-0b8c2a9266c0"))
+                        .build()).get(), URI.create("https://ericsson.com/v2/1900e98b-7272-4cbd-8e95-0b8c2a9266c0"));
+   }
+}

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/functions/InternalURLLiveTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/functions/InternalURLLiveTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.nova.v2_0.functions;
+
+import static org.jclouds.Constants.PROPERTY_CONNECTION_TIMEOUT;
+
+import java.util.Properties;
+
+import org.jclouds.openstack.nova.v2_0.internal.BaseNovaApiLiveTest;
+import org.jclouds.openstack.v2_0.config.InternalUrlModule;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
+
+/**
+ * Simple live test to check the correct loading of the internal endpoint
+ * services.
+ * 
+ * @author Ignacio Mulas
+ * 
+ */
+@Test(groups = "live", testName = "InternalURLLiveTest")
+public class InternalURLLiveTest extends BaseNovaApiLiveTest {
+
+   @Test(description = "InternalUrl service endpoints loader")
+   public void testGetInternalUrlServiceEndpoint() throws Exception {
+      String zone = api.getConfiguredZones().iterator().next();
+      // List current servers to ensure that can reach nova with internalUrl ip
+      try {
+         api.getServerApiForZone(zone).list().concat().toList();
+      } catch (Exception e) {
+         Assert.fail("Could not retrieve servers list using the internalUrl", e);
+      }
+   }
+
+   @Override
+   protected Properties setupProperties() {
+      Properties properties = super.setupProperties();
+      properties.setProperty(PROPERTY_CONNECTION_TIMEOUT, "5000");
+      return properties;
+   }
+
+   @Override
+   protected Iterable<Module> setupModules() {
+      return ImmutableSet.<Module> of(getLoggingModule(), new InternalUrlModule());
+   }
+
+}


### PR DESCRIPTION
This code adds the possibility to configure Jclouds (keystone module) to use the internal urls services' endpoints.
