### PR TITLE
JCLOUDS-386: Removing the remote-resources plugin

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -705,10 +705,6 @@
           <version>2.3</version>
         </plugin>
         <plugin>
-          <artifactId>maven-remote-resources-plugin</artifactId>
-          <version>1.4</version>
-        </plugin>
-        <plugin>
           <artifactId>maven-pmd-plugin</artifactId>
           <version>2.7.1</version>
         </plugin>
@@ -998,20 +994,7 @@
         </site>
       </distributionManagement>
       <build>
-        <plugins>
-          <plugin>      
-            <artifactId>maven-remote-resources-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>process</goal>
-                </goals>
-                <configuration>
-                  <skip>true</skip>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>        
+        <plugins> 
           <plugin>
             <!-- When building jclouds-project, override the config to use the local file -->
             <artifactId>maven-checkstyle-plugin</artifactId>

--- a/resources/pom.xml
+++ b/resources/pom.xml
@@ -33,14 +33,6 @@
   <build>
     <resources>
       <resource>
-        <targetPath>META-INF</targetPath>
-        <directory>${project.basedir}</directory>
-        <includes>
-          <include>LICENSE.txt</include>
-          <include>NOTICE.txt</include>
-        </includes>
-      </resource>
-      <resource>
         <targetPath>resources</targetPath>
         <directory>${project.basedir}</directory>
         <includes>
@@ -48,35 +40,5 @@
         </includes>
       </resource>
     </resources>
-    <plugins>
-      <plugin>      
-        <artifactId>maven-remote-resources-plugin</artifactId>
-        <executions>              
-          <execution>
-            <id>bundle-remote-resources</id>
-            <goals>
-              <goal>bundle</goal>
-            </goals>
-            <!-- run *after* copying resources to the output directory -->
-            <phase>process-resources</phase>
-            <configuration>
-              <resourcesDirectory>${project.build.outputDirectory}</resourcesDirectory>
-              <includes>
-                <include>META-INF/LICENSE.txt</include>
-                <include>META-INF/NOTICE.txt</include>
-              </includes>
-            </configuration>                        
-          </execution>
-          <execution>
-            <goals>
-              <goal>process</goal>
-            </goals>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>        
-    </plugins>
   </build>
 </project>


### PR DESCRIPTION
We only use the shared resources for the Checkstyle config now, and that doesn't need to be "mixed in" to the project output directory
