### PR TITLE
JCLOUDS-361. Add support for filter parameters to DescribeInstances for aws-ec2

### DIFF
--- a/apis/ec2/pom.xml
+++ b/apis/ec2/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <test.ec2.endpoint>https://ec2.us-east-1.amazonaws.com</test.ec2.endpoint>
-    <test.ec2.api-version>2010-06-15</test.ec2.api-version>
+    <test.ec2.api-version>2010-08-31</test.ec2.api-version>
     <test.ec2.build-version />
     <test.ec2.identity>${test.aws.identity}</test.ec2.identity>
     <test.ec2.credential>${test.aws.credential}</test.ec2.credential>

--- a/apis/ec2/src/main/java/org/jclouds/ec2/EC2ApiMetadata.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/EC2ApiMetadata.java
@@ -72,7 +72,7 @@ public final class EC2ApiMetadata extends BaseHttpApiMetadata<EC2Api> {
          .credentialName("Secret Access Key")
          .defaultEndpoint("https://ec2.us-east-1.amazonaws.com")
          .documentation(URI.create("http://docs.amazonwebservices.com/AWSEC2/latest/APIReference"))
-         .version("2010-06-15")
+         .version("2010-08-31")
          .defaultProperties(EC2ApiMetadata.defaultProperties())
          .view(EC2ComputeServiceContext.class)
          .defaultModules(ImmutableSet.<Class<? extends Module>>of(EC2HttpApiModule.class, EC2ResolveImagesModule.class, EC2ComputeServiceContextModule.class));

--- a/apis/ec2/src/main/java/org/jclouds/ec2/domain/RunningInstance.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/domain/RunningInstance.java
@@ -330,7 +330,7 @@ public class RunningInstance implements Comparable<RunningInstance> {
     * more information, go to the Metadata section of the Amazon Elastic Compute Cloud Developer
     * Guide.
     * 
-    * @see <a href="http://docs.amazonwebservices.com/AWSEC2/2010-06-15/DeveloperGuide/" />
+    * @see <a href="http://docs.amazonwebservices.com/AWSEC2/2010-08-31/DeveloperGuide/" />
     */
    public String getAmiLaunchIndex() {
       return amiLaunchIndex;

--- a/apis/ec2/src/main/java/org/jclouds/ec2/features/AMIApi.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/features/AMIApi.java
@@ -28,6 +28,7 @@ import javax.ws.rs.Path;
 
 import org.jclouds.Fallbacks.EmptySetOnNotFoundOr404;
 import org.jclouds.aws.filters.FormSigner;
+import org.jclouds.ec2.binders.BindFiltersToIndexedFormParams;
 import org.jclouds.ec2.binders.BindUserGroupsToIndexedFormParams;
 import org.jclouds.ec2.binders.BindUserIdsToIndexedFormParams;
 import org.jclouds.ec2.domain.Image;
@@ -50,6 +51,8 @@ import org.jclouds.rest.annotations.FormParams;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.VirtualHost;
 import org.jclouds.rest.annotations.XMLResponseParser;
+
+import com.google.common.collect.Multimap;
 
 /**
  * Provides access to AMI Services.
@@ -84,6 +87,33 @@ public interface AMIApi {
    Set<? extends Image> describeImagesInRegion(
             @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
             DescribeImagesOptions... options);
+
+   /**
+    * Returns information about AMIs, AKIs, and ARIs. This includes image type, product codes,
+    * architecture, and kernel and RAM disk IDs. Images available to you include public images,
+    * private images that you own, and private images owned by other users for which you have
+    * explicit launch permissions.
+    *
+    * @param region
+    *           AMIs are tied to the Region where its files are located within Amazon S3.
+    * @param filter
+    *           Multimap of filter key/values.
+    * @see InstanceApi#describeInstances
+    * @see #describeImageAttribute
+    * @see <a href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeImages.html"
+    *      />
+    * @see DescribeImagesOptions
+    */
+   @Named("DescribeImages")
+   @POST
+   @Path("/")
+   @FormParams(keys = ACTION, values = "DescribeImages")
+   @XMLResponseParser(DescribeImagesResponseHandler.class)
+   @Fallback(EmptySetOnNotFoundOr404.class)
+   Set<? extends Image> describeImagesInRegionWithFilter(
+           @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
+           @BinderParam(BindFiltersToIndexedFormParams.class) Multimap<String, String> filter,
+           DescribeImagesOptions... options);
 
    /**
     * Creates an AMI that uses an Amazon EBS root device from a "running" or "stopped" instance.

--- a/apis/ec2/src/main/java/org/jclouds/ec2/features/ElasticIPAddressApi.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/features/ElasticIPAddressApi.java
@@ -27,6 +27,7 @@ import javax.ws.rs.Path;
 
 import org.jclouds.Fallbacks.EmptySetOnNotFoundOr404;
 import org.jclouds.aws.filters.FormSigner;
+import org.jclouds.ec2.binders.BindFiltersToIndexedFormParams;
 import org.jclouds.ec2.binders.BindPublicIpsToIndexedFormParams;
 import org.jclouds.ec2.domain.PublicIpInstanceIdPair;
 import org.jclouds.ec2.xml.AllocateAddressResponseHandler;
@@ -38,8 +39,11 @@ import org.jclouds.rest.annotations.EndpointParam;
 import org.jclouds.rest.annotations.Fallback;
 import org.jclouds.rest.annotations.FormParams;
 import org.jclouds.rest.annotations.RequestFilters;
+import org.jclouds.rest.annotations.SinceApiVersion;
 import org.jclouds.rest.annotations.VirtualHost;
 import org.jclouds.rest.annotations.XMLResponseParser;
+
+import com.google.common.collect.Multimap;
 
 /**
  * Provides access to EC2 Elastic IP Addresses via REST API.
@@ -168,4 +172,29 @@ public interface ElasticIPAddressApi {
             @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
             @BinderParam(BindPublicIpsToIndexedFormParams.class) String... publicIps);
 
+   /**
+    * Lists elastic IP addresses assigned to your identity or provides information on addresses
+    * matching a given filter.
+    *
+    * @param region
+    *           Elastic IP addresses are tied to a Region and cannot be mapped across Regions.
+    * @param filter
+    *
+    * @throws AWSResponseException
+    *            if the requested publicIp is not found
+    * @see #allocateAddress
+    * @see #releaseAddress
+    * @see <a href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeAddresses.html"
+    *      />
+    */
+   @SinceApiVersion("2010-08-31")
+   @Named("DescribeAddresses")
+   @POST
+   @Path("/")
+   @FormParams(keys = ACTION, values = "DescribeAddresses")
+   @XMLResponseParser(DescribeAddressesResponseHandler.class)
+   @Fallback(EmptySetOnNotFoundOr404.class)
+   Set<PublicIpInstanceIdPair> describeAddressesInRegionWithFilter(
+           @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
+           @BinderParam(BindFiltersToIndexedFormParams.class) Multimap<String, String> filter);
 }

--- a/apis/ec2/src/main/java/org/jclouds/ec2/features/KeyPairApi.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/features/KeyPairApi.java
@@ -27,6 +27,7 @@ import javax.ws.rs.Path;
 
 import org.jclouds.Fallbacks.EmptySetOnNotFoundOr404;
 import org.jclouds.aws.filters.FormSigner;
+import org.jclouds.ec2.binders.BindFiltersToIndexedFormParams;
 import org.jclouds.ec2.binders.BindKeyNamesToIndexedFormParams;
 import org.jclouds.ec2.domain.KeyPair;
 import org.jclouds.ec2.xml.DescribeKeyPairsResponseHandler;
@@ -40,6 +41,8 @@ import org.jclouds.rest.annotations.FormParams;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.VirtualHost;
 import org.jclouds.rest.annotations.XMLResponseParser;
+
+import com.google.common.collect.Multimap;
 
 /**
  * Provides access to EC2 via their REST API.
@@ -103,6 +106,31 @@ public interface KeyPairApi {
    Set<KeyPair> describeKeyPairsInRegion(
             @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
             @BinderParam(BindKeyNamesToIndexedFormParams.class) String... keyPairNames);
+
+   /**
+    * Returns information about key pairs available to you. If you specify filters,
+    * information about keypairs matching those filters is returned. Otherwise, all
+    * keypairs you have access to are returned.
+    *
+    * @param region
+    *           Key pairs (to connect to instances) are Region-specific.
+    * @param filter
+    *           Multimap of filter key/values.
+    *
+    * @see #runInstances
+    * @see #describeAvailabilityZones
+    * @see <a href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeKeyPairs.html"
+    *      />
+    */
+   @Named("DescribeKeyPairs")
+   @POST
+   @Path("/")
+   @FormParams(keys = ACTION, values = "DescribeKeyPairs")
+   @XMLResponseParser(DescribeKeyPairsResponseHandler.class)
+   @Fallback(EmptySetOnNotFoundOr404.class)
+   Set<KeyPair> describeKeyPairsInRegionWithFilter(
+           @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
+           @BinderParam(BindFiltersToIndexedFormParams.class) Multimap<String, String> filter);
 
    /**
     * Deletes the specified key pair, by removing the public key from Amazon EC2. You must own the

--- a/apis/ec2/src/main/java/org/jclouds/ec2/features/SecurityGroupApi.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/features/SecurityGroupApi.java
@@ -28,6 +28,7 @@ import javax.ws.rs.Path;
 import org.jclouds.Fallbacks.EmptySetOnNotFoundOr404;
 import org.jclouds.Fallbacks.VoidOnNotFoundOr404;
 import org.jclouds.aws.filters.FormSigner;
+import org.jclouds.ec2.binders.BindFiltersToIndexedFormParams;
 import org.jclouds.ec2.binders.BindGroupNamesToIndexedFormParams;
 import org.jclouds.ec2.binders.BindUserIdGroupPairToSourceSecurityGroupFormParams;
 import org.jclouds.ec2.domain.SecurityGroup;
@@ -43,6 +44,8 @@ import org.jclouds.rest.annotations.FormParams;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.VirtualHost;
 import org.jclouds.rest.annotations.XMLResponseParser;
+
+import com.google.common.collect.Multimap;
 
 /**
  * Provides access to EC2 via their REST API.
@@ -113,19 +116,19 @@ public interface SecurityGroupApi {
 
    /**
     * Returns information about security groups that you own.
-    * 
+    *
     * @param region
     *           Security groups are not copied across Regions. Instances within the Region cannot
     *           communicate with instances outside the Region using group-based firewall rules.
     *           Traffic from instances in another Region is seen as WAN bandwidth.
     * @param securityGroupNames
     *           Name of the security groups
-    * 
+    *
     * @see #createSecurityGroup
     * @see #authorizeSecurityGroupIngress
     * @see #revokeSecurityGroupIngress
     * @see #deleteSecurityGroup
-    * 
+    *
     * @see <a href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeSecurityGroups.html"
     *      />
     */
@@ -136,8 +139,36 @@ public interface SecurityGroupApi {
    @XMLResponseParser(DescribeSecurityGroupsResponseHandler.class)
    @Fallback(EmptySetOnNotFoundOr404.class)
    Set<SecurityGroup> describeSecurityGroupsInRegion(
-            @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
-            @BinderParam(BindGroupNamesToIndexedFormParams.class) String... securityGroupNames);
+           @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
+           @BinderParam(BindGroupNamesToIndexedFormParams.class) String... securityGroupNames);
+
+   /**
+    * Returns information about security groups that you own.
+    *
+    * @param region
+    *           Security groups are not copied across Regions. Instances within the Region cannot
+    *           communicate with instances outside the Region using group-based firewall rules.
+    *           Traffic from instances in another Region is seen as WAN bandwidth.
+    * @param filter
+    *           Multimap of filter key/values.
+    *
+    * @see #createSecurityGroup
+    * @see #authorizeSecurityGroupIngress
+    * @see #revokeSecurityGroupIngress
+    * @see #deleteSecurityGroup
+    *
+    * @see <a href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeSecurityGroups.html"
+    *      />
+    */
+   @Named("DescribeSecurityGroups")
+   @POST
+   @Path("/")
+   @FormParams(keys = ACTION, values = "DescribeSecurityGroups")
+   @XMLResponseParser(DescribeSecurityGroupsResponseHandler.class)
+   @Fallback(EmptySetOnNotFoundOr404.class)
+   Set<SecurityGroup> describeSecurityGroupsInRegionWithFilter(
+           @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
+           @BinderParam(BindFiltersToIndexedFormParams.class) Multimap<String, String> filter);
 
    /**
     * 

--- a/apis/ec2/src/main/java/org/jclouds/ec2/features/WindowsApi.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/features/WindowsApi.java
@@ -29,6 +29,7 @@ import org.jclouds.Fallbacks.EmptySetOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.aws.filters.FormSigner;
 import org.jclouds.ec2.binders.BindBundleIdsToIndexedFormParams;
+import org.jclouds.ec2.binders.BindFiltersToIndexedFormParams;
 import org.jclouds.ec2.binders.BindS3UploadPolicyAndSignature;
 import org.jclouds.ec2.domain.BundleTask;
 import org.jclouds.ec2.domain.PasswordData;
@@ -46,6 +47,8 @@ import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.SinceApiVersion;
 import org.jclouds.rest.annotations.VirtualHost;
 import org.jclouds.rest.annotations.XMLResponseParser;
+
+import com.google.common.collect.Multimap;
 
 /**
  * Provides access to EC2 Windows Features via the Query API
@@ -136,12 +139,12 @@ public interface WindowsApi {
             @FormParam("BundleId") String bundleId);
 
    /**
-    * 
+    *
     * Describes current bundling tasks.
-    * 
+    *
     * @param region
     *           The bundleTask ID is tied to the Region.
-    * 
+    *
     * @see #cancelBundleTaskInRegion
     * @see #bundleInstanceInRegion
     * @see <a href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeBundleTasks.html"
@@ -154,8 +157,32 @@ public interface WindowsApi {
    @XMLResponseParser(DescribeBundleTasksResponseHandler.class)
    @Fallback(EmptySetOnNotFoundOr404.class)
    Set<BundleTask> describeBundleTasksInRegion(
-            @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
-            @BinderParam(BindBundleIdsToIndexedFormParams.class) String... bundleTaskIds);
+           @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
+           @BinderParam(BindBundleIdsToIndexedFormParams.class) String... bundleTaskIds);
+
+   /**
+    *
+    * Describes current bundling tasks.
+    *
+    * @param region
+    *           The bundleTask ID is tied to the Region.
+    * @param filter
+    *           Filter multimap
+    *
+    * @see #cancelBundleTaskInRegion
+    * @see #bundleInstanceInRegion
+    * @see <a href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeBundleTasks.html"
+    *      />
+    */
+   @Named("DescribeBundleTasks")
+   @POST
+   @Path("/")
+   @FormParams(keys = ACTION, values = "DescribeBundleTasks")
+   @XMLResponseParser(DescribeBundleTasksResponseHandler.class)
+   @Fallback(EmptySetOnNotFoundOr404.class)
+   Set<BundleTask> describeBundleTasksInRegionWithFilter(
+           @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
+           @BinderParam(BindFiltersToIndexedFormParams.class) Multimap<String, String> filter);
 
    /**
     *

--- a/apis/ec2/src/main/java/org/jclouds/ec2/xml/DescribeImagesResponseHandler.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/xml/DescribeImagesResponseHandler.java
@@ -46,7 +46,7 @@ import com.google.common.collect.Sets;
 /**
  * Parses the following XML document:
  * <p/>
- * DescribeImagesResponse xmlns="http://ec2.amazonaws.com/doc/2010-06-15/"
+ * DescribeImagesResponse xmlns="http://ec2.amazonaws.com/doc/2010-08-31/"
  * 
  * @author Adrian Cole
  * @see <a href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeImages.html"

--- a/apis/ec2/src/main/java/org/jclouds/ec2/xml/DescribeKeyPairsResponseHandler.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/xml/DescribeKeyPairsResponseHandler.java
@@ -32,7 +32,7 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.Sets;
 
 /**
- * Parses: DescribeKeyPairsResponse xmlns="http://ec2.amazonaws.com/doc/2010-06-15/"
+ * Parses: DescribeKeyPairsResponse xmlns="http://ec2.amazonaws.com/doc/2010-08-31/"
  * 
  * @see <a href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeKeyPairs.html"
  *      />

--- a/apis/ec2/src/main/java/org/jclouds/ec2/xml/DescribeSecurityGroupsResponseHandler.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/xml/DescribeSecurityGroupsResponseHandler.java
@@ -34,7 +34,7 @@ import com.google.common.collect.ImmutableSet.Builder;
 
 /**
  * Parses: DescribeSecurityGroupsResponse
- * xmlns="http://ec2.amazonaws.com/doc/2010-06-15/"
+ * xmlns="http://ec2.amazonaws.com/doc/2010-08-31/"
  *
  * @see <a href=
  *      "http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/index.html?ApiReference-query-DescribesecurityGroupInfo.html"

--- a/apis/ec2/src/main/java/org/jclouds/ec2/xml/InstanceStateChangeHandler.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/xml/InstanceStateChangeHandler.java
@@ -33,9 +33,9 @@ import com.google.common.collect.Sets;
 /**
  * Parses the following XML document:
  * <p/>
- * TerminateInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2010-06-15/"
- * StartInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2010-06-15/" StopInstancesResponse
- * xmlns="http://ec2.amazonaws.com/doc/2010-06-15/"
+ * TerminateInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2010-08-31/"
+ * StartInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2010-08-31/" StopInstancesResponse
+ * xmlns="http://ec2.amazonaws.com/doc/2010-08-31/"
  * 
  * @author Adrian Cole
  * @see <a href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-ItemType-TerminateInstancesResponseInfoType.html"

--- a/apis/ec2/src/test/java/org/jclouds/ec2/compute/EC2ComputeServiceExpectTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/compute/EC2ComputeServiceExpectTest.java
@@ -52,6 +52,7 @@ public class EC2ComputeServiceExpectTest extends BaseEC2ComputeServiceExpectTest
       requestResponseMap.put(describeInstanceRequest, describeInstanceResponse);
       requestResponseMap.put(describeInstanceMultiIdsRequest, describeInstanceMultiIdsResponse);
       requestResponseMap.put(describeImageRequest, describeImagesResponse);
+      requestResponseMap.put(createTagsRequest, createTagsResponse);
 
       ComputeService apiThatCreatesNode = requestsSendResponses(requestResponseMap.build());
 
@@ -78,6 +79,7 @@ public class EC2ComputeServiceExpectTest extends BaseEC2ComputeServiceExpectTest
       requestResponseMap.put(describeInstanceRequest, describeInstanceResponse);
       requestResponseMap.put(describeInstanceMultiIdsRequest, describeInstanceMultiIdsResponse);
       requestResponseMap.put(describeImageRequest, describeImagesResponse);
+      requestResponseMap.put(createTagsRequest, createTagsResponse);
 
       ComputeService apiThatCreatesNode = requestsSendResponses(requestResponseMap.build());
 

--- a/apis/ec2/src/test/java/org/jclouds/ec2/compute/internal/BaseEC2ComputeServiceExpectTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/compute/internal/BaseEC2ComputeServiceExpectTest.java
@@ -59,6 +59,8 @@ public abstract class BaseEC2ComputeServiceExpectTest extends BaseEC2ComputeServ
    protected HttpRequest describeInstanceMultiIdsRequest;
    protected HttpResponse describeInstanceMultiIdsResponse;
    protected HttpRequest describeImageRequest;
+   protected HttpRequest createTagsRequest;
+   protected HttpResponse createTagsResponse;
 
    public BaseEC2ComputeServiceExpectTest() {
       region = "us-east-1";
@@ -211,6 +213,29 @@ public abstract class BaseEC2ComputeServiceExpectTest extends BaseEC2ComputeServ
                           .addHeader("Host", "ec2." + region + ".amazonaws.com")
                           .addFormParam("ImageId.1", "ami-aecd60c7")
                           .addFormParam("Action", "DescribeImages").build());
+
+      createTagsRequest =
+              formSigner.filter(HttpRequest.builder()
+                      .method("POST")
+                      .endpoint("https://ec2.us-east-1.amazonaws.com/")
+                      .addHeader("Host", "ec2.us-east-1.amazonaws.com")
+                      .payload(
+                              payloadFromStringWithContentType(
+                                      "Action=CreateTags" +
+                                              "&ResourceId.1=i-2baa5550" +
+                                              "&Signature=Trp5e5%2BMqeBeBZbLYa9s9gxahQ9nkx6ETfsGl82IV8Y%3D" +
+                                              "&SignatureMethod=HmacSHA256" +
+                                              "&SignatureVersion=2" +
+                                              "&Tag.1.Key=Name" +
+                                              "&Tag.1.Value=test-2baa5550" +
+                                              "&Timestamp=2012-04-16T15%3A54%3A08.897Z" +
+                                              "&Version=2010-08-31" +
+                                              "&AWSAccessKeyId=identity",
+                                      "application/x-www-form-urlencoded"))
+                      .build());
+
+      createTagsResponse = HttpResponse.builder().statusCode(200).build();
+
    }
 
    @Override

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/AMIApiExpectTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/AMIApiExpectTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.ec2.features;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.testng.Assert.assertEquals;
+
+import org.jclouds.ec2.EC2Api;
+import org.jclouds.ec2.domain.Image;
+import org.jclouds.ec2.internal.BaseEC2ApiExpectTest;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpResponse;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * @author Andrew Bayer
+ */
+@Test(groups = "unit", testName = "AMIApiExpectTest")
+public class AMIApiExpectTest extends BaseEC2ApiExpectTest<EC2Api> {
+
+   HttpRequest filter = HttpRequest.builder().method("POST")
+           .endpoint("https://ec2.us-east-1.amazonaws.com/")
+           .addHeader("Host", "ec2.us-east-1.amazonaws.com")
+           .addFormParam("Action", "DescribeImages")
+           .addFormParam("Filter.1.Name", "owner-id")
+           .addFormParam("Filter.1.Value.1", "206029621532")
+           .addFormParam("Signature", "BxOCrCYJujtaUqSPagRvv1ki76veVBiKK3yWHvRWgR0%3D")
+           .addFormParam("SignatureMethod", "HmacSHA256")
+           .addFormParam("SignatureVersion", "2")
+           .addFormParam("Timestamp", "2012-04-16T15%3A54%3A08.897Z")
+           .addFormParam("Version", "2010-08-31")
+           .addFormParam("AWSAccessKeyId", "identity").build();
+
+   public void testFilterWhenResponseIs2xx() {
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(200)
+              .payload(payloadFromResourceWithContentType("/describe_images.xml", "text/xml")).build();
+
+      EC2Api apiWhenExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse, filter, filterResponse);
+
+      Image image = getOnlyElement(apiWhenExist.getAMIApi().get().describeImagesInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("owner-id", "206029621532")
+                      .build()));
+
+      assertEquals(image.getId(), "ami-be3adfd7");
+   }
+
+   public void testFilterWhenResponseIs404() {
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(404).build();
+
+      EC2Api apiWhenNotExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse, filter, filterResponse);
+
+      assertEquals(apiWhenNotExist.getAMIApi().get().describeImagesInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("owner-id", "206029621532")
+                      .build()),
+              ImmutableSet.of());
+   }
+}

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/AMIApiTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/AMIApiTest.java
@@ -54,11 +54,11 @@ public class AMIApiTest extends BaseEC2ApiTest<AMIApi> {
                                         .addFormParam("Action", "CreateImage")
                                         .addFormParam("InstanceId", "instanceId")
                                         .addFormParam("Name", "name")
-                                        .addFormParam("Signature", "hBIUf4IUOiCKGQKehaNwwbZUjRN4NC4RSNfJ%2B8kvJdY%3D")
+                                        .addFormParam("Signature", "MuMtOMs697BLVks2RUZUNeLdVCo6NXPHuDhh0nmNtvc%3D")
                                         .addFormParam("SignatureMethod", "HmacSHA256")
                                         .addFormParam("SignatureVersion", "2")
                                         .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                        .addFormParam("Version", "2010-06-15")
+                                        .addFormParam("Version", "2010-08-31")
                                         .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testCreateImage() throws SecurityException, NoSuchMethodException, IOException {
@@ -87,11 +87,11 @@ public class AMIApiTest extends BaseEC2ApiTest<AMIApi> {
                                                .addFormParam("InstanceId", "instanceId")
                                                .addFormParam("Name", "name")
                                                .addFormParam("NoReboot", "true")
-                                               .addFormParam("Signature", "fz3KW27JxlSq9ivmVOl4IujcHXXw1cOhdig80I7wR6o%3D")
+                                               .addFormParam("Signature", "8SgbaWihxOICMXDLvwk3ahy/99nhZvTvbno%2B8dMyvJg%3D")
                                                .addFormParam("SignatureMethod", "HmacSHA256")
                                                .addFormParam("SignatureVersion", "2")
                                                .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                               .addFormParam("Version", "2010-06-15")
+                                               .addFormParam("Version", "2010-08-31")
                                                .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testCreateImageOptions() throws SecurityException, NoSuchMethodException, IOException {
@@ -118,11 +118,11 @@ public class AMIApiTest extends BaseEC2ApiTest<AMIApi> {
                                            .endpoint("https://ec2.us-east-1.amazonaws.com/")
                                            .addHeader("Host", "ec2.us-east-1.amazonaws.com")
                                            .addFormParam("Action", "DescribeImages")
-                                           .addFormParam("Signature", "qE4vexSFJqS0UWK%2BccV3s%2BP9woL3M5HI5bTBoM7s/LY%3D")
+                                           .addFormParam("Signature", "hQxNAaRVX6OvXV0IKgx1vV0FoNbRyuHQ2fhRhaPJnS8%3D")
                                            .addFormParam("SignatureMethod", "HmacSHA256")
                                            .addFormParam("SignatureVersion", "2")
                                            .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                           .addFormParam("Version", "2010-06-15")
+                                           .addFormParam("Version", "2010-08-31")
                                            .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testDescribeImages() throws SecurityException, NoSuchMethodException, IOException {
@@ -153,11 +153,11 @@ public class AMIApiTest extends BaseEC2ApiTest<AMIApi> {
                                                   .addFormParam("ImageId.2", "2")
                                                   .addFormParam("Owner.1", "fred")
                                                   .addFormParam("Owner.2", "nancy")
-                                                  .addFormParam("Signature", "%2BE9wji7oFnNUaGmOBggYNNp6v%2BL8OzSGjuI4nx1l2Jw%3D")
+                                                  .addFormParam("Signature", "cIft3g1fwMu52NgB0En9NtHyXjVhmeSx7TBP7YR%2BTvI%3D")
                                                   .addFormParam("SignatureMethod", "HmacSHA256")
                                                   .addFormParam("SignatureVersion", "2")
                                                   .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                                  .addFormParam("Version", "2010-06-15")
+                                                  .addFormParam("Version", "2010-08-31")
                                                   .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testDescribeImagesOptions() throws SecurityException, NoSuchMethodException, IOException {
@@ -185,11 +185,11 @@ public class AMIApiTest extends BaseEC2ApiTest<AMIApi> {
                                             .addHeader("Host", "ec2.us-east-1.amazonaws.com")
                                             .addFormParam("Action", "DeregisterImage")
                                             .addFormParam("ImageId", "imageId")
-                                            .addFormParam("Signature", "3sk9LAJAIr2lG04OMuI0qtzCoBtCU1Ac9I6TTmAWjyA%3D")
+                                            .addFormParam("Signature", "tm6nGoPPJh7xt5TSdV5Ov0DJvcGTAW%2BYSfXL7j%2BTkOA%3D")
                                             .addFormParam("SignatureMethod", "HmacSHA256")
                                             .addFormParam("SignatureVersion", "2")
                                             .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                            .addFormParam("Version", "2010-06-15")
+                                            .addFormParam("Version", "2010-08-31")
                                             .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testDeregisterImage() throws SecurityException, NoSuchMethodException, IOException {
@@ -216,11 +216,11 @@ public class AMIApiTest extends BaseEC2ApiTest<AMIApi> {
                                                       .addFormParam("Action", "RegisterImage")
                                                       .addFormParam("ImageLocation", "pathToManifest")
                                                       .addFormParam("Name", "name")
-                                                      .addFormParam("Signature", "alGqfUiV/bpmpCAj/YzG9VxdTeCwOYyoPjNfwYhm7os%3D")
+                                                      .addFormParam("Signature", "Ie7k7w4Bdki3uCGeSFGdJ5EKrp/ohkHvWwivbIaVLEM%3D")
                                                       .addFormParam("SignatureMethod", "HmacSHA256")
                                                       .addFormParam("SignatureVersion", "2")
                                                       .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                                      .addFormParam("Version", "2010-06-15")
+                                                      .addFormParam("Version", "2010-08-31")
                                                       .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testRegisterImageFromManifest() throws SecurityException, NoSuchMethodException, IOException {
@@ -248,11 +248,11 @@ public class AMIApiTest extends BaseEC2ApiTest<AMIApi> {
                                                              .addFormParam("Description", "description")
                                                              .addFormParam("ImageLocation", "pathToManifest")
                                                              .addFormParam("Name", "name")
-                                                             .addFormParam("Signature", "p77vQLVlPoak6cP/8eoM%2Bz6zkSXx9e2iSlGgLvIwP7I%3D")
+                                                             .addFormParam("Signature", "ilWV1eAWW6kTK/jHliQ%2BIkzJR4DRNy4ye%2BSKtnUjjDs%3D")
                                                              .addFormParam("SignatureMethod", "HmacSHA256")
                                                              .addFormParam("SignatureVersion", "2")
                                                              .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                                             .addFormParam("Version", "2010-06-15")
+                                                             .addFormParam("Version", "2010-08-31")
                                                              .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testRegisterImageFromManifestOptions() throws SecurityException, NoSuchMethodException, IOException {
@@ -283,11 +283,11 @@ public class AMIApiTest extends BaseEC2ApiTest<AMIApi> {
                                                      .addFormParam("BlockDeviceMapping.0.Ebs.SnapshotId", "snapshotId")
                                                      .addFormParam("Name", "imageName")
                                                      .addFormParam("RootDeviceName", "/dev/sda1")
-                                                     .addFormParam("Signature", "KGqYXGpJ/UQVTM172Y2TwU4tlG21JXd3Qrx5nSLBVuA%3D")
+                                                     .addFormParam("Signature", "ZbZcY6uwxPbD65jFmiNZXoWeHY/2zqRuGuDmTfkt84A%3D")
                                                      .addFormParam("SignatureMethod", "HmacSHA256")
                                                      .addFormParam("SignatureVersion", "2")
                                                      .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                                     .addFormParam("Version", "2010-06-15")
+                                                     .addFormParam("Version", "2010-08-31")
                                                      .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testRegisterImageBackedByEBS() throws SecurityException, NoSuchMethodException, IOException {
@@ -324,11 +324,11 @@ public class AMIApiTest extends BaseEC2ApiTest<AMIApi> {
                                                             .addFormParam("Description", "description")
                                                             .addFormParam("Name", "imageName")
                                                             .addFormParam("RootDeviceName", "/dev/sda1")
-                                                            .addFormParam("Signature", "xuWi0w8iODQrg4E0azwqNm2lz/Rf4hBa7m%2BunDTZvVI%3D")
+                                                            .addFormParam("Signature", "DrNujyZMGrKvuw73A7ObFTThXvc/MRfNqjvIy8gey5g%3D")
                                                             .addFormParam("SignatureMethod", "HmacSHA256")
                                                             .addFormParam("SignatureVersion", "2")
                                                             .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                                            .addFormParam("Version", "2010-06-15")
+                                                            .addFormParam("Version", "2010-08-31")
                                                             .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testRegisterImageBackedByEBSOptions() throws SecurityException, NoSuchMethodException, IOException {
@@ -358,11 +358,11 @@ public class AMIApiTest extends BaseEC2ApiTest<AMIApi> {
                                                            .addFormParam("Action", "DescribeImageAttribute")
                                                            .addFormParam("Attribute", "blockDeviceMapping")
                                                            .addFormParam("ImageId", "imageId")
-                                                           .addFormParam("Signature", "puwfzm8BlfeKiEZ9CNn5ax86weZ6SQ2xyZhN6etu4gA%3D")
+                                                           .addFormParam("Signature", "MJCIc1roG%2BnIWxRSUqV9KP9Wc4AWuuiNkxeDSih5/mI%3D")
                                                            .addFormParam("SignatureMethod", "HmacSHA256")
                                                            .addFormParam("SignatureVersion", "2")
                                                            .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                                           .addFormParam("Version", "2010-06-15")
+                                                           .addFormParam("Version", "2010-08-31")
                                                            .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testGetBlockDeviceMappingsForImage() throws SecurityException, NoSuchMethodException, IOException {
@@ -390,11 +390,11 @@ public class AMIApiTest extends BaseEC2ApiTest<AMIApi> {
                                                         .addFormParam("Action", "DescribeImageAttribute")
                                                         .addFormParam("Attribute", "launchPermission")
                                                         .addFormParam("ImageId", "imageId")
-                                                        .addFormParam("Signature", "ocCMlLh3Kpg6HwIcPKlrwoPPg9C5rt5nD0dl717mOq8%3D")
+                                                        .addFormParam("Signature", "iN7JbsAhM1NAES3o%2BOw8BaaFJ%2B1g9imBjcU4mFCyrxM%3D")
                                                         .addFormParam("SignatureMethod", "HmacSHA256")
                                                         .addFormParam("SignatureVersion", "2")
                                                         .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                                        .addFormParam("Version", "2010-06-15")
+                                                        .addFormParam("Version", "2010-08-31")
                                                         .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testGetLaunchPermissionForImage() throws SecurityException, NoSuchMethodException, IOException {
@@ -422,14 +422,14 @@ public class AMIApiTest extends BaseEC2ApiTest<AMIApi> {
                                                           .addFormParam("Attribute", "launchPermission")
                                                           .addFormParam("ImageId", "imageId")
                                                           .addFormParam("OperationType", "add")
-                                                          .addFormParam("Signature", "WZzNWOC1KHbuySvXEuLTiBA%2BVUfKpSBN2Lud6MrhlCQ%3D")
+                                                          .addFormParam("Signature", "ZuMuzW/iQDRURhUJaBzvoAdNJrE454y6X0jM24lcxxk%3D")
                                                           .addFormParam("SignatureMethod", "HmacSHA256")
                                                           .addFormParam("SignatureVersion", "2")
                                                           .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
                                                           .addFormParam("UserGroup.1", "all")
                                                           .addFormParam("UserId.1", "bob")
                                                           .addFormParam("UserId.2", "sue")
-                                                          .addFormParam("Version", "2010-06-15")
+                                                          .addFormParam("Version", "2010-08-31")
                                                           .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testAddLaunchPermissionsToImage() throws SecurityException, NoSuchMethodException, IOException {
@@ -459,14 +459,14 @@ public class AMIApiTest extends BaseEC2ApiTest<AMIApi> {
                                                    .addFormParam("Attribute", "launchPermission")
                                                    .addFormParam("ImageId", "imageId")
                                                    .addFormParam("OperationType", "remove")
-                                                   .addFormParam("Signature", "z8OYGQBAwu4HwXV6VF/vuOZlBtptxLxtCQiLXY7UvMU%3D")
+                                                   .addFormParam("Signature", "HreSEawbVaUp/UMicCJbhrx%2BmoX01f2pEphJCPz8/5g%3D")
                                                    .addFormParam("SignatureMethod", "HmacSHA256")
                                                    .addFormParam("SignatureVersion", "2")
                                                    .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
                                                    .addFormParam("UserGroup.1", "all")
                                                    .addFormParam("UserId.1", "bob")
                                                    .addFormParam("UserId.2", "sue")
-                                                   .addFormParam("Version", "2010-06-15")
+                                                   .addFormParam("Version", "2010-08-31")
                                                    .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testRemoveLaunchPermissionsFromImage() throws SecurityException, NoSuchMethodException, IOException {
@@ -494,11 +494,11 @@ public class AMIApiTest extends BaseEC2ApiTest<AMIApi> {
                                                           .addFormParam("Action", "ResetImageAttribute")
                                                           .addFormParam("Attribute", "launchPermission")
                                                           .addFormParam("ImageId", "imageId")
-                                                          .addFormParam("Signature", "mOVwrqAzidhz%2B4E1dqOJAzG9G9ZX7eDpi8BobN4dA%2BE%3D")
+                                                          .addFormParam("Signature", "fVCR9aGYvNX/Jt1/uqBGcUQRLrHwxtcvmNYKzpul1P4%3D")
                                                           .addFormParam("SignatureMethod", "HmacSHA256")
                                                           .addFormParam("SignatureVersion", "2")
                                                           .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                                          .addFormParam("Version", "2010-06-15")
+                                                          .addFormParam("Version", "2010-08-31")
                                                           .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testResetLaunchPermissionsOnImage() throws SecurityException, NoSuchMethodException, IOException {

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/AvailabilityZoneAndRegionApiLiveTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/AvailabilityZoneAndRegionApiLiveTest.java
@@ -62,7 +62,7 @@ public class AvailabilityZoneAndRegionApiLiveTest extends BaseComputeServiceCont
       for (String region : ec2Api.getConfiguredRegions()) {
          Set<AvailabilityZoneInfo> allResults = client.describeAvailabilityZonesInRegion(region);
          assertNotNull(allResults);
-         assert allResults.size() >= 1 : allResults.size();
+         assert !allResults.isEmpty() : allResults.size();
          Iterator<AvailabilityZoneInfo> iterator = allResults.iterator();
          String id1 = iterator.next().getZone();
          Set<AvailabilityZoneInfo> oneResult = client.describeAvailabilityZonesInRegion(region,
@@ -78,7 +78,7 @@ public class AvailabilityZoneAndRegionApiLiveTest extends BaseComputeServiceCont
       SortedMap<String, URI> allResults = Maps.newTreeMap();
       allResults.putAll(client.describeRegions());
       assertNotNull(allResults);
-      assert allResults.size() >= 1 : allResults.size();
+      assert !allResults.isEmpty() : allResults.size();
       Iterator<Entry<String, URI>> iterator = allResults.entrySet().iterator();
       String r1 = iterator.next().getKey();
       SortedMap<String, URI> oneResult = Maps.newTreeMap();

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/EC2ElasticBlockStoreApiExpectTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/EC2ElasticBlockStoreApiExpectTest.java
@@ -16,17 +16,22 @@
  */
 package org.jclouds.ec2.features;
 
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static org.testng.Assert.assertEquals;
 
 import org.jclouds.ec2.EC2Api;
+import org.jclouds.ec2.domain.Snapshot;
 import org.jclouds.ec2.domain.Volume;
 import org.jclouds.ec2.internal.BaseEC2ApiExpectTest;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
+import org.jclouds.rest.ResourceNotFoundException;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * @author Adrian Cole
@@ -52,7 +57,7 @@ public class EC2ElasticBlockStoreApiExpectTest extends BaseEC2ApiExpectTest<EC2A
                        .method("POST")
                        .endpoint("https://ec2.us-east-1.amazonaws.com/")
                        .addHeader("Host", "ec2.us-east-1.amazonaws.com")
-                       .payload(payloadFromStringWithContentType("Action=CreateVolume&AvailabilityZone=us-east-1a&Signature=FB5hTZHKSAuiygoafIdJh1EnfTu0ogC2VfRQOar85mg%3D&SignatureMethod=HmacSHA256&SignatureVersion=2&Size=4&Timestamp=2012-04-16T15%3A54%3A08.897Z&Version=2010-06-15&AWSAccessKeyId=identity", "application/x-www-form-urlencoded")).build(),
+                       .payload(payloadFromStringWithContentType("Action=CreateVolume&AvailabilityZone=us-east-1a&Signature=NCu8HU8u0A385rTgj%2BN5lq606jkc1eu88jof9yAxb6s%3D&SignatureMethod=HmacSHA256&SignatureVersion=2&Size=4&Timestamp=2012-04-16T15%3A54%3A08.897Z&Version=2010-08-31&AWSAccessKeyId=identity", "application/x-www-form-urlencoded")).build(),
             HttpResponse.builder()
                         .statusCode(200)
                         .payload(payloadFromResource("/created_volume.xml")).build());
@@ -84,5 +89,84 @@ public class EC2ElasticBlockStoreApiExpectTest extends BaseEC2ApiExpectTest<EC2A
       ElasticBlockStoreApi client = requestsSendResponses(builder.build()).getElasticBlockStoreApi().get();
 
       assertEquals(client.createVolumeFromSnapshotInAvailabilityZone(region + "a", 1, "snap-8b7ffbdd"), creating.toBuilder().region(region).build());
+   }
+
+   HttpRequest filterVolumes = HttpRequest.builder().method("POST")
+           .endpoint("https://ec2.us-east-1.amazonaws.com/")
+           .addHeader("Host", "ec2.us-east-1.amazonaws.com")
+           .addFormParam("Action", "DescribeVolumes")
+           .addFormParam("Filter.1.Name", "snapshot-id")
+           .addFormParam("Filter.1.Value.1", "snap-536d1b3a")
+           .addFormParam("Signature", "7g2ySW39nIVfxtIbuVttUBom7sssmQknxX/9SThkm2Y%3D")
+           .addFormParam("SignatureMethod", "HmacSHA256")
+           .addFormParam("SignatureVersion", "2")
+           .addFormParam("Timestamp", "2012-04-16T15%3A54%3A08.897Z")
+           .addFormParam("Version", "2010-08-31")
+           .addFormParam("AWSAccessKeyId", "identity").build();
+
+   public void testFilterVolumesWhenResponseIs2xx() {
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(200)
+              .payload(payloadFromResourceWithContentType("/describe_volumes_single.xml", "text/xml")).build();
+
+      EC2Api apiWhenExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse, filterVolumes, filterResponse);
+
+      Volume volume = getOnlyElement(apiWhenExist.getElasticBlockStoreApi().get().describeVolumesInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("snapshot-id", "snap-536d1b3a")
+                      .build()));
+
+      assertEquals(volume.getId(), "vol-4282672b");
+   }
+
+   @Test(expectedExceptions = ResourceNotFoundException.class)
+   public void testFilterVolumesWhenResponseIs404() {
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(404).build();
+
+      EC2Api apiWhenNotExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse, filterVolumes, filterResponse);
+
+      assertEquals(apiWhenNotExist.getElasticBlockStoreApi().get().describeVolumesInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("snapshot-id", "snap-536d1b3a")
+                      .build()),
+              ImmutableSet.of());
+   }
+
+   HttpRequest filterSnapshots = HttpRequest.builder().method("POST")
+           .endpoint("https://ec2.us-east-1.amazonaws.com/")
+           .addHeader("Host", "ec2.us-east-1.amazonaws.com")
+           .addFormParam("Action", "DescribeSnapshots")
+           .addFormParam("Filter.1.Name", "volume-id")
+           .addFormParam("Filter.1.Value.1", "4d826724")
+           .addFormParam("Signature", "vT7R4YmfQJPNLSojXEMY1qcErMh0OzrOTYxbGYSZ4Uw%3D")
+           .addFormParam("SignatureMethod", "HmacSHA256")
+           .addFormParam("SignatureVersion", "2")
+           .addFormParam("Timestamp", "2012-04-16T15%3A54%3A08.897Z")
+           .addFormParam("Version", "2010-08-31")
+           .addFormParam("AWSAccessKeyId", "identity").build();
+
+   public void testFilterSnapshotsWhenResponseIs2xx() {
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(200)
+              .payload(payloadFromResourceWithContentType("/describe_snapshots.xml", "text/xml")).build();
+
+      EC2Api apiWhenExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse, filterSnapshots, filterResponse);
+
+      Snapshot snapshot = getOnlyElement(apiWhenExist.getElasticBlockStoreApi().get().describeSnapshotsInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("volume-id", "4d826724")
+                      .build()));
+
+      assertEquals(snapshot.getId(), "snap-78a54011");
+   }
+
+   public void testFilterSnapshotsWhenResponseIs404() {
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(404).build();
+
+      EC2Api apiWhenNotExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse, filterSnapshots, filterResponse);
+
+      assertEquals(apiWhenNotExist.getElasticBlockStoreApi().get().describeSnapshotsInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("volume-id", "4d826724")
+                      .build()),
+              ImmutableSet.of());
    }
 }

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/ElasticBlockStoreApiTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/ElasticBlockStoreApiTest.java
@@ -70,11 +70,11 @@ public class ElasticBlockStoreApiTest extends BaseEC2ApiTest<ElasticBlockStoreAp
                                             .endpoint("https://ec2.us-east-1.amazonaws.com/")
                                             .addHeader("Host", "ec2.us-east-1.amazonaws.com")
                                             .addFormParam("Action", "DescribeVolumes")
-                                            .addFormParam("Signature", "hNuorhZQS%2BThX5dWXOvBkvnmTpgp6SvwHmgzjjfKyG8%3D")
+                                            .addFormParam("Signature", "nNxWg5dwYZEQu1QCzCtNp7iDmPR8wXXdKhWmLEKFLGI%3D")
                                             .addFormParam("SignatureMethod", "HmacSHA256")
                                             .addFormParam("SignatureVersion", "2")
                                             .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                            .addFormParam("Version", "2010-06-15")
+                                            .addFormParam("Version", "2010-08-31")
                                             .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testDescribeVolumes() throws SecurityException, NoSuchMethodException, IOException {
@@ -119,11 +119,11 @@ public class ElasticBlockStoreApiTest extends BaseEC2ApiTest<ElasticBlockStoreAp
                                          .addFormParam("Action", "AttachVolume")
                                          .addFormParam("Device", "/device")
                                          .addFormParam("InstanceId", "instanceId")
-                                         .addFormParam("Signature", "LaOppR61eWpdNgMYJ3ccfo9vzbmUyJf9Ars%2Bbcu4OGI%3D")
+                                         .addFormParam("Signature", "0%2BUY5oCQzoJapEHq4Dl2R/0nAA8uXEHqvHbnnNI5NcA%3D")
                                          .addFormParam("SignatureMethod", "HmacSHA256")
                                          .addFormParam("SignatureVersion", "2")
                                          .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                         .addFormParam("Version", "2010-06-15")
+                                         .addFormParam("Version", "2010-08-31")
                                          .addFormParam("VolumeId", "id")
                                          .addFormParam("AWSAccessKeyId", "identity").build();
 
@@ -151,11 +151,11 @@ public class ElasticBlockStoreApiTest extends BaseEC2ApiTest<ElasticBlockStoreAp
                                          .addHeader("Host", "ec2.us-east-1.amazonaws.com")
                                          .addFormParam("Action", "DetachVolume")
                                          .addFormParam("Force", "false")
-                                         .addFormParam("Signature", "4c6EmHwCYbe%2BifuUV0PNXpKfReoZvJXyme37mKtnLk8%3D")
+                                         .addFormParam("Signature", "tfNB1g2WVqb3EwvBJlk4duU1H1fDOa1SBstsm1elpbg%3D")
                                          .addFormParam("SignatureMethod", "HmacSHA256")
                                          .addFormParam("SignatureVersion", "2")
                                          .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                         .addFormParam("Version", "2010-06-15")
+                                         .addFormParam("Version", "2010-08-31")
                                          .addFormParam("VolumeId", "id")
                                          .addFormParam("AWSAccessKeyId", "identity").build();
 
@@ -185,11 +185,11 @@ public class ElasticBlockStoreApiTest extends BaseEC2ApiTest<ElasticBlockStoreAp
                                                 .addFormParam("Device", "/device")
                                                 .addFormParam("Force", "true")
                                                 .addFormParam("InstanceId", "instanceId")
-                                                .addFormParam("Signature", "GrUGXc6H5W%2BNF8zcXU8gSRbt1ELt%2BTcCDEvbY1a88NE%3D")
+                                                .addFormParam("Signature", "VFhgwdkKBKXr/dEn2gvk6Vqq3JIunw4zZgM2Tt/ouME%3D")
                                                 .addFormParam("SignatureMethod", "HmacSHA256")
                                                 .addFormParam("SignatureVersion", "2")
                                                 .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                                .addFormParam("Version", "2010-06-15")
+                                                .addFormParam("Version", "2010-08-31")
                                                 .addFormParam("VolumeId", "id")
                                                 .addFormParam("AWSAccessKeyId", "identity").build();
 
@@ -311,7 +311,7 @@ public class ElasticBlockStoreApiTest extends BaseEC2ApiTest<ElasticBlockStoreAp
                                                                  .addFormParam("Action", "ModifySnapshotAttribute")
                                                                  .addFormParam("Attribute", "createVolumePermission")
                                                                  .addFormParam("OperationType", "add")
-                                                                 .addFormParam("Signature", "AizV1N1rCCXi%2BbzXX/Vz7shFq9yAJAwcmAGyRQMH%2Bjs%3D")
+                                                                 .addFormParam("Signature", "s8m8DqQRXmecWguuRjxfl3Ibd%2B1AjjktGzTlJLUTcPc%3D")
                                                                  .addFormParam("SignatureMethod", "HmacSHA256")
                                                                  .addFormParam("SignatureVersion", "2")
                                                                  .addFormParam("SnapshotId", "snapshotId")
@@ -319,7 +319,7 @@ public class ElasticBlockStoreApiTest extends BaseEC2ApiTest<ElasticBlockStoreAp
                                                                  .addFormParam("UserGroup.1", "all")
                                                                  .addFormParam("UserId.1", "bob")
                                                                  .addFormParam("UserId.2", "sue")
-                                                                 .addFormParam("Version", "2010-06-15")
+                                                                 .addFormParam("Version", "2010-08-31")
                                                                  .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testAddCreateVolumePermissionsToSnapshot() throws SecurityException, NoSuchMethodException, IOException {
@@ -348,7 +348,7 @@ public class ElasticBlockStoreApiTest extends BaseEC2ApiTest<ElasticBlockStoreAp
                                                                       .addFormParam("Action", "ModifySnapshotAttribute")
                                                                       .addFormParam("Attribute", "createVolumePermission")
                                                                       .addFormParam("OperationType", "remove")
-                                                                      .addFormParam("Signature", "Lmlt2daM%2BJ4kIoU9HmCempwVGZP1fC6V%2Br9o8MQjYy8%3D")
+                                                                      .addFormParam("Signature", "RzxHUIWV80cyhQDtrMiHDWUosS1g8cn1%2B7ONLJCe1dg%3D")
                                                                       .addFormParam("SignatureMethod", "HmacSHA256")
                                                                       .addFormParam("SignatureVersion", "2")
                                                                       .addFormParam("SnapshotId", "snapshotId")
@@ -356,7 +356,7 @@ public class ElasticBlockStoreApiTest extends BaseEC2ApiTest<ElasticBlockStoreAp
                                                                       .addFormParam("UserGroup.1", "all")
                                                                       .addFormParam("UserId.1", "bob")
                                                                       .addFormParam("UserId.2", "sue")
-                                                                      .addFormParam("Version", "2010-06-15")
+                                                                      .addFormParam("Version", "2010-08-31")
                                                                       .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testRemoveCreateVolumePermissionsFromSnapshot() throws SecurityException, NoSuchMethodException,

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/ElasticIPAddressApiExpectTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/ElasticIPAddressApiExpectTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.ec2.features;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.util.Properties;
+
+import org.jclouds.Constants;
+import org.jclouds.ec2.EC2Api;
+import org.jclouds.ec2.domain.PublicIpInstanceIdPair;
+import org.jclouds.ec2.internal.BaseEC2ApiExpectTest;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpResponse;
+import org.jclouds.rest.internal.BaseRestApiExpectTest;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * @author Andrew Bayer
+ *
+ * @see org.jclouds.ec2.features.ElasticIPAddressApi
+ */
+@Test(groups = "unit")
+public class ElasticIPAddressApiExpectTest extends BaseEC2ApiExpectTest<EC2Api> {
+
+   protected Properties setupProperties() {
+      Properties props = super.setupProperties();
+      props.put(Constants.PROPERTY_API_VERSION, "2010-08-31");
+      return props;
+   }
+
+   HttpRequest filter =
+           HttpRequest.builder()
+                   .method("POST")
+                   .endpoint("https://ec2.us-east-1.amazonaws.com/")
+                   .addHeader("Host", "ec2.us-east-1.amazonaws.com")
+                   .payload(BaseRestApiExpectTest.payloadFromStringWithContentType(
+                           "Action=DescribeAddresses" +
+                                   "&Filter.1.Name=instance-id" +
+                                   "&Filter.1.Value.1=i-f15ebb98" +
+                                   "&Signature=dJbTUsBGHSrarQQAwmLm8LLI255R/lzdE7ZcYJucOzI%3D" +
+                                   "&SignatureMethod=HmacSHA256" +
+                                   "&SignatureVersion=2" +
+                                   "&Timestamp=2012-04-16T15%3A54%3A08.897Z" +
+                                   "&Version=2010-08-31" +
+                                   "&AWSAccessKeyId=identity",
+                           "application/x-www-form-urlencoded"))
+                   .build();
+
+   public void testFilterWhenResponseIs2xx() throws Exception {
+
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(200)
+              .payload(payloadFromResourceWithContentType("/describe_addresses_single.xml", "text/xml")).build();
+
+
+      EC2Api apiWhenExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse,
+              filter, filterResponse);
+
+      PublicIpInstanceIdPair address = getOnlyElement(apiWhenExist.getElasticIPAddressApi()
+              .get().describeAddressesInRegionWithFilter("us-east-1",
+                      ImmutableMultimap.<String, String>builder()
+                              .put("instance-id", "i-f15ebb98")
+                              .build()));
+      assertNotNull(address, "address should not be null");
+
+      assertEquals(address.getPublicIp(), "67.202.55.255");
+   }
+
+   public void testFilterWhenResponseIs404() throws Exception {
+
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(404).build();
+
+      EC2Api apiWhenDontExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse,
+              filter, filterResponse);
+
+      assertEquals(apiWhenDontExist.getElasticIPAddressApi()
+              .get().describeAddressesInRegionWithFilter("us-east-1",
+                      ImmutableMultimap.<String, String>builder()
+                              .put("instance-id", "i-f15ebb98")
+                              .build()), ImmutableSet.of());
+   }
+
+}

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/ElasticIPAddressApiLiveTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/ElasticIPAddressApiLiveTest.java
@@ -23,12 +23,11 @@ import java.util.SortedSet;
 
 import org.jclouds.compute.internal.BaseComputeServiceContextLiveTest;
 import org.jclouds.ec2.EC2Api;
-import org.jclouds.ec2.EC2ApiMetadata;
-import org.jclouds.ec2.compute.EC2ComputeServiceContext;
 import org.jclouds.ec2.domain.PublicIpInstanceIdPair;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Sets;
 
 /**
@@ -58,13 +57,19 @@ public class ElasticIPAddressApiLiveTest extends BaseComputeServiceContextLiveTe
       for (String region : ec2Api.getConfiguredRegions()) {
          SortedSet<PublicIpInstanceIdPair> allResults = Sets.newTreeSet(client.describeAddressesInRegion(region));
          assertNotNull(allResults);
-         if (allResults.size() >= 1) {
+         if (!allResults.isEmpty()) {
             PublicIpInstanceIdPair pair = allResults.last();
             SortedSet<PublicIpInstanceIdPair> result = Sets.newTreeSet(client.describeAddressesInRegion(region, pair
                      .getPublicIp()));
             assertNotNull(result);
             PublicIpInstanceIdPair compare = result.last();
             assertEquals(compare, pair);
+
+            SortedSet<PublicIpInstanceIdPair> filterResult = Sets.newTreeSet(client.describeAddressesInRegionWithFilter(
+                    region, ImmutableMultimap.<String, String>builder().put("public-ip", pair.getPublicIp()).build()));
+            assertNotNull(filterResult);
+            PublicIpInstanceIdPair filterCompare = filterResult.last();
+            assertEquals(filterCompare, pair);
          }
       }
    }

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/ElasticIPAddressApiTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/ElasticIPAddressApiTest.java
@@ -63,11 +63,11 @@ public class ElasticIPAddressApiTest extends BaseEC2ApiTest<ElasticIPAddressApi>
                                              .addFormParam("Action", "AssociateAddress")
                                              .addFormParam("InstanceId", "me")
                                              .addFormParam("PublicIp", "127.0.0.1")
-                                             .addFormParam("Signature", "YmPyvEljuFw0INSUbQx5xAhC/1GQ4a1Ht6TdoXeMc9Y%3D")
+                                             .addFormParam("Signature", "nLU6xGLqXtT/dmyAvkN4BdL/3CxQlDWJYeskikhl54k%3D")
                                              .addFormParam("SignatureMethod", "HmacSHA256")
                                              .addFormParam("SignatureVersion", "2")
                                              .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                             .addFormParam("Version", "2010-06-15")
+                                             .addFormParam("Version", "2010-08-31")
                                              .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testAssociateAddress() throws SecurityException, NoSuchMethodException, IOException {

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/InstanceApiExpectTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/InstanceApiExpectTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.ec2.features;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.testng.Assert.assertNotNull;
+
+import java.util.Properties;
+
+import org.jclouds.Constants;
+import org.jclouds.ec2.EC2Api;
+import org.jclouds.ec2.domain.RunningInstance;
+import org.jclouds.ec2.internal.BaseEC2ApiExpectTest;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpResponse;
+import org.jclouds.rest.internal.BaseRestApiExpectTest;
+import org.jclouds.util.Strings2;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * @author Andrew Bayer
+ *
+ * @see InstanceApi
+ */
+@Test(groups = "unit")
+public class InstanceApiExpectTest extends BaseEC2ApiExpectTest<EC2Api> {
+
+   protected Properties setupProperties() {
+      Properties props = super.setupProperties();
+      props.put(Constants.PROPERTY_API_VERSION, "2010-08-31");
+      return props;
+   }
+
+   HttpRequest filter =
+           HttpRequest.builder()
+                   .method("POST")
+                   .endpoint("https://ec2.us-east-1.amazonaws.com/")
+                   .addHeader("Host", "ec2.us-east-1.amazonaws.com")
+                   .payload(BaseRestApiExpectTest.payloadFromStringWithContentType(
+                           "Action=DescribeInstances" +
+                                   "&Filter.1.Name=key-name" +
+                                   "&Filter.1.Value.1=" + Strings2.urlEncode("adriancole.ec21") +
+                                   "&Signature=%2B2ktAljlAPNUMAJUFh3poQrTvwcwWytuQFBg/ktKdTc%3D" +
+                                   "&SignatureMethod=HmacSHA256" +
+                                   "&SignatureVersion=2" +
+                                   "&Timestamp=2012-04-16T15%3A54%3A08.897Z" +
+                                   "&Version=2010-08-31" +
+                                   "&AWSAccessKeyId=identity",
+                           "application/x-www-form-urlencoded"))
+                   .build();
+
+   public void testFilterWhenResponseIs2xx() throws Exception {
+
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(200)
+              .payload(payloadFromResourceWithContentType("/describe_instances_running.xml", "text/xml")).build();
+
+
+      EC2Api apiWhenExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse,
+              filter, filterResponse);
+
+      RunningInstance instance = getOnlyElement(getOnlyElement(apiWhenExist.getInstanceApi().get().describeInstancesInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("key-name", "adriancole.ec21")
+                      .build())));
+      assertNotNull(instance, "Instance should not be null");
+
+      Assert.assertEquals(instance.getId(), "i-0799056f");
+   }
+
+   public void testFilterWhenResponseIs404() throws Exception {
+
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(404).build();
+
+      EC2Api apiWhenDontExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse,
+              filter, filterResponse);
+
+      Assert.assertEquals(apiWhenDontExist.getInstanceApi().get().describeInstancesInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("key-name", "adriancole.ec21")
+                      .build()), ImmutableSet.of());
+   }
+
+}

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/InstanceApiTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/InstanceApiTest.java
@@ -351,12 +351,12 @@ public class InstanceApiTest extends BaseEC2ApiTest<InstanceApi> {
                                                    .addFormParam("Action", "ModifyInstanceAttribute")
                                                    .addFormParam("Attribute", "userData")
                                                    .addFormParam("InstanceId", "1")
-                                                   .addFormParam("Signature", "LfUmzLM5DsACR5nQcEfGF5FPdznOwwhJ7tjhBWfHtGs%3D")
+                                                   .addFormParam("Signature", "SfxT/1i/WokibleyEHo0zHizHisLzbDzzRxfOdnr1vY%3D")
                                                    .addFormParam("SignatureMethod", "HmacSHA256")
                                                    .addFormParam("SignatureVersion", "2")
                                                    .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
                                                    .addFormParam("Value", "dGVzdA%3D%3D")
-                                                   .addFormParam("Version", "2010-06-15")
+                                                   .addFormParam("Version", "2010-08-31")
                                                    .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testSetUserDataForInstanceInRegion() throws SecurityException, NoSuchMethodException, IOException {
@@ -384,12 +384,12 @@ public class InstanceApiTest extends BaseEC2ApiTest<InstanceApi> {
                                                   .addFormParam("Action", "ModifyInstanceAttribute")
                                                   .addFormParam("Attribute", "ramdisk")
                                                   .addFormParam("InstanceId", "1")
-                                                  .addFormParam("Signature", "qx6NeVbihiYrKvi5Oe5LzMsGHTjS7%2BqoNhh2abt275g%3D")
+                                                  .addFormParam("Signature", "aMQzFsknmQt1OA8Rb8aIzZoFXGK23UvrMIy8imNVUeQ%3D")
                                                   .addFormParam("SignatureMethod", "HmacSHA256")
                                                   .addFormParam("SignatureVersion", "2")
                                                   .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
                                                   .addFormParam("Value", "test")
-                                                  .addFormParam("Version", "2010-06-15")
+                                                  .addFormParam("Version", "2010-08-31")
                                                   .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testSetRamdiskForInstanceInRegion() throws SecurityException, NoSuchMethodException, IOException {
@@ -417,12 +417,12 @@ public class InstanceApiTest extends BaseEC2ApiTest<InstanceApi> {
                                                  .addFormParam("Action", "ModifyInstanceAttribute")
                                                  .addFormParam("Attribute", "kernel")
                                                  .addFormParam("InstanceId", "1")
-                                                 .addFormParam("Signature", "juSiuoiXJzTxj3q0LUW2528HzDyP4JAcKin%2BI4AuIT0%3D")
+                                                 .addFormParam("Signature", "GaQ9sC0uXHlN5JAMWQpYx%2Bc3XaF38qZgJex/kyqdR1E%3D")
                                                  .addFormParam("SignatureMethod", "HmacSHA256")
                                                  .addFormParam("SignatureVersion", "2")
                                                  .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
                                                  .addFormParam("Value", "test")
-                                                 .addFormParam("Version", "2010-06-15")
+                                                 .addFormParam("Version", "2010-08-31")
                                                  .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testSetKernelForInstanceInRegion() throws SecurityException, NoSuchMethodException, IOException {
@@ -450,12 +450,12 @@ public class InstanceApiTest extends BaseEC2ApiTest<InstanceApi> {
                                                       .addFormParam("Action", "ModifyInstanceAttribute")
                                                       .addFormParam("Attribute", "disableApiTermination")
                                                       .addFormParam("InstanceId", "1")
-                                                      .addFormParam("Signature", "tiBMWWTi22BWeAjsRfuzVom0tQgsOBeYTkatMuWRrbg%3D")
+                                                      .addFormParam("Signature", "hErzi%2Bf4jBADviJ%2BLVTTGhlHWhMR/pyPUSBZgaHC79I%3D")
                                                       .addFormParam("SignatureMethod", "HmacSHA256")
                                                       .addFormParam("SignatureVersion", "2")
                                                       .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
                                                       .addFormParam("Value", "true")
-                                                      .addFormParam("Version", "2010-06-15")
+                                                      .addFormParam("Version", "2010-08-31")
                                                       .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testSetApiTerminationDisabledForInstanceInRegion() throws SecurityException, NoSuchMethodException,
@@ -484,12 +484,12 @@ public class InstanceApiTest extends BaseEC2ApiTest<InstanceApi> {
                                                     .addFormParam("Action", "ModifyInstanceAttribute")
                                                     .addFormParam("Attribute", "instanceType")
                                                     .addFormParam("InstanceId", "1")
-                                                    .addFormParam("Signature", "XK%2BzQmQ0S57gXIgVRMqUkKunURN9TaCJD1YWiYMAOHo%3D")
+                                                    .addFormParam("Signature", "OYJQ1w79NoxkcrawNK6U71k3Wl78kqz2ikzTXmQCX2E%3D")
                                                     .addFormParam("SignatureMethod", "HmacSHA256")
                                                     .addFormParam("SignatureVersion", "2")
                                                     .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
                                                     .addFormParam("Value", "c1.medium")
-                                                    .addFormParam("Version", "2010-06-15")
+                                                    .addFormParam("Version", "2010-08-31")
                                                     .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testSetInstanceTypeForInstanceInRegion() throws SecurityException, NoSuchMethodException, IOException {
@@ -517,12 +517,12 @@ public class InstanceApiTest extends BaseEC2ApiTest<InstanceApi> {
                                                                  .addFormParam("Action", "ModifyInstanceAttribute")
                                                                  .addFormParam("Attribute", "instanceInitiatedShutdownBehavior")
                                                                  .addFormParam("InstanceId", "1")
-                                                                 .addFormParam("Signature", "s5xBMLd%2BXNVp44x7C6qVE58qBov//f6yvxoM757KcZU%3D")
+                                                                 .addFormParam("Signature", "2Tgi9M9AcCv5Y%2BEXwq0SD6g8bBGtPPEgjdTtfdGZQlI%3D")
                                                                  .addFormParam("SignatureMethod", "HmacSHA256")
                                                                  .addFormParam("SignatureVersion", "2")
                                                                  .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
                                                                  .addFormParam("Value", "terminate")
-                                                                 .addFormParam("Version", "2010-06-15")
+                                                                 .addFormParam("Version", "2010-08-31")
                                                                  .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testSetInstanceInitiatedShutdownBehaviorForInstanceInRegion() throws SecurityException,

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/KeyPairApiExpectTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/KeyPairApiExpectTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.ec2.features;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.testng.Assert.assertEquals;
+
+import org.jclouds.ec2.EC2Api;
+import org.jclouds.ec2.domain.KeyPair;
+import org.jclouds.ec2.internal.BaseEC2ApiExpectTest;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpResponse;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * @author Andrew Bayer
+ */
+@Test(groups = "unit", testName = "KeyPairApiExpectTest")
+public class KeyPairApiExpectTest extends BaseEC2ApiExpectTest<EC2Api> {
+
+   HttpRequest filter = HttpRequest.builder().method("POST")
+           .endpoint("https://ec2.us-east-1.amazonaws.com/")
+           .addHeader("Host", "ec2.us-east-1.amazonaws.com")
+           .addFormParam("Action", "DescribeKeyPairs")
+           .addFormParam("Filter.1.Name", "key-name")
+           .addFormParam("Filter.1.Value.1", "gsg-keypair")
+           .addFormParam("Signature", "xg8vGx%2Bv9UEG0%2BFGy%2BhincdI2ziWLbwPJvW85l%2Bvqwg%3D")
+           .addFormParam("SignatureMethod", "HmacSHA256")
+           .addFormParam("SignatureVersion", "2")
+           .addFormParam("Timestamp", "2012-04-16T15%3A54%3A08.897Z")
+           .addFormParam("Version", "2010-08-31")
+           .addFormParam("AWSAccessKeyId", "identity").build();
+
+   public void testFilterWhenResponseIs2xx() {
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(200)
+              .payload(payloadFromResourceWithContentType("/describe_keypairs.xml", "text/xml")).build();
+
+      EC2Api apiWhenExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse, filter, filterResponse);
+
+      KeyPair keyPair = getOnlyElement(apiWhenExist.getKeyPairApi().get().describeKeyPairsInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("key-name", "gsg-keypair")
+                      .build()));
+
+      assertEquals(keyPair.getKeyName(), "gsg-keypair");
+   }
+
+   public void testFilterWhenResponseIs404() {
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(404).build();
+
+      EC2Api apiWhenNotExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse, filter, filterResponse);
+
+      assertEquals(apiWhenNotExist.getKeyPairApi().get().describeKeyPairsInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("key-name", "gsg-keypair")
+                      .build()),
+              ImmutableSet.of());
+   }
+}

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/SecurityGroupApiExpectTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/SecurityGroupApiExpectTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.ec2.features;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.testng.Assert.assertEquals;
+
+import org.jclouds.ec2.EC2Api;
+import org.jclouds.ec2.domain.SecurityGroup;
+import org.jclouds.ec2.internal.BaseEC2ApiExpectTest;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpResponse;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * @author Andrew Bayer
+ */
+@Test(groups = "unit", testName = "SecurityGroupApiExpectTest")
+public class SecurityGroupApiExpectTest extends BaseEC2ApiExpectTest<EC2Api> {
+
+   HttpRequest filter = HttpRequest.builder().method("POST")
+           .endpoint("https://ec2.us-east-1.amazonaws.com/")
+           .addHeader("Host", "ec2.us-east-1.amazonaws.com")
+           .addFormParam("Action", "DescribeSecurityGroups")
+           .addFormParam("Filter.1.Name", "owner-id")
+           .addFormParam("Filter.1.Value.1", "993194456877")
+           .addFormParam("Signature", "zk8EEWkG9Hi0bBLPueF9WdTUKapxQqUXgyJTxeZHXBc%3D")
+           .addFormParam("SignatureMethod", "HmacSHA256")
+           .addFormParam("SignatureVersion", "2")
+           .addFormParam("Timestamp", "2012-04-16T15%3A54%3A08.897Z")
+           .addFormParam("Version", "2010-08-31")
+           .addFormParam("AWSAccessKeyId", "identity").build();
+
+   public void testFilterWhenResponseIs2xx() {
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(200)
+              .payload(payloadFromResourceWithContentType("/describe_securitygroups_extension_single.xml", "text/xml")).build();
+
+      EC2Api apiWhenExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse, filter, filterResponse);
+
+      SecurityGroup group = getOnlyElement(apiWhenExist.getSecurityGroupApi().get().describeSecurityGroupsInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("owner-id", "993194456877")
+                      .build()));
+
+      assertEquals(group.getId(), "sg-3c6ef654");
+   }
+
+   public void testFilterWhenResponseIs404() {
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(404).build();
+
+      EC2Api apiWhenNotExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse, filter, filterResponse);
+
+      assertEquals(apiWhenNotExist.getSecurityGroupApi().get().describeSecurityGroupsInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("owner-id", "993194456877")
+                      .build()),
+              ImmutableSet.of());
+   }
+}

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/SecurityGroupApiTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/SecurityGroupApiTest.java
@@ -65,11 +65,11 @@ public class SecurityGroupApiTest extends BaseEC2ApiTest<SecurityGroupApi> {
                                                 .addFormParam("Action", "CreateSecurityGroup")
                                                 .addFormParam("GroupDescription", "description")
                                                 .addFormParam("GroupName", "name")
-                                                .addFormParam("Signature", "F3o0gnZcX9sWrtDUhVwi3k5GY2JKLP0Dhi6CcEqK2vE%3D")
+                                                .addFormParam("Signature", "msp9zFJLrRXYsVu/vbSZE8tQVS/TEvF0Cu/ldYVFdcA%3D")
                                                 .addFormParam("SignatureMethod", "HmacSHA256")
                                                 .addFormParam("SignatureVersion", "2")
                                                 .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                                .addFormParam("Version", "2010-06-15")
+                                                .addFormParam("Version", "2010-08-31")
                                                 .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testCreateSecurityGroup() throws SecurityException, NoSuchMethodException, IOException {
@@ -153,12 +153,12 @@ public class SecurityGroupApiTest extends BaseEC2ApiTest<SecurityGroupApi> {
                                                               .addFormParam("FromPort", "6000")
                                                               .addFormParam("GroupName", "group")
                                                               .addFormParam("IpProtocol", "tcp")
-                                                              .addFormParam("Signature", "6NQega9YUGDxdwk3Y0Hv71u/lHi%2B0D6qMCJLpJVD/aI%3D")
+                                                              .addFormParam("Signature", "xeaZpQ1Lvhp%2BqETpEzOPGHW6isAWYwgtBdCnTqWzkAw%3D")
                                                               .addFormParam("SignatureMethod", "HmacSHA256")
                                                               .addFormParam("SignatureVersion", "2")
                                                               .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
                                                               .addFormParam("ToPort", "7000")
-                                                              .addFormParam("Version", "2010-06-15")
+                                                              .addFormParam("Version", "2010-08-31")
                                                               .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testAuthorizeSecurityGroupIngressCidr() throws SecurityException, NoSuchMethodException, IOException {
@@ -207,12 +207,12 @@ public class SecurityGroupApiTest extends BaseEC2ApiTest<SecurityGroupApi> {
                                                            .addFormParam("FromPort", "6000")
                                                            .addFormParam("GroupName", "group")
                                                            .addFormParam("IpProtocol", "tcp")
-                                                           .addFormParam("Signature", "WPlDYXI8P6Ip4F2JIEP3lWrVlP/7gxbZvlshKYlrvxk%3D")
+                                                           .addFormParam("Signature", "P5lxCXMwz6FE8Wo79nEMh8clgLDK3rZxCPRTOKssKKQ%3D")
                                                            .addFormParam("SignatureMethod", "HmacSHA256")
                                                            .addFormParam("SignatureVersion", "2")
                                                            .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
                                                            .addFormParam("ToPort", "7000")
-                                                           .addFormParam("Version", "2010-06-15")
+                                                           .addFormParam("Version", "2010-08-31")
                                                            .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testRevokeSecurityGroupIngressCidr() throws SecurityException, NoSuchMethodException, IOException {

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/WindowsApiTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/WindowsApiTest.java
@@ -45,7 +45,7 @@ public class WindowsApiTest extends BaseEC2ApiTest<WindowsApi> {
                                                    .addHeader("Host", "ec2.us-east-1.amazonaws.com")
                                                    .addFormParam("Action", "BundleInstance")
                                                    .addFormParam("InstanceId", "i-e468cd8d")
-                                                   .addFormParam("Signature", "Uw5gH4eN3H8KXeFfIVLDDt88ApYn8L4pkf31hpojpcM%3D")
+                                                   .addFormParam("Signature", "78A6SjliGJg%2BKzaICB9I4bqEXFoNa4FKonuIwAj9hik%3D")
                                                    .addFormParam("SignatureMethod", "HmacSHA256")
                                                    .addFormParam("SignatureVersion", "2")
                                                    .addFormParam("Storage.S3.Bucket", "my-bucket")
@@ -53,7 +53,7 @@ public class WindowsApiTest extends BaseEC2ApiTest<WindowsApi> {
                                                    .addFormParam("Storage.S3.UploadPolicy", "eyJleHBpcmF0aW9uIjogIjIwMDgtMDgtMzBUMDg6NDk6MDlaIiwiY29uZGl0aW9ucyI6IFt7ImJ1Y2tldCI6ICJteS1idWNrZXQifSxbInN0YXJ0cy13aXRoIiwgIiRrZXkiLCAibXktbmV3LWltYWdlIl1dfQ%3D%3D")
                                                    .addFormParam("Storage.S3.UploadPolicySignature", "ih/iohGe0A7y4QVRbKaq6BZShzUsmBEJEa9AdFbxM6Y%3D")
                                                    .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                                   .addFormParam("Version", "2010-06-15")
+                                                   .addFormParam("Version", "2010-08-31")
                                                    .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testBundleInstanceInRegion() throws SecurityException, NoSuchMethodException, IOException {
@@ -88,7 +88,7 @@ public class WindowsApiTest extends BaseEC2ApiTest<WindowsApi> {
                                                           .addHeader("Host", "ec2.us-east-1.amazonaws.com")
                                                           .addFormParam("Action", "BundleInstance")
                                                           .addFormParam("InstanceId","i-e468cd8d")
-                                                          .addFormParam("Signature", "ahFjX9Tv/DGMFq9EFdF1mWSAnTKyQyyIj7dWJxBOhaE%3D")
+                                                          .addFormParam("Signature", "9UbWwb%2BnO2vHn2O59K9FpmaK445RwX7vXsruHRznwik%3D")
                                                           .addFormParam("SignatureMethod", "HmacSHA256")
                                                           .addFormParam("SignatureVersion", "2")
                                                           .addFormParam("Storage.S3.AWSAccessKeyId", "10QMXFEV71ZS32XQFTR2")
@@ -97,7 +97,7 @@ public class WindowsApiTest extends BaseEC2ApiTest<WindowsApi> {
                                                           .addFormParam("Storage.S3.UploadPolicy", "eyJleHBpcmF0aW9uIjogIjIwMDgtMDgtMzBUMDg6NDk6MDlaIiwiY29uZGl0aW9ucyI6IFt7ImJ1Y2tldCI6ICJteS1idWNrZXQifSxbInN0YXJ0cy13aXRoIiwgIiRrZXkiLCAibXktbmV3LWltYWdlIl1dfQ%3D%3D")
                                                           .addFormParam("Storage.S3.UploadPolicySignature", "ih/iohGe0A7y4QVRbKaq6BZShzUsmBEJEa9AdFbxM6Y%3D")
                                                           .addFormParam("Timestamp", "2009-11-08T15%3A54%3A08.897Z")
-                                                          .addFormParam("Version", "2010-06-15")
+                                                          .addFormParam("Version", "2010-08-31")
                                                           .addFormParam("AWSAccessKeyId", "identity").build();
 
    public void testBundleInstanceInRegionOptions() throws SecurityException, NoSuchMethodException, IOException {

--- a/apis/ec2/src/test/java/org/jclouds/ec2/internal/BaseEC2ExpectTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/internal/BaseEC2ExpectTest.java
@@ -72,7 +72,7 @@ public abstract class BaseEC2ExpectTest<T> extends BaseRestClientExpectTest<T> {
                           .endpoint("https://ec2." + region + ".amazonaws.com/")
                           .addHeader("Host", "ec2." + region + ".amazonaws.com")
                           .payload(payloadFromStringWithContentType(
-                                 "Action=DescribeAvailabilityZones&Version=2010-06-15",
+                                 "Action=DescribeAvailabilityZones&Version=2010-08-31",
                                  MediaType.APPLICATION_FORM_URLENCODED)).build()),
                HttpResponse.builder().statusCode(200)
                            .payload(payloadFromResourceWithContentType(

--- a/apis/ec2/src/test/java/org/jclouds/ec2/xml/DescribeRegionsResponseHandlerTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/xml/DescribeRegionsResponseHandlerTest.java
@@ -85,7 +85,7 @@ public class DescribeRegionsResponseHandlerTest extends BaseHandlerTest {
    public void testEuc() {
 
       InputStream is = Strings2
-            .toInputStream("<DescribeRegionsResponse xmlns=\"http://ec2.amazonaws.com/doc/2010-06-15/\"><requestId>6a3b36f9-9ff4-47cf-87e3-285b08fbe5e5</requestId><regionInfo><item><regionName>Eucalyptus</regionName><regionEndpoint>http://173.205.188.130:8773/services/Eucalyptus</regionEndpoint></item><item><regionName>Walrus</regionName><regionEndpoint>http://173.205.188.130:8773/services/Walrus</regionEndpoint></item></regionInfo></DescribeRegionsResponse>");
+            .toInputStream("<DescribeRegionsResponse xmlns=\"http://ec2.amazonaws.com/doc/2010-08-31/\"><requestId>6a3b36f9-9ff4-47cf-87e3-285b08fbe5e5</requestId><regionInfo><item><regionName>Eucalyptus</regionName><regionEndpoint>http://173.205.188.130:8773/services/Eucalyptus</regionEndpoint></item><item><regionName>Walrus</regionName><regionEndpoint>http://173.205.188.130:8773/services/Walrus</regionEndpoint></item></regionInfo></DescribeRegionsResponse>");
 
       Map<String, URI> expected = ImmutableMap.<String, URI> of("Eucalyptus",
             URI.create("http://173.205.188.130:8773/services/Eucalyptus"));

--- a/apis/ec2/src/test/resources/describe_addresses_single.xml
+++ b/apis/ec2/src/test/resources/describe_addresses_single.xml
@@ -1,0 +1,8 @@
+<DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2009-11-30/">
+    <addressesSet>
+        <item>
+            <instanceId>i-f15ebb98</instanceId>
+            <publicIp>67.202.55.255</publicIp>
+        </item>
+    </addressesSet>
+</DescribeAddressesResponse>

--- a/apis/ec2/src/test/resources/describe_securitygroups_empty.xml
+++ b/apis/ec2/src/test/resources/describe_securitygroups_empty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <DescribeSecurityGroupsResponse
-	xmlns="http://ec2.amazonaws.com/doc/2010-06-15/">
+	xmlns="http://ec2.amazonaws.com/doc/2010-08-31/">
 	<requestId>L6EFIZVPJS76T3K5-0UV</requestId>
 	<securityGroupInfo>
 		<item>

--- a/apis/ec2/src/test/resources/describe_volumes_single.xml
+++ b/apis/ec2/src/test/resources/describe_volumes_single.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<DescribeVolumesResponse xmlns="http://ec2.amazonaws.com/doc/2009-11-30/">
+    <requestId>31ab5542-e479-44cb-aa94-c340c2481e0b</requestId>
+    <volumeSet>
+        <item>
+            <volumeId>vol-4282672b</volumeId>
+            <size>800</size>
+            <snapshotId>snap-536d1b3a</snapshotId>
+            <availabilityZone>us-east-1a</availabilityZone>
+            <status>in-use</status>
+            <createTime>2008-05-07T11:51:50.000Z</createTime>
+            <attachmentSet />
+        </item>
+    </volumeSet>
+</DescribeVolumesResponse>

--- a/apis/ec2/src/test/resources/run_instances_cloudbridge.xml
+++ b/apis/ec2/src/test/resources/run_instances_cloudbridge.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2010-06-15/">
+<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2010-08-31/">
   <requestId>56eeacd9-c790-45c3-85f3-e4380b55e1d8</requestId>
   <reservationId>r-f847a6ca</reservationId>
   <ownerId>55ed6530-9b32-48f1-acb7-6ec0d3255a65</ownerId>

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/features/AWSInstanceApi.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/features/AWSInstanceApi.java
@@ -30,11 +30,12 @@ import org.jclouds.aws.ec2.domain.AWSRunningInstance;
 import org.jclouds.aws.ec2.xml.AWSDescribeInstancesResponseHandler;
 import org.jclouds.aws.ec2.xml.AWSRunInstancesResponseHandler;
 import org.jclouds.aws.filters.FormSigner;
+import org.jclouds.ec2.binders.BindFiltersToIndexedFormParams;
 import org.jclouds.ec2.binders.BindInstanceIdsToIndexedFormParams;
 import org.jclouds.ec2.binders.IfNotNullBindAvailabilityZoneToFormParam;
 import org.jclouds.ec2.domain.Reservation;
-import org.jclouds.ec2.options.RunInstancesOptions;
 import org.jclouds.ec2.features.InstanceApi;
+import org.jclouds.ec2.options.RunInstancesOptions;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.location.functions.RegionToEndpointOrProviderIfNull;
 import org.jclouds.rest.annotations.BinderParam;
@@ -44,6 +45,8 @@ import org.jclouds.rest.annotations.FormParams;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.VirtualHost;
 import org.jclouds.rest.annotations.XMLResponseParser;
+
+import com.google.common.collect.Multimap;
 
 /**
  * Provides access to EC2 Instance Services via their REST API.
@@ -65,6 +68,16 @@ public interface AWSInstanceApi extends InstanceApi {
    Set<? extends Reservation<? extends AWSRunningInstance>> describeInstancesInRegion(
             @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
             @BinderParam(BindInstanceIdsToIndexedFormParams.class) String... instanceIds);
+
+   @Named("DescribeInstances")
+   @POST
+   @Path("/")
+   @FormParams(keys = ACTION, values = "DescribeInstances")
+   @XMLResponseParser(AWSDescribeInstancesResponseHandler.class)
+   @Fallback(EmptySetOnNotFoundOr404.class)
+   Set<? extends Reservation<? extends AWSRunningInstance>> describeInstancesInRegionWithFilter(
+           @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
+           @BinderParam(BindFiltersToIndexedFormParams.class) Multimap<String, String> filter);
 
    @Named("RunInstances")
    @Override

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/features/AWSSecurityGroupApi.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/features/AWSSecurityGroupApi.java
@@ -31,6 +31,7 @@ import org.jclouds.aws.ec2.options.CreateSecurityGroupOptions;
 import org.jclouds.aws.ec2.xml.AWSEC2DescribeSecurityGroupsResponseHandler;
 import org.jclouds.aws.ec2.xml.CreateSecurityGroupResponseHandler;
 import org.jclouds.aws.filters.FormSigner;
+import org.jclouds.ec2.binders.BindFiltersToIndexedFormParams;
 import org.jclouds.ec2.binders.BindGroupIdsToIndexedFormParams;
 import org.jclouds.ec2.binders.BindGroupNamesToIndexedFormParams;
 import org.jclouds.ec2.binders.BindIpPermissionToIndexedFormParams;
@@ -49,6 +50,7 @@ import org.jclouds.rest.annotations.VirtualHost;
 import org.jclouds.rest.annotations.XMLResponseParser;
 
 import com.google.common.annotations.Beta;
+import com.google.common.collect.Multimap;
 
 /**
  * Provides access to EC2 SecurityGroup Services via their REST API.
@@ -132,4 +134,14 @@ public interface AWSSecurityGroupApi extends SecurityGroupApi {
    Set<SecurityGroup> describeSecurityGroupsInRegion(
            @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
            @BinderParam(BindGroupNamesToIndexedFormParams.class) String... securityGroupNames);
+
+   @Named("DescribeSecurityGroups")
+   @POST
+   @Path("/")
+   @FormParams(keys = ACTION, values = "DescribeSecurityGroups")
+   @XMLResponseParser(AWSEC2DescribeSecurityGroupsResponseHandler.class)
+   @Fallback(EmptySetOnNotFoundOr404.class)
+   Set<SecurityGroup> describeSecurityGroupsInRegionWithFilter(
+           @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
+           @BinderParam(BindFiltersToIndexedFormParams.class) Multimap<String, String> filter);
 }

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/features/PlacementGroupApi.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/features/PlacementGroupApi.java
@@ -30,6 +30,7 @@ import org.jclouds.Fallbacks.VoidOnNotFoundOr404;
 import org.jclouds.aws.ec2.domain.PlacementGroup;
 import org.jclouds.aws.ec2.xml.DescribePlacementGroupsResponseHandler;
 import org.jclouds.aws.filters.FormSigner;
+import org.jclouds.ec2.binders.BindFiltersToIndexedFormParams;
 import org.jclouds.ec2.binders.BindGroupNamesToIndexedFormParams;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.location.functions.RegionToEndpointOrProviderIfNull;
@@ -40,6 +41,8 @@ import org.jclouds.rest.annotations.FormParams;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.VirtualHost;
 import org.jclouds.rest.annotations.XMLResponseParser;
+
+import com.google.common.collect.Multimap;
 
 /**
  * Provides access to EC2 Placement Groups via their REST API.
@@ -133,4 +136,27 @@ public interface PlacementGroupApi {
             @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
             @BinderParam(BindGroupNamesToIndexedFormParams.class) String... placementGroupIds);
 
+   /**
+    *
+    * Returns information about one or more placement groups in your account.
+    *
+    * @param region
+    *           The bundleTask ID is tied to the Region.
+    * @param filter
+    *           Multimap of filter key/values
+    *
+    * @see #deletePlacementGroupInRegion
+    * @see #createPlacementGroupInRegion
+    * @see <a href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribePlacementGroups.html"
+    *      />
+    */
+   @Named("DescribePlacementGroups")
+   @POST
+   @Path("/")
+   @FormParams(keys = ACTION, values = "DescribePlacementGroups")
+   @XMLResponseParser(DescribePlacementGroupsResponseHandler.class)
+   @Fallback(EmptySetOnNotFoundOr404.class)
+   Set<PlacementGroup> describePlacementGroupsInRegionWithFilter(
+           @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
+           @BinderParam(BindFiltersToIndexedFormParams.class) Multimap<String, String> filter);
 }

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/features/SpotInstanceApi.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/features/SpotInstanceApi.java
@@ -38,6 +38,7 @@ import org.jclouds.aws.ec2.xml.DescribeSpotPriceHistoryResponseHandler;
 import org.jclouds.aws.ec2.xml.SpotInstanceHandler;
 import org.jclouds.aws.ec2.xml.SpotInstancesHandler;
 import org.jclouds.aws.filters.FormSigner;
+import org.jclouds.ec2.binders.BindFiltersToIndexedFormParams;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.location.functions.RegionToEndpointOrProviderIfNull;
 import org.jclouds.rest.annotations.BinderParam;
@@ -47,6 +48,8 @@ import org.jclouds.rest.annotations.FormParams;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.VirtualHost;
 import org.jclouds.rest.annotations.XMLResponseParser;
+
+import com.google.common.collect.Multimap;
 
 /**
  * Provides access to EC2 Spot Instances via their REST API.
@@ -87,6 +90,36 @@ public interface SpotInstanceApi {
    Set<SpotInstanceRequest> describeSpotInstanceRequestsInRegion(
          @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
          @BinderParam(BindSpotInstanceRequestIdsToIndexedFormParams.class) String... requestIds);
+
+   /**
+    * Describes Spot Instance requests. Spot Instances are instances that Amazon EC2 starts on your
+    * behalf when the maximum price that you specify exceeds the current Spot Price. Amazon EC2
+    * periodically sets the Spot Price based on available Spot Instance capacity and current spot
+    * instance requests. For conceptual information about Spot Instances, refer to the Amazon
+    * Elastic Compute Cloud Developer Guide or Amazon Elastic Compute Cloud User Guide.
+    *
+    * @param region
+    *           Region where the spot instance service is running
+    * @param filter
+    *           Mulitmap of filter key/values.
+    *
+    * @see #requestSpotInstancesInRegion
+    * @see #cancelSpotInstanceRequestsInRegion
+    * @see #describeSpotPriceHistoryInRegion
+    * @see <a href=
+    *      "http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeSpotInstanceRequests.html"
+    *      />
+    * @return TODO
+    */
+   @Named("DescribeSpotInstanceRequests")
+   @POST
+   @Path("/")
+   @FormParams(keys = ACTION, values = "DescribeSpotInstanceRequests")
+   @Fallback(EmptySetOnNotFoundOr404.class)
+   @XMLResponseParser(SpotInstancesHandler.class)
+   Set<SpotInstanceRequest> describeSpotInstanceRequestsInRegionWithFilter(
+           @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
+           @BinderParam(BindFiltersToIndexedFormParams.class) Multimap<String, String> filter);
 
    /**
     * request a single spot instance

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/AWSInstanceApiLiveTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/AWSInstanceApiLiveTest.java
@@ -21,7 +21,6 @@ import static org.testng.Assert.assertNotNull;
 import java.util.Set;
 
 import org.jclouds.aws.ec2.AWSEC2Api;
-import org.jclouds.aws.ec2.AWSEC2ApiMetadata;
 import org.jclouds.compute.internal.BaseComputeServiceContextLiveTest;
 import org.jclouds.ec2.domain.Reservation;
 import org.jclouds.ec2.domain.RunningInstance;
@@ -58,5 +57,4 @@ public class AWSInstanceApiLiveTest extends BaseComputeServiceContextLiveTest {
          assert allResults.size() >= 0 : allResults.size();
       }
    }
-
 }

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/PlacementGroupApiExpectTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/PlacementGroupApiExpectTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.aws.ec2.features;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.testng.Assert.assertEquals;
+
+import org.jclouds.aws.ec2.AWSEC2Api;
+import org.jclouds.aws.ec2.compute.internal.BaseAWSEC2ComputeServiceExpectTest;
+import org.jclouds.aws.ec2.domain.PlacementGroup;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpResponse;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * @author Andrew Bayer
+ */
+@Test(groups = "unit", testName = "PlacementGroupApiExpectTest")
+public class PlacementGroupApiExpectTest extends BaseAWSEC2ComputeServiceExpectTest {
+
+   HttpRequest filter = HttpRequest.builder().method("POST")
+           .endpoint("https://ec2.us-east-1.amazonaws.com/")
+           .addHeader("Host", "ec2.us-east-1.amazonaws.com")
+           .addFormParam("Action", "DescribePlacementGroups")
+           .addFormParam("Filter.1.Name", "strategy")
+           .addFormParam("Filter.1.Value.1", "cluster")
+           .addFormParam("Signature", "SaA7Un1BE3m9jIEKyjXNdQPzFh/QAJSCebvKXiwUEK0%3D")
+           .addFormParam("SignatureMethod", "HmacSHA256")
+           .addFormParam("SignatureVersion", "2")
+           .addFormParam("Timestamp", "2012-04-16T15%3A54%3A08.897Z")
+           .addFormParam("Version", "2012-06-01")
+           .addFormParam("AWSAccessKeyId", "identity").build();
+
+   public void testFilterWhenResponseIs2xx() {
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(200)
+              .payload(payloadFromResourceWithContentType("/describe_placement_groups.xml", "text/xml")).build();
+
+      AWSEC2Api apiWhenExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse, filter, filterResponse)
+              .getContext().unwrapApi(AWSEC2Api.class);
+
+      PlacementGroup group = getOnlyElement(apiWhenExist.getPlacementGroupApi().get().describePlacementGroupsInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("strategy", "cluster")
+                      .build()));
+
+      assertEquals(group.getName(), "XYZ-cluster");
+   }
+
+   public void testFilterWhenResponseIs404() {
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(404).build();
+
+      AWSEC2Api apiWhenNotExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse, filter, filterResponse)
+              .getContext().unwrapApi(AWSEC2Api.class);
+
+      assertEquals(apiWhenNotExist.getPlacementGroupApi().get().describePlacementGroupsInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("strategy", "cluster")
+                      .build()),
+              ImmutableSet.of());
+   }
+}

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/SpotInstanceApiExpectTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/SpotInstanceApiExpectTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.aws.ec2.features;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.testng.Assert.assertEquals;
+
+import org.jclouds.aws.ec2.AWSEC2Api;
+import org.jclouds.aws.ec2.compute.internal.BaseAWSEC2ComputeServiceExpectTest;
+import org.jclouds.aws.ec2.domain.SpotInstanceRequest;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpResponse;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * @author Andrew Bayer
+ */
+@Test(groups = "unit", testName = "SpotInstanceApiExpectTest")
+public class SpotInstanceApiExpectTest extends BaseAWSEC2ComputeServiceExpectTest {
+
+   HttpRequest filter = HttpRequest.builder().method("POST")
+           .endpoint("https://ec2.us-east-1.amazonaws.com/")
+           .addHeader("Host", "ec2.us-east-1.amazonaws.com")
+           .addFormParam("Action", "DescribeSpotInstanceRequests")
+           .addFormParam("Filter.1.Name", "instance-id")
+           .addFormParam("Filter.1.Value.1", "i-ef308e8e")
+           .addFormParam("Signature", "wQtGpumMCDEzvlldKepCKeEjD9iE7eAyiRBlQztcJMA%3D")
+           .addFormParam("SignatureMethod", "HmacSHA256")
+           .addFormParam("SignatureVersion", "2")
+           .addFormParam("Timestamp", "2012-04-16T15%3A54%3A08.897Z")
+           .addFormParam("Version", "2012-06-01")
+           .addFormParam("AWSAccessKeyId", "identity").build();
+
+   public void testFilterWhenResponseIs2xx() {
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(200)
+              .payload(payloadFromResourceWithContentType("/describe_spot_instance.xml", "text/xml")).build();
+
+      AWSEC2Api apiWhenExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse, filter, filterResponse)
+              .getContext().unwrapApi(AWSEC2Api.class);
+
+      SpotInstanceRequest request = getOnlyElement(apiWhenExist.getSpotInstanceApi().get().describeSpotInstanceRequestsInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("instance-id", "i-ef308e8e")
+                      .build()));
+
+      assertEquals(request.getId(), "sir-1ede0012");
+   }
+
+   public void testFilterWhenResponseIs404() {
+      HttpResponse filterResponse = HttpResponse.builder().statusCode(404).build();
+
+      AWSEC2Api apiWhenNotExist = requestsSendResponses(describeRegionsRequest, describeRegionsResponse, filter, filterResponse)
+              .getContext().unwrapApi(AWSEC2Api.class);
+
+      assertEquals(apiWhenNotExist.getSpotInstanceApi().get().describeSpotInstanceRequestsInRegionWithFilter("us-east-1",
+              ImmutableMultimap.<String, String>builder()
+                      .put("instance-id", "i-ef308e8e")
+                      .build()),
+              ImmutableSet.of());
+   }
+}


### PR DESCRIPTION
Note - this is just the first part mentioned in the JIRA - adding the filter support in the first place. I need to figure out how to do the rest - translating NodeMetadata Predicates into EC2 instance filters, which...well, it'll be a bit of a pain, but oh my will it be useful.
