### PR TITLE
Implement a poor-mans rollback if static nat creation fails

### DIFF
--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/compute/strategy/CloudStackComputeServiceAdapter.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/compute/strategy/CloudStackComputeServiceAdapter.java
@@ -251,7 +251,7 @@ public class CloudStackComputeServiceAdapter implements
              }
           }
       } catch (RuntimeException re) {
-          logger.error("-- exception after node has been created, trying to destroy the created VM");
+          logger.error("-- exception after node has been created, trying to destroy the created virtualMachine(%s)", vm.getId());
           destroyNode(vm.getId());
           throw(re);
       }


### PR DESCRIPTION
Catch exceptions while implementing static nat, destroy the already created vm and rethrow the exception. This will keep the concept of a failed operation clear for the api users, they would expect that the vm is not created when the builder throws an exception.
