### PR TITLE
Fix OpenStack Nova SecurityGroupExtension based on live tests

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/compute/functions/NovaSecurityGroupInZoneToSecurityGroup.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/compute/functions/NovaSecurityGroupInZoneToSecurityGroup.java
@@ -68,6 +68,8 @@ public class NovaSecurityGroupInZoneToSecurityGroup implements Function<Security
 
       builder.location(zone);
 
+      builder.id(group.getZone() + "/" + group.getSecurityGroup().getId());
+
       return builder.build();
    }
 }

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/compute/functions/SecurityGroupRuleToIpPermission.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/compute/functions/SecurityGroupRuleToIpPermission.java
@@ -16,15 +16,30 @@
  */
 package org.jclouds.openstack.nova.v2_0.compute.functions;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Iterables.getFirst;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
 import javax.annotation.Resource;
+import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.jclouds.compute.reference.ComputeServiceConstants;
+import org.jclouds.domain.Location;
 import org.jclouds.logging.Logger;
 import org.jclouds.net.domain.IpPermission;
 import org.jclouds.openstack.nova.v2_0.domain.SecurityGroupRule;
+import org.jclouds.openstack.nova.v2_0.domain.zonescoped.SecurityGroupInZone;
+import org.jclouds.openstack.nova.v2_0.domain.zonescoped.ZoneAndName;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.base.Supplier;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.Atomics;
 
 
 /**
@@ -37,8 +52,18 @@ public class SecurityGroupRuleToIpPermission implements Function<SecurityGroupRu
    @Resource
    @Named(ComputeServiceConstants.COMPUTE_LOGGER)
    protected Logger logger = Logger.NULL;
-   
-   public SecurityGroupRuleToIpPermission() {
+   protected final Predicate<AtomicReference<ZoneAndName>> returnSecurityGroupExistsInZone;
+   protected final Supplier<Map<String, Location>> locationIndex;
+   LoadingCache<ZoneAndName, SecurityGroupInZone> groupMap;
+
+   @Inject
+   public SecurityGroupRuleToIpPermission(@Named("SECURITYGROUP_PRESENT") Predicate<AtomicReference<ZoneAndName>> returnSecurityGroupExistsInZone,
+                                          Supplier<Map<String, Location>> locationIndex,
+                                          LoadingCache<ZoneAndName, SecurityGroupInZone> groupMap) {
+      this.returnSecurityGroupExistsInZone = checkNotNull(returnSecurityGroupExistsInZone,
+              "returnSecurityGroupExistsInZone");
+      this.locationIndex = checkNotNull(locationIndex, "locationIndex");
+      this.groupMap = checkNotNull(groupMap, "groupMap");
    }
 
    @Override
@@ -47,11 +72,28 @@ public class SecurityGroupRuleToIpPermission implements Function<SecurityGroupRu
       builder.ipProtocol(rule.getIpProtocol());
       builder.fromPort(rule.getFromPort());
       builder.toPort(rule.getToPort());
-      if (rule.getGroup() != null) 
-         builder.tenantIdGroupNamePair(rule.getGroup().getTenantId(), rule.getGroup().getName());
+      if (rule.getGroup() != null) {
+         String zone = getFirst(filter(locationIndex.get().keySet(), isSecurityGroupInZone(rule.getGroup().getName())),
+                 null);
+         if (zone != null) {
+            SecurityGroupInZone group = groupMap.getUnchecked(ZoneAndName.fromZoneAndName(zone, rule.getGroup().getName()));
+            builder.groupId(zone + "/" + group.getSecurityGroup().getId());
+         }
+      }
       if (rule.getIpRange() != null)
          builder.cidrBlock(rule.getIpRange());
       
       return builder.build();
+   }
+
+   protected Predicate<String> isSecurityGroupInZone(final String groupName) {
+      return new Predicate<String>() {
+
+         @Override
+         public boolean apply(String zone) {
+            AtomicReference<ZoneAndName> securityGroupInZoneRef = Atomics.newReference(ZoneAndName.fromZoneAndName(zone, groupName));
+            return returnSecurityGroupExistsInZone.apply(securityGroupInZoneRef);
+         }
+      };
    }
 }

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/compute/extensions/NovaSecurityGroupExtensionExpectTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/compute/extensions/NovaSecurityGroupExtensionExpectTest.java
@@ -52,6 +52,13 @@ import com.google.common.collect.Sets;
 public class NovaSecurityGroupExtensionExpectTest extends BaseNovaComputeServiceExpectTest {
 
    protected String zone = "az-1.region-a.geo-1";
+   protected HttpRequest list = HttpRequest.builder().method("GET").endpoint(
+           URI.create("https://az-1.region-a.geo-1.compute.hpcloudsvc.com/v1.1/3456/os-security-groups")).headers(
+           ImmutableMultimap.<String, String> builder().put("Accept", "application/json").put("X-Auth-Token",
+                   authToken).build()).build();
+
+   protected HttpResponse listResponse = HttpResponse.builder().statusCode(200).payload(
+           payloadFromResource("/securitygroup_list_extension.json")).build();
 
    @Override
    protected Properties setupProperties() {
@@ -61,13 +68,6 @@ public class NovaSecurityGroupExtensionExpectTest extends BaseNovaComputeService
    }
 
    public void testListSecurityGroups() {
-      HttpRequest list = HttpRequest.builder().method("GET").endpoint(
-              URI.create("https://az-1.region-a.geo-1.compute.hpcloudsvc.com/v1.1/3456/os-security-groups")).headers(
-              ImmutableMultimap.<String, String> builder().put("Accept", "application/json").put("X-Auth-Token",
-                      authToken).build()).build();
-
-      HttpResponse listResponse = HttpResponse.builder().statusCode(200).payload(
-              payloadFromResource("/securitygroup_list.json")).build();
 
 
       Builder<HttpRequest, HttpResponse> requestResponseMap = ImmutableMap.<HttpRequest, HttpResponse> builder();
@@ -149,15 +149,24 @@ public class NovaSecurityGroupExtensionExpectTest extends BaseNovaComputeService
       Builder<HttpRequest, HttpResponse> requestResponseMap = ImmutableMap.<HttpRequest, HttpResponse> builder();
       requestResponseMap.put(keystoneAuthWithUsernameAndPasswordAndTenantName, responseWithKeystoneAccess);
       requestResponseMap.put(extensionsOfNovaRequest, extensionsOfNovaResponse);
-      requestResponseMap.put(getSecurityGroup, getSecurityGroupResponse).build();
+      requestResponseMap.put(getSecurityGroup, getSecurityGroupResponse);
+      requestResponseMap.put(list, listResponse).build();
 
       SecurityGroupExtension extension = requestsSendResponses(requestResponseMap.build()).getSecurityGroupExtension().get();
 
       SecurityGroup group = extension.getSecurityGroupById(zone + "/160");
-      assertEquals(group.getId(), "160");
+      assertEquals(group.getId(), zone + "/160");
    }
 
    public void testCreateSecurityGroup() {
+      HttpRequest getSecurityGroup = HttpRequest.builder().method("GET").endpoint(
+              URI.create("https://az-1.region-a.geo-1.compute.hpcloudsvc.com/v1.1/3456/os-security-groups/160")).headers(
+              ImmutableMultimap.<String, String> builder().put("Accept", "application/json").put("X-Auth-Token",
+                      authToken).build()).build();
+
+      HttpResponse getSecurityGroupResponse = HttpResponse.builder().statusCode(200).payload(
+              payloadFromResource("/securitygroup_details_extension.json")).build();
+
       HttpRequest create = HttpRequest.builder().method("POST").endpoint(
               URI.create("https://az-1.region-a.geo-1.compute.hpcloudsvc.com/v1.1/3456/os-security-groups")).headers(
               ImmutableMultimap.<String, String> builder().put("Accept", "application/json").put("X-Auth-Token",
@@ -182,7 +191,8 @@ public class NovaSecurityGroupExtensionExpectTest extends BaseNovaComputeService
       requestResponseMap.put(keystoneAuthWithUsernameAndPasswordAndTenantName, responseWithKeystoneAccess);
       requestResponseMap.put(extensionsOfNovaRequest, extensionsOfNovaResponse);
       requestResponseMap.put(create, createResponse);
-      requestResponseMap.put(list, listResponse).build();
+      requestResponseMap.put(list, listResponse);
+      requestResponseMap.put(getSecurityGroup, getSecurityGroupResponse).build();
 
       SecurityGroupExtension extension = requestsSendResponses(requestResponseMap.build()).getSecurityGroupExtension().get();
 
@@ -191,7 +201,7 @@ public class NovaSecurityGroupExtensionExpectTest extends BaseNovaComputeService
               .id(zone)
               .description("zone")
               .build());
-      assertEquals(group.getId(), "160");
+      assertEquals(group.getId(), zone + "/160");
    }
 
    public void testRemoveSecurityGroup() {
@@ -250,9 +260,9 @@ public class NovaSecurityGroupExtensionExpectTest extends BaseNovaComputeService
 
 
       SecurityGroupExtension extension = orderedRequestsSendResponses(ImmutableList.of(keystoneAuthWithUsernameAndPasswordAndTenantName,
-              extensionsOfNovaRequest, getSecurityGroup, createRule, getSecurityGroup),
+              extensionsOfNovaRequest, getSecurityGroup, createRule, getSecurityGroup, list, list),
               ImmutableList.of(responseWithKeystoneAccess, extensionsOfNovaResponse, getSecurityGroupNoRulesResponse,
-                      createRuleResponse, getSecurityGroupResponse)).getSecurityGroupExtension().get();
+                      createRuleResponse, getSecurityGroupResponse, listResponse, listResponse)).getSecurityGroupExtension().get();
 
       IpPermission.Builder builder = IpPermission.builder();
 
@@ -299,9 +309,9 @@ public class NovaSecurityGroupExtensionExpectTest extends BaseNovaComputeService
 
 
       SecurityGroupExtension extension = orderedRequestsSendResponses(ImmutableList.of(keystoneAuthWithUsernameAndPasswordAndTenantName,
-              extensionsOfNovaRequest, getSecurityGroup, createRule, getSecurityGroup),
+              extensionsOfNovaRequest, getSecurityGroup, createRule, getSecurityGroup, list, list),
               ImmutableList.of(responseWithKeystoneAccess, extensionsOfNovaResponse, getSecurityGroupNoRulesResponse,
-                      createRuleResponse, getSecurityGroupResponse)).getSecurityGroupExtension().get();
+                      createRuleResponse, getSecurityGroupResponse, listResponse, listResponse)).getSecurityGroupExtension().get();
 
       SecurityGroup origGroup = extension.getSecurityGroupById(zone + "/160");
 
@@ -345,9 +355,9 @@ public class NovaSecurityGroupExtensionExpectTest extends BaseNovaComputeService
 
 
       SecurityGroupExtension extension = orderedRequestsSendResponses(ImmutableList.of(keystoneAuthWithUsernameAndPasswordAndTenantName,
-              extensionsOfNovaRequest, getSecurityGroup, createRule, getSecurityGroup),
+              extensionsOfNovaRequest, getSecurityGroup, createRule, getSecurityGroup, list, list),
               ImmutableList.of(responseWithKeystoneAccess, extensionsOfNovaResponse, getSecurityGroupNoRulesResponse,
-                      createRuleResponse, getSecurityGroupResponse)).getSecurityGroupExtension().get();
+                      createRuleResponse, getSecurityGroupResponse, listResponse, listResponse)).getSecurityGroupExtension().get();
 
       IpPermission.Builder builder = IpPermission.builder();
 
@@ -394,9 +404,9 @@ public class NovaSecurityGroupExtensionExpectTest extends BaseNovaComputeService
 
 
       SecurityGroupExtension extension = orderedRequestsSendResponses(ImmutableList.of(keystoneAuthWithUsernameAndPasswordAndTenantName,
-              extensionsOfNovaRequest, getSecurityGroup, createRule, getSecurityGroup),
+              extensionsOfNovaRequest, getSecurityGroup, createRule, getSecurityGroup, list, list),
               ImmutableList.of(responseWithKeystoneAccess, extensionsOfNovaResponse, getSecurityGroupNoRulesResponse,
-                      createRuleResponse, getSecurityGroupResponse)).getSecurityGroupExtension().get();
+                      createRuleResponse, getSecurityGroupResponse, listResponse, listResponse)).getSecurityGroupExtension().get();
 
       SecurityGroup origGroup = extension.getSecurityGroupById(zone + "/160");
 

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/compute/functions/NovaSecurityGroupInZoneToSecurityGroupTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/compute/functions/NovaSecurityGroupInZoneToSecurityGroupTest.java
@@ -41,7 +41,6 @@ import com.google.common.collect.ImmutableSet;
 @Test(groups = "unit", testName = "NovaSecurityGroupInZoneToSecurityGroupTest")
 public class NovaSecurityGroupInZoneToSecurityGroupTest {
 
-   private static final SecurityGroupRuleToIpPermission ruleConverter = new SecurityGroupRuleToIpPermission();
    Location provider = new LocationBuilder().scope(LocationScope.PROVIDER).id("openstack-nova")
            .description("openstack-nova").build();
    Location zone = new LocationBuilder().id("az-1.region-a.geo-1").description("az-1.region-a.geo-1")
@@ -58,11 +57,12 @@ public class NovaSecurityGroupInZoneToSecurityGroupTest {
 
       SecurityGroup newGroup = parser.apply(origGroup);
 
-      assertEquals(newGroup.getId(), origGroup.getSecurityGroup().getId());
+      assertEquals(newGroup.getId(), origGroup.getZone() + "/" + origGroup.getSecurityGroup().getId());
       assertEquals(newGroup.getProviderId(), origGroup.getSecurityGroup().getId());
       assertEquals(newGroup.getName(), origGroup.getSecurityGroup().getName());
       assertEquals(newGroup.getOwnerId(), origGroup.getSecurityGroup().getTenantId());
-      assertEquals(newGroup.getIpPermissions(), ImmutableSet.copyOf(transform(origGroup.getSecurityGroup().getRules(), ruleConverter)));
+      assertEquals(newGroup.getIpPermissions(), ImmutableSet.copyOf(transform(origGroup.getSecurityGroup().getRules(),
+              NovaSecurityGroupToSecurityGroupTest.ruleConverter)));
       assertEquals(newGroup.getLocation().getId(), origGroup.getZone());
    }
 
@@ -75,16 +75,17 @@ public class NovaSecurityGroupInZoneToSecurityGroupTest {
 
       SecurityGroup newGroup = parser.apply(origGroup);
 
-      assertEquals(newGroup.getId(), origGroup.getSecurityGroup().getId());
+      assertEquals(newGroup.getId(), origGroup.getZone() + "/" + origGroup.getSecurityGroup().getId());
       assertEquals(newGroup.getProviderId(), origGroup.getSecurityGroup().getId());
       assertEquals(newGroup.getName(), origGroup.getSecurityGroup().getName());
       assertEquals(newGroup.getOwnerId(), origGroup.getSecurityGroup().getTenantId());
-      assertEquals(newGroup.getIpPermissions(), ImmutableSet.copyOf(transform(origGroup.getSecurityGroup().getRules(), ruleConverter)));
+      assertEquals(newGroup.getIpPermissions(), ImmutableSet.copyOf(transform(origGroup.getSecurityGroup().getRules(),
+              NovaSecurityGroupToSecurityGroupTest.ruleConverter)));
       assertEquals(newGroup.getLocation().getId(), origGroup.getZone());
    }
 
    private NovaSecurityGroupInZoneToSecurityGroup createGroupParser() {
-      NovaSecurityGroupToSecurityGroup baseParser = new NovaSecurityGroupToSecurityGroup(ruleConverter);
+      NovaSecurityGroupToSecurityGroup baseParser = new NovaSecurityGroupToSecurityGroup(NovaSecurityGroupToSecurityGroupTest.ruleConverter);
 
       NovaSecurityGroupInZoneToSecurityGroup parser = new NovaSecurityGroupInZoneToSecurityGroup(baseParser, locationIndex);
 

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/compute/functions/SecurityGroupRuleToIpPermissionTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/compute/functions/SecurityGroupRuleToIpPermissionTest.java
@@ -39,7 +39,7 @@ public class SecurityGroupRuleToIpPermissionTest {
    @Test
    public void testApplyWithGroup() {
 
-      TenantIdAndName group = TenantIdAndName.builder().tenantId("tenant").name("name").build();
+      TenantIdAndName group = TenantIdAndName.builder().tenantId("tenant").name("some-group").build();
       
       SecurityGroupRule ruleToConvert = SecurityGroupRule.builder()
          .id("some-id")
@@ -50,15 +50,12 @@ public class SecurityGroupRuleToIpPermissionTest {
          .parentGroupId("some-other-id")
          .build();
 
-      SecurityGroupRuleToIpPermission converter = new SecurityGroupRuleToIpPermission();
-
-      IpPermission convertedPerm = converter.apply(ruleToConvert);
+      IpPermission convertedPerm = NovaSecurityGroupToSecurityGroupTest.ruleConverter.apply(ruleToConvert);
 
       assertEquals(convertedPerm.getIpProtocol(), ruleToConvert.getIpProtocol());
       assertEquals(convertedPerm.getFromPort(), ruleToConvert.getFromPort());
       assertEquals(convertedPerm.getToPort(), ruleToConvert.getToPort());
-      assertTrue(convertedPerm.getTenantIdGroupNamePairs().containsKey(group.getTenantId()));
-      assertTrue(convertedPerm.getTenantIdGroupNamePairs().containsValue(group.getName()));
+      assertTrue(convertedPerm.getGroupIds().contains("az-1.region-a.geo-1/some-id"));
       assertTrue(convertedPerm.getCidrBlocks().size() == 0);
    }
 
@@ -73,9 +70,7 @@ public class SecurityGroupRuleToIpPermissionTest {
          .parentGroupId("some-other-id")
          .build();
 
-      SecurityGroupRuleToIpPermission converter = new SecurityGroupRuleToIpPermission();
-
-      IpPermission convertedPerm = converter.apply(ruleToConvert);
+      IpPermission convertedPerm = NovaSecurityGroupToSecurityGroupTest.ruleConverter.apply(ruleToConvert);
 
       assertEquals(convertedPerm.getIpProtocol(), ruleToConvert.getIpProtocol());
       assertEquals(convertedPerm.getFromPort(), ruleToConvert.getFromPort());

--- a/apis/openstack-nova/src/test/resources/securitygroup_details_extension.json
+++ b/apis/openstack-nova/src/test/resources/securitygroup_details_extension.json
@@ -16,8 +16,8 @@
               {
                  "from_port": 22,
                  "group": {
-                     "tenant_id": "admin",
-                     "name": "11111"
+                     "tenant_id": "tenant0",
+                     "name": "name0"
                   },
                   "ip_protocol": "tcp",
                   "to_port": 22,

--- a/apis/openstack-nova/src/test/resources/securitygroup_list_extension.json
+++ b/apis/openstack-nova/src/test/resources/securitygroup_list_extension.json
@@ -42,10 +42,10 @@
           "id":119
         }
       ],
-      "tenant_id":"dev_16767499955063",
-      "id":160,
-      "name":"jclouds-test",
-      "description":"jclouds-test"
+        "tenant_id": "tenant0",
+        "id": 160,
+        "name": "name0",
+        "description": "description0"
     }
   ]
 }

--- a/compute/src/test/java/org/jclouds/compute/extensions/internal/BaseSecurityGroupExtensionLiveTest.java
+++ b/compute/src/test/java/org/jclouds/compute/extensions/internal/BaseSecurityGroupExtensionLiveTest.java
@@ -244,8 +244,9 @@ public abstract class BaseSecurityGroupExtensionLiveTest extends BaseComputeServ
                                                                                      emptyStringSet(),
                                                                                      ImmutableSet.of(group.getId()),
                                                                                      newGroup);
-         
-         assertTrue(secondNewGroup.getIpPermissions().contains(secondPerm)); 
+
+         assertTrue(secondNewGroup.getIpPermissions().contains(secondPerm), "permissions for second group should contain "
+                 + secondPerm + " but do not: " + secondNewGroup.getIpPermissions());
       }
 
       if (securityGroupExtension.get().supportsTenantIdGroupNamePairs()

--- a/providers/hpcloud-compute/src/test/java/org/jclouds/hpcloud/compute/compute/extensions/HPCloudComputeSecurityGroupExtensionLiveTest.java
+++ b/providers/hpcloud-compute/src/test/java/org/jclouds/hpcloud/compute/compute/extensions/HPCloudComputeSecurityGroupExtensionLiveTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.hpcloud.compute.compute.extensions;
+
+import org.jclouds.compute.extensions.internal.BaseSecurityGroupExtensionLiveTest;
+import org.jclouds.sshj.config.SshjSshClientModule;
+import org.testng.annotations.Test;
+
+import com.google.inject.Module;
+
+/**
+ * 
+ * @author Andrew Bayer
+ * 
+ */
+@Test(groups = "live", singleThreaded = true, testName = "HPCloudComputeImageExtensionLiveTest")
+public class HPCloudComputeSecurityGroupExtensionLiveTest extends BaseSecurityGroupExtensionLiveTest {
+
+   public HPCloudComputeSecurityGroupExtensionLiveTest() {
+      provider = "hpcloud-compute";
+   }
+
+   @Override
+   protected Module getSshModule() {
+      return new SshjSshClientModule();
+   }
+}


### PR DESCRIPTION
So there were a few problems, but the core ugly one is that what you
pass in for creating a rule allowing groups' access is not the same
thing you get back from a group with such a rule, which makes mapping
between the arguments and the output insanely painful. So now, well,
we do some insanely painful stuff.
