### PR TITLE
JCLOUDS-373: Fix SoftLayerOrderItemDuplicateException.

### DIFF
--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/exceptions/SoftLayerOrderItemDuplicateException.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/exceptions/SoftLayerOrderItemDuplicateException.java
@@ -16,10 +16,14 @@
  */
 package org.jclouds.softlayer.exceptions;
 
-public class SoftLayerOrderItemDuplicateException extends RuntimeException {
+import org.jclouds.http.HttpCommand;
+import org.jclouds.http.HttpResponse;
+import org.jclouds.http.HttpResponseException;
 
-   public SoftLayerOrderItemDuplicateException(String message, Exception exception) {
-      super(message, exception);
+public class SoftLayerOrderItemDuplicateException extends HttpResponseException {
+
+   public SoftLayerOrderItemDuplicateException(HttpCommand command, HttpResponse response, String message) {
+      super(command, response, message);
    }
 
 }

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/handlers/SoftLayerErrorHandler.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/handlers/SoftLayerErrorHandler.java
@@ -66,7 +66,7 @@ public class SoftLayerErrorHandler implements HttpErrorHandler {
                   } else if (message.indexOf("currently an active transaction") != -1) {
                      exception = new IllegalStateException(message, exception);
                   } else if (message.indexOf("SoftLayer_Exception_Order_Item_Duplicate") != -1) {
-                     exception = new SoftLayerOrderItemDuplicateException(message, exception);
+                     exception = new SoftLayerOrderItemDuplicateException(command, response, message);
                   }
                }
          }


### PR DESCRIPTION
- SoftLayerOrderItemDuplicateException extends IllegalStateException for consistency and for Throwables2.propagateIfPossible
