### PR TITLE
Adding a set of ports to IpPermission

### DIFF
--- a/apis/ec2/src/main/java/org/jclouds/ec2/util/IpPermissions.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/util/IpPermissions.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
+import com.google.common.collect.TreeRangeSet;
 
 /**
  *
@@ -44,7 +45,7 @@ public class IpPermissions extends IpPermission {
    protected IpPermissions(IpProtocol ipProtocol, int fromPort, int toPort,
          Multimap<String, String> userIdGroupPairs, Iterable<String> groupIds, Iterable<String> ipRanges) {
       super(ipProtocol, fromPort, toPort, userIdGroupPairs, groupIds, userIdGroupPairs.size() == 0 ? ipRanges
-            : ImmutableSet.<String> of());
+            : ImmutableSet.<String> of(), TreeRangeSet.<Integer>create());
    }
 
    /**

--- a/apis/ec2/src/test/java/org/jclouds/ec2/xml/DescribeSecurityGroupsResponseHandlerTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/xml/DescribeSecurityGroupsResponseHandlerTest.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.TreeRangeSet;
 
 /**
  * Tests behavior of {@code DescribeSecurityGroupsResponseHandler}
@@ -46,12 +47,12 @@ public class DescribeSecurityGroupsResponseHandlerTest extends BaseEC2HandlerTes
       InputStream is = getClass().getResourceAsStream("/describe_securitygroups.xml");
 
       Set<SecurityGroup> expected = ImmutableSet.of(
-            new SecurityGroup(defaultRegion, "sg-3c6ef654", "WebServers", "UYY3TLBUXIEON5NQVUUX6OMPWBZIQNFM", "Web Servers",
-                  ImmutableSet.of(new IpPermission(IpProtocol.TCP, 80, 80, ImmutableMultimap.<String, String> of(),
-                        ImmutableSet.<String> of(), ImmutableSet.of("0.0.0.0/0")))),
-            new SecurityGroup(defaultRegion, "sg-867309ab", "RangedPortsBySource", "UYY3TLBUXIEON5NQVUUX6OMPWBZIQNFM", "Group A",
-                  ImmutableSet.of(new IpPermission(IpProtocol.TCP, 6000, 7000, ImmutableMultimap
-                        .<String, String> of(), ImmutableSet.<String> of(), ImmutableSet.<String> of()))));
+              new SecurityGroup(defaultRegion, "sg-3c6ef654", "WebServers", "UYY3TLBUXIEON5NQVUUX6OMPWBZIQNFM", "Web Servers",
+                      ImmutableSet.of(new IpPermission(IpProtocol.TCP, 80, 80, ImmutableMultimap.<String, String>of(),
+                              ImmutableSet.<String>of(), ImmutableSet.of("0.0.0.0/0"), TreeRangeSet.<Integer>create()))),
+              new SecurityGroup(defaultRegion, "sg-867309ab", "RangedPortsBySource", "UYY3TLBUXIEON5NQVUUX6OMPWBZIQNFM", "Group A",
+                      ImmutableSet.of(new IpPermission(IpProtocol.TCP, 6000, 7000, ImmutableMultimap
+                              .<String, String>of(), ImmutableSet.<String>of(), ImmutableSet.<String>of(), TreeRangeSet.<Integer>create()))));
 
       DescribeSecurityGroupsResponseHandler handler = injector.getInstance(DescribeSecurityGroupsResponseHandler.class);
       addDefaultRegionToHandler(handler);
@@ -72,9 +73,9 @@ public class DescribeSecurityGroupsResponseHandlerTest extends BaseEC2HandlerTes
             new SecurityGroup(defaultRegion, "sg-3c6ef654", "jclouds#cluster#world", "UYY3TLBUXIEON5NQVUUX6OMPWBZIQNFM", "Cluster",
                   ImmutableSet.of(
                         new IpPermission(IpProtocol.TCP, 22, 22, ImmutableMultimap.<String, String> of(),
-                              ImmutableSet.<String> of(), ImmutableSet.of("0.0.0.0/0")),
+                              ImmutableSet.<String> of(), ImmutableSet.of("0.0.0.0/0"), TreeRangeSet.<Integer>create()),
                         new IpPermission(IpProtocol.ALL, -1, -1, userIdGroupPairs,
-                              ImmutableSet.<String> of(), ImmutableSet.<String> of()))));
+                              ImmutableSet.<String> of(), ImmutableSet.<String> of(), TreeRangeSet.<Integer>create()))));
 
       DescribeSecurityGroupsResponseHandler handler = injector.getInstance(DescribeSecurityGroupsResponseHandler.class);
       addDefaultRegionToHandler(handler);

--- a/compute/src/main/java/org/jclouds/net/util/IpPermissions.java
+++ b/compute/src/main/java/org/jclouds/net/util/IpPermissions.java
@@ -24,6 +24,7 @@ import org.jclouds.net.domain.IpProtocol;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.TreeRangeSet;
 
 /**
  * 
@@ -34,9 +35,10 @@ import com.google.common.collect.Multimap;
 public class IpPermissions extends IpPermission {
 
    protected IpPermissions(IpProtocol ipProtocol, int fromPort, int toPort,
-         Multimap<String, String> tenantIdGroupPairs, Iterable<String> groupIds, Iterable<String> cidrBlocks) {
+         Multimap<String, String> tenantIdGroupPairs, Iterable<String> groupIds, Iterable<String> cidrBlocks,
+         Iterable<Integer> ports) {
       super(ipProtocol, fromPort, toPort, tenantIdGroupPairs, groupIds, tenantIdGroupPairs.size() == 0 ? cidrBlocks
-            : ImmutableSet.<String> of());
+              : ImmutableSet.<String> of(), TreeRangeSet.<Integer>create());
    }
 
    public static ICMPTypeSelection permitICMP() {
@@ -107,7 +109,7 @@ public class IpPermissions extends IpPermission {
 
       protected ToGroupSourceSelection(IpProtocol ipProtocol, int fromPort, int toPort) {
          super(ipProtocol, fromPort, toPort, ImmutableMultimap.<String, String> of(), ImmutableSet.<String> of(),
-               ImmutableSet.of("0.0.0.0/0"));
+               ImmutableSet.of("0.0.0.0/0"), ImmutableSet.<Integer> of());
       }
 
       public IpPermissions originatingFromSecurityGroupId(String groupId) {
@@ -116,7 +118,7 @@ public class IpPermissions extends IpPermission {
 
       public IpPermissions originatingFromSecurityGroupIds(Iterable<String> groupIds) {
          return new IpPermissions(getIpProtocol(), getFromPort(), getToPort(), getTenantIdGroupNamePairs(), groupIds,
-               ImmutableSet.<String> of());
+               ImmutableSet.<String> of(), ImmutableSet.<Integer> of());
       }
    }
 
@@ -131,17 +133,18 @@ public class IpPermissions extends IpPermission {
 
       public IpPermissions originatingFromCidrBlocks(Iterable<String> cidrIps) {
          return new IpPermissions(getIpProtocol(), getFromPort(), getToPort(),
-               ImmutableMultimap.<String, String> of(), ImmutableSet.<String> of(), cidrIps);
+                 ImmutableMultimap.<String, String> of(), ImmutableSet.<String> of(), cidrIps,
+                 ImmutableSet.<Integer> of());
       }
 
       public IpPermissions originatingFromTenantAndSecurityGroup(String tenantId, String groupName) {
          return toTenantsGroupsNamed(ImmutableMultimap.of(checkNotNull(tenantId, "tenantId"),
-               checkNotNull(groupName, "groupName")));
+                 checkNotNull(groupName, "groupName")));
       }
 
       public IpPermissions toTenantsGroupsNamed(Multimap<String, String> tenantIdGroupNamePairs) {
          return new IpPermissions(getIpProtocol(), getFromPort(), getToPort(), tenantIdGroupNamePairs, getGroupIds(),
-               ImmutableSet.<String> of());
+                 ImmutableSet.<String> of(), ImmutableSet.<Integer> of());
       }
    }
 }


### PR DESCRIPTION
This is to enable translating GCE's Firewall.Rules, which support
RangeSets of ports, into a set of ports, so that IpPermission can
accurately reflect GCE and other possible usecases.
