### PR TITLE
Add failing test for aws-ec2 API assignability

### DIFF
--- a/apis/ec2/src/test/java/org/jclouds/ec2/EC2ContextBuilderText.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/EC2ContextBuilderText.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.ec2;
+
+import static org.jclouds.reflect.Reflection2.typeToken;
+
+import org.jclouds.ContextBuilder;
+import org.jclouds.View;
+import org.jclouds.compute.ComputeServiceContext;
+import org.testng.annotations.Test;
+
+/**
+ * @author Andrew Bayer
+ */
+@Test(groups = "unit", testName = "EC2ContextBuilderTest")
+public class EC2ContextBuilderText {
+   public void testAssignability() {
+      View view = ContextBuilder.newBuilder(new EC2ApiMetadata()).credentials("foo", "bar")
+              .buildView(typeToken(ComputeServiceContext.class));
+      view.unwrapApi(EC2Api.class);
+   }
+}

--- a/apis/openstack-nova-ec2/src/test/java/org/jclouds/openstack/nova/ec2/NovaEC2ContextBuilderTest.java
+++ b/apis/openstack-nova-ec2/src/test/java/org/jclouds/openstack/nova/ec2/NovaEC2ContextBuilderTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.nova.ec2;
+
+import static org.jclouds.reflect.Reflection2.typeToken;
+
+import org.jclouds.ContextBuilder;
+import org.jclouds.View;
+import org.jclouds.compute.ComputeServiceContext;
+import org.jclouds.ec2.EC2Api;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * @author Andrew Bayer
+ */
+@Test(groups = "unit", testName = "NovaEC2ContextBuilderTest")
+public class NovaEC2ContextBuilderTest {
+
+   public void testAssignability() {
+      View view = ContextBuilder.newBuilder(new NovaEC2ApiMetadata()).credentials("foo", "bar")
+              .buildView(typeToken(ComputeServiceContext.class));
+      view.unwrapApi(EC2Api.class);
+      view.unwrapApi(NovaEC2Api.class);
+   }
+}

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/AWSEC2ContextBuilderTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/AWSEC2ContextBuilderTest.java
@@ -18,13 +18,17 @@ package org.jclouds.aws.ec2;
 
 import static org.jclouds.aws.ec2.reference.AWSEC2Constants.PROPERTY_EC2_AMI_QUERY;
 import static org.jclouds.ec2.reference.EC2Constants.PROPERTY_EC2_AMI_OWNERS;
+import static org.jclouds.reflect.Reflection2.typeToken;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Map;
 import java.util.Properties;
 
 import org.jclouds.ContextBuilder;
+import org.jclouds.View;
 import org.jclouds.aws.ec2.compute.config.ImageQuery;
+import org.jclouds.compute.ComputeServiceContext;
+import org.jclouds.ec2.EC2Api;
 import org.testng.annotations.Test;
 
 import com.google.inject.Key;
@@ -39,6 +43,13 @@ public class AWSEC2ContextBuilderTest {
       return ContextBuilder.newBuilder(new AWSEC2ProviderMetadata()).overrides(input).credentials("foo", "bar")
                .buildInjector().getInstance(Key.get(new TypeLiteral<Map<String, String>>() {
                }, ImageQuery.class));
+   }
+
+   public void testAssignability() {
+      View view = ContextBuilder.newBuilder(new AWSEC2ProviderMetadata()).credentials("foo", "bar")
+              .buildView(typeToken(ComputeServiceContext.class));
+      view.unwrapApi(EC2Api.class);
+      view.unwrapApi(AWSEC2Api.class);
    }
 
    public void testConvertImageSyntax() {

--- a/providers/trmk-ecloud/src/test/java/org/jclouds/trmk/ecloud/TerremarkECloudClientMockTest.java
+++ b/providers/trmk-ecloud/src/test/java/org/jclouds/trmk/ecloud/TerremarkECloudClientMockTest.java
@@ -18,6 +18,7 @@ package org.jclouds.trmk.ecloud;
 
 import static com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor;
 import static org.jclouds.Constants.PROPERTY_MAX_RETRIES;
+import static org.jclouds.reflect.Reflection2.typeToken;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
@@ -27,7 +28,10 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.jclouds.ContextBuilder;
+import org.jclouds.View;
+import org.jclouds.compute.ComputeServiceContext;
 import org.jclouds.concurrent.config.ExecutorServiceModule;
+import org.jclouds.trmk.vcloud_0_8.TerremarkVCloudApi;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
@@ -59,6 +63,14 @@ public class TerremarkECloudClientMockTest {
    }
 
    String versionXML = "<SupportedVersions><VersionInfo><Version>0.8b-ext2.8</Version><LoginUrl>URLv0.8/login</LoginUrl></VersionInfo></SupportedVersions>";
+
+   @Test
+   public void testAssignability() {
+      View view = ContextBuilder.newBuilder(new TerremarkECloudProviderMetadata()).credentials("foo", "bar")
+              .buildView(typeToken(ComputeServiceContext.class));
+      view.unwrapApi(TerremarkVCloudApi.class);
+      view.unwrapApi(TerremarkECloudApi.class);
+   }
 
    @Test
    public void testLoginSetsContentLength() throws IOException, InterruptedException {

--- a/providers/trmk-vcloudexpress/src/test/java/org/jclouds/trmk/vcloudexpress/TerremarkVCloudExpressContextBuilderTest.java
+++ b/providers/trmk-vcloudexpress/src/test/java/org/jclouds/trmk/vcloudexpress/TerremarkVCloudExpressContextBuilderTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.trmk.vcloudexpress;
+
+import static org.jclouds.reflect.Reflection2.typeToken;
+
+import org.jclouds.ContextBuilder;
+import org.jclouds.View;
+import org.jclouds.compute.ComputeServiceContext;
+import org.jclouds.trmk.vcloud_0_8.TerremarkVCloudApi;
+import org.testng.annotations.Test;
+
+/**
+ * @author Andrew Bayer
+ */
+@Test(singleThreaded = true)
+public class TerremarkVCloudExpressContextBuilderTest {
+
+   @Test
+   public void testAssignability() {
+      View view = ContextBuilder.newBuilder(new TerremarkVCloudExpressProviderMetadata()).credentials("foo", "bar")
+              .buildView(typeToken(ComputeServiceContext.class));
+      view.unwrapApi(TerremarkVCloudApi.class);
+      view.unwrapApi(TerremarkVCloudExpressApi.class);
+   }
+}


### PR DESCRIPTION
This should be failing currently, but the underlying problem needs to be fixed.
