### PR TITLE
CloudStackApi should extend Closeable

### DIFF
--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/CloudStackApi.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/CloudStackApi.java
@@ -16,6 +16,8 @@
  */
 package org.jclouds.cloudstack;
 
+import java.io.Closeable;
+
 import org.jclouds.cloudstack.features.AccountApi;
 import org.jclouds.cloudstack.features.AddressApi;
 import org.jclouds.cloudstack.features.AsyncJobApi;
@@ -48,7 +50,7 @@ import org.jclouds.rest.annotations.Delegate;
  * @author Adrian Cole
  * @see <a href="http://download.cloud.com/releases/2.2.0/api_2.2.12/TOC_User.html" />
  */
-public interface CloudStackApi {
+public interface CloudStackApi extends Closeable {
    /**
     * Provides synchronous access to Zone features.
     */

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/CloudStackContextBuilderTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/CloudStackContextBuilderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.cloudstack;
+
+import static org.jclouds.reflect.Reflection2.typeToken;
+
+import org.jclouds.ContextBuilder;
+import org.jclouds.View;
+import org.jclouds.compute.ComputeServiceContext;
+import org.testng.annotations.Test;
+
+/**
+ * @author Andrew Bayer
+ */
+@Test(groups = "unit", testName = "CloudStackContextBuilderTest")
+public class CloudStackContextBuilderTest {
+
+   public void testAssignability() {
+      View view = ContextBuilder.newBuilder(new CloudStackApiMetadata()).credentials("foo", "bar")
+              .buildView(typeToken(ComputeServiceContext.class));
+      view.unwrapApi(CloudStackApi.class);
+   }
+}


### PR DESCRIPTION
Without that, you can't actually do view.unwrapApi(CloudStackApi.class).
