### PR TITLE
Backport JCLOUDS-416 to 1.7.x. Add TemplateOptions#networks.

### DIFF
--- a/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/compute/options/CloudSigmaTemplateOptions.java
+++ b/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/compute/options/CloudSigmaTemplateOptions.java
@@ -16,12 +16,12 @@
  */
 package org.jclouds.cloudsigma.compute.options;
 
-import java.util.Map;
-
 import org.jclouds.cloudsigma.domain.AffinityType;
 import org.jclouds.compute.options.TemplateOptions;
 import org.jclouds.domain.LoginCredentials;
 import org.jclouds.scriptbuilder.domain.Statement;
+
+import java.util.Map;
 
 public class CloudSigmaTemplateOptions extends TemplateOptions implements Cloneable {
 
@@ -112,6 +112,14 @@ public class CloudSigmaTemplateOptions extends TemplateOptions implements Clonea
       public static CloudSigmaTemplateOptions nodeNames(Iterable<String> nodeNames) {
          CloudSigmaTemplateOptions options = new CloudSigmaTemplateOptions();
          return CloudSigmaTemplateOptions.class.cast(options.nodeNames(nodeNames));
+      }
+
+      /**
+       * @see TemplateOptions#nodeNames(Iterable)
+       */
+      public static CloudSigmaTemplateOptions networks(Iterable<String> networks) {
+         CloudSigmaTemplateOptions options = new CloudSigmaTemplateOptions();
+         return CloudSigmaTemplateOptions.class.cast(options.networks(networks));
       }
 
       public static CloudSigmaTemplateOptions overrideLoginUser(String user) {
@@ -276,6 +284,14 @@ public class CloudSigmaTemplateOptions extends TemplateOptions implements Clonea
    @Override
    public CloudSigmaTemplateOptions nodeNames(Iterable<String> nodeNames) {
       return CloudSigmaTemplateOptions.class.cast(super.nodeNames(nodeNames));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public CloudSigmaTemplateOptions networks(Iterable<String> networks) {
+      return CloudSigmaTemplateOptions.class.cast(super.networks(networks));
    }
 
    @Override

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/compute/options/CloudStackTemplateOptions.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/compute/options/CloudStackTemplateOptions.java
@@ -51,7 +51,6 @@ import com.google.common.collect.Sets;
 public class CloudStackTemplateOptions extends TemplateOptions implements Cloneable {
 
    protected Set<String> securityGroupIds = Sets.<String> newLinkedHashSet();
-   protected Set<String> networkIds = Sets.<String> newLinkedHashSet();
    protected Map<String, String> ipsToNetworks = Maps.<String, String>newLinkedHashMap();
    protected String ipOnDefaultNetwork;
    protected String keyPair;
@@ -76,7 +75,6 @@ public class CloudStackTemplateOptions extends TemplateOptions implements Clonea
       if (to instanceof CloudStackTemplateOptions) {
          CloudStackTemplateOptions eTo = CloudStackTemplateOptions.class.cast(to);
          eTo.securityGroupIds(this.securityGroupIds);
-         eTo.networkIds(this.networkIds);
          eTo.ipsToNetworks(this.ipsToNetworks);
          eTo.ipOnDefaultNetwork(this.ipOnDefaultNetwork);
          eTo.keyPair(this.keyPair);
@@ -150,23 +148,31 @@ public class CloudStackTemplateOptions extends TemplateOptions implements Clonea
    }
 
    /**
+    * @deprecated See TemplateOptions#networks
     * @see DeployVirtualMachineOptions#networkId
     */
+   @Deprecated
    public CloudStackTemplateOptions networkId(String networkId) {
-      this.networkIds.add(networkId);
+      this.networks.add(networkId);
       return this;
    }
 
    /**
+    * @deprecated See TemplateOptions#networks
     * @see DeployVirtualMachineOptions#networkIds
     */
+   @Deprecated
    public CloudStackTemplateOptions networkIds(Iterable<String> networkIds) {
-      Iterables.addAll(this.networkIds, checkNotNull(networkIds, "networkIds was null"));
+      Iterables.addAll(this.networks, checkNotNull(networkIds, "networkIds was null"));
       return this;
    }
 
+   /**
+    * @deprecated See TemplateOptions#getNetworks
+    */
+   @Deprecated
    public Set<String> getNetworkIds() {
-      return networkIds;
+      return this.getNetworks();
    }
 
    public CloudStackTemplateOptions setupStaticNat(boolean setupStaticNat) {
@@ -298,19 +304,21 @@ public class CloudStackTemplateOptions extends TemplateOptions implements Clonea
       }
 
       /**
+       * @deprecated See TemplateOptions#networks
        * @see CloudStackTemplateOptions#networkId
        */
+      @Deprecated
       public static CloudStackTemplateOptions networkId(String id) {
-         CloudStackTemplateOptions options = new CloudStackTemplateOptions();
-         return options.networkId(id);
+         return networks(id);
       }
 
       /**
+       * @deprecated see TemplateOptions#networks
        * @see CloudStackTemplateOptions#networkIds
        */
+      @Deprecated
       public static CloudStackTemplateOptions networkIds(Iterable<String> networkIds) {
-         CloudStackTemplateOptions options = new CloudStackTemplateOptions();
-         return options.networkIds(networkIds);
+         return networks(networkIds);
       }
 
       /**
@@ -409,6 +417,22 @@ public class CloudStackTemplateOptions extends TemplateOptions implements Clonea
          CloudStackTemplateOptions options = new CloudStackTemplateOptions();
          return CloudStackTemplateOptions.class.cast(options.nodeNames(nodeNames));
       }
+
+      /**
+       * @see TemplateOptions#networks(Iterable)
+       */
+      public static CloudStackTemplateOptions networks(Iterable<String> networks) {
+         CloudStackTemplateOptions options = new CloudStackTemplateOptions();
+         return CloudStackTemplateOptions.class.cast(options.networks(networks));
+      }
+
+      /**
+       * @see TemplateOptions#networks(String...)
+       */
+      public static CloudStackTemplateOptions networks(String... networks) {
+         CloudStackTemplateOptions options = new CloudStackTemplateOptions();
+         return CloudStackTemplateOptions.class.cast(options.networks(networks));
+      }
    }
 
    // methods that only facilitate returning the correct object type
@@ -467,5 +491,21 @@ public class CloudStackTemplateOptions extends TemplateOptions implements Clonea
    @Override
    public CloudStackTemplateOptions nodeNames(Iterable<String> nodeNames) {
       return CloudStackTemplateOptions.class.cast(super.nodeNames(nodeNames));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public CloudStackTemplateOptions networks(Iterable<String> networks) {
+      return CloudStackTemplateOptions.class.cast(super.networks(networks));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public CloudStackTemplateOptions networks(String... networks) {
+      return CloudStackTemplateOptions.class.cast(super.networks(networks));
    }
 }

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/compute/strategy/AdvancedNetworkOptionsConverter.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/compute/strategy/AdvancedNetworkOptionsConverter.java
@@ -16,20 +16,17 @@
  */
 package org.jclouds.cloudstack.compute.strategy;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Predicates.and;
-import static com.google.common.collect.Iterables.filter;
-import static org.jclouds.cloudstack.predicates.NetworkPredicates.defaultNetworkInZone;
-import static org.jclouds.cloudstack.predicates.NetworkPredicates.isIsolatedNetwork;
-import static org.jclouds.cloudstack.predicates.NetworkPredicates.supportsStaticNAT;
-
-import java.util.Map;
-
+import com.google.common.collect.Iterables;
 import org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions;
 import org.jclouds.cloudstack.domain.Network;
 import org.jclouds.cloudstack.options.DeployVirtualMachineOptions;
 
-import com.google.common.collect.Iterables;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Predicates.and;
+import static com.google.common.collect.Iterables.filter;
+import static org.jclouds.cloudstack.predicates.NetworkPredicates.*;
 
 /**
  * Convert template options into DeployVirtualMachineOptions, when the target zone has advanced networking.
@@ -43,8 +40,8 @@ public class AdvancedNetworkOptionsConverter implements OptionsConverter {
       // at least one network must be given to CloudStack,
       // but jclouds will try to autodetect an appropriate network if none given.
       checkArgument(templateOptions.getSecurityGroupIds().isEmpty(), "security groups cannot be specified for locations (zones) that use advanced networking");
-      if (templateOptions.getNetworkIds().size() > 0) {
-         options.networkIds(templateOptions.getNetworkIds());
+      if (!templateOptions.getNetworks().isEmpty()) {
+         options.networkIds(templateOptions.getNetworks());
       } else if (templateOptions.getIpsToNetworks().isEmpty()) {
          checkArgument(!networks.isEmpty(), "please setup a network for zone: " + zoneId);
          Network defaultNetworkInZone = Iterables.getFirst(filter(networks.values(), and(defaultNetworkInZone(zoneId), supportsStaticNAT())), null);

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/compute/strategy/BasicNetworkOptionsConverter.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/compute/strategy/BasicNetworkOptionsConverter.java
@@ -16,11 +16,11 @@
  */
 package org.jclouds.cloudstack.compute.strategy;
 
-import java.util.Map;
-
 import org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions;
 import org.jclouds.cloudstack.domain.Network;
 import org.jclouds.cloudstack.options.DeployVirtualMachineOptions;
+
+import java.util.Map;
 
 /**
  * Convert template options into DeployVirtualMachineOptions, when the target zone has basic networking.
@@ -32,11 +32,11 @@ public class BasicNetworkOptionsConverter implements OptionsConverter {
    public DeployVirtualMachineOptions apply(CloudStackTemplateOptions templateOptions, Map<String, Network> networks, String zoneId, DeployVirtualMachineOptions options) {
       // both security groups and networks are optional, and CloudStack will
       // use the zone/user's default network/security group if none given
-      if (templateOptions.getSecurityGroupIds().size() > 0) {
+      if (!templateOptions.getSecurityGroupIds().isEmpty()) {
          options.securityGroupIds(templateOptions.getSecurityGroupIds());
       }
-      if (templateOptions.getNetworkIds().size() > 0) {
-         options.networkIds(templateOptions.getNetworkIds());
+      if (!templateOptions.getNetworks().isEmpty()) {
+         options.networkIds(templateOptions.getNetworks());
       }
       return options;
    }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/compute/CloudStackExperimentLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/compute/CloudStackExperimentLiveTest.java
@@ -16,17 +16,6 @@
  */
 package org.jclouds.cloudstack.compute;
 
-import static com.google.common.collect.Iterables.concat;
-import static com.google.common.collect.Iterables.get;
-import static com.google.common.collect.Sets.newTreeSet;
-import static org.jclouds.cloudstack.options.CreateNetworkOptions.Builder.vlan;
-import static org.jclouds.cloudstack.options.ListNetworkOfferingsOptions.Builder.specifyVLAN;
-
-import java.net.URI;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions;
 import org.jclouds.cloudstack.domain.Network;
 import org.jclouds.cloudstack.domain.TrafficType;
@@ -37,6 +26,17 @@ import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.Template;
 import org.jclouds.compute.predicates.NodePredicates;
 import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.google.common.collect.Iterables.concat;
+import static com.google.common.collect.Iterables.get;
+import static com.google.common.collect.Sets.newTreeSet;
+import static org.jclouds.cloudstack.options.CreateNetworkOptions.Builder.vlan;
+import static org.jclouds.cloudstack.options.ListNetworkOfferingsOptions.Builder.specifyVLAN;
 
 /**
  * @author Adrian Cole
@@ -101,7 +101,7 @@ public class CloudStackExperimentLiveTest extends BaseCloudStackApiLiveTest {
                vlan(vlanId).startIP("192.168.1.2").netmask("255.255.255.0").gateway("192.168.1.1"));
 
          // set options to specify this network id
-         template.getOptions().as(CloudStackTemplateOptions.class).networkId(network.getId());
+         template.getOptions().as(CloudStackTemplateOptions.class).networks(network.getId());
 
          // launch the VM
          nodes = view.getComputeService().createNodesInGroup(group, 1, template);

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/compute/options/CloudStackTemplateOptionsTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/compute/options/CloudStackTemplateOptionsTest.java
@@ -16,32 +16,15 @@
  */
 package org.jclouds.cloudstack.compute.options;
 
-import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.account;
-import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.dataDiskSize;
-import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.diskOfferingId;
-import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.domainId;
-import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.generateKeyPair;
-import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.generateSecurityGroup;
-import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.ipOnDefaultNetwork;
-import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.ipsToNetworks;
-import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.keyPair;
-import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.networkId;
-import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.networkIds;
-import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.securityGroupId;
-import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.securityGroupIds;
-import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.setupStaticNat;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
-
-import java.util.Map;
-
+import com.google.common.collect.ImmutableSet;
 import org.jclouds.compute.options.TemplateOptions;
 import org.testng.annotations.Test;
 import org.testng.collections.Maps;
 
-import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+
+import static org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions.Builder.*;
+import static org.testng.Assert.*;
 
 /**
  * Tests possible uses of {@code CloudStackTemplateOptions} and
@@ -115,31 +98,31 @@ public class CloudStackTemplateOptionsTest {
    @Test
    public void testDefaultNetworkIds() {
       TemplateOptions options = new CloudStackTemplateOptions();
-      assertEquals(options.as(CloudStackTemplateOptions.class).getNetworkIds(), ImmutableSet.of());
+      assertEquals(options.as(CloudStackTemplateOptions.class).getNetworks(), ImmutableSet.of());
    }
 
    @Test
    public void testNetworkId() {
-      TemplateOptions options = new CloudStackTemplateOptions().networkId("3");
-      assertEquals(options.as(CloudStackTemplateOptions.class).getNetworkIds(), ImmutableSet.of("3"));
+      TemplateOptions options = new CloudStackTemplateOptions().networks("3");
+      assertEquals(options.as(CloudStackTemplateOptions.class).getNetworks(), ImmutableSet.of("3"));
    }
 
    @Test
    public void testNetworkIdStatic() {
-      TemplateOptions options = networkId("3");
-      assertEquals(options.as(CloudStackTemplateOptions.class).getNetworkIds(), ImmutableSet.of("3"));
+      TemplateOptions options = networks(ImmutableSet.of("3"));
+      assertEquals(options.as(CloudStackTemplateOptions.class).getNetworks(), ImmutableSet.of("3"));
    }
 
    @Test
    public void testNetworkIds() {
-      TemplateOptions options = new CloudStackTemplateOptions().networkIds(ImmutableSet.of("3"));
-      assertEquals(options.as(CloudStackTemplateOptions.class).getNetworkIds(), ImmutableSet.of("3"));
+      TemplateOptions options = new CloudStackTemplateOptions().networks(ImmutableSet.of("3"));
+      assertEquals(options.as(CloudStackTemplateOptions.class).getNetworks(), ImmutableSet.of("3"));
    }
 
    @Test
    public void testNetworkIdsStatic() {
-      TemplateOptions options = networkIds(ImmutableSet.of("3"));
-      assertEquals(options.as(CloudStackTemplateOptions.class).getNetworkIds(), ImmutableSet.of("3"));
+      TemplateOptions options = networks(ImmutableSet.of("3"));
+      assertEquals(options.as(CloudStackTemplateOptions.class).getNetworks(), ImmutableSet.of("3"));
    }
 
    @Test

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/compute/strategy/OptionsConverterTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/compute/strategy/OptionsConverterTest.java
@@ -16,19 +16,18 @@
  */
 package org.jclouds.cloudstack.compute.strategy;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-
-import java.util.Map;
-
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions;
 import org.jclouds.cloudstack.domain.Network;
 import org.jclouds.cloudstack.domain.NetworkService;
 import org.jclouds.cloudstack.options.DeployVirtualMachineOptions;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true, testName="OptionsConverterTest")
 public class OptionsConverterTest {
@@ -42,7 +41,7 @@ public class OptionsConverterTest {
    public void testBasicNetworkOptionsConverter() {
       BasicNetworkOptionsConverter converter = new BasicNetworkOptionsConverter();
 
-      CloudStackTemplateOptions optionsIn = CloudStackTemplateOptions.Builder.securityGroupId("42").networkId("46");
+      CloudStackTemplateOptions optionsIn = CloudStackTemplateOptions.Builder.securityGroupId("42").networks("46");
       DeployVirtualMachineOptions optionsOut = new DeployVirtualMachineOptions();
 
       DeployVirtualMachineOptions optionsOut2 = converter.apply(optionsIn, EMPTY_NETWORKS_MAP, ZONE_ID, optionsOut);
@@ -70,7 +69,7 @@ public class OptionsConverterTest {
    @Test
    public void testAdvancedExplicitNetworkSelection() {
       AdvancedNetworkOptionsConverter converter = new AdvancedNetworkOptionsConverter();
-      DeployVirtualMachineOptions optionsActual = converter.apply(CloudStackTemplateOptions.Builder.networkId("42"),
+      DeployVirtualMachineOptions optionsActual = converter.apply(CloudStackTemplateOptions.Builder.networks("42"),
          EMPTY_NETWORKS_MAP, ZONE_ID, DeployVirtualMachineOptions.NONE);
       DeployVirtualMachineOptions optionsExpected = DeployVirtualMachineOptions.Builder.networkId("42");
       assertEquals(optionsActual, optionsExpected);

--- a/apis/ec2/src/main/java/org/jclouds/ec2/compute/options/EC2TemplateOptions.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/compute/options/EC2TemplateOptions.java
@@ -16,16 +16,12 @@
  */
 package org.jclouds.ec2.compute.options;
 
-import static com.google.common.base.Objects.equal;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Strings.emptyToNull;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import com.google.common.base.Objects;
+import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
 import org.jclouds.compute.options.TemplateOptions;
 import org.jclouds.domain.LoginCredentials;
 import org.jclouds.ec2.domain.BlockDeviceMapping;
@@ -36,12 +32,13 @@ import org.jclouds.ec2.domain.BlockDeviceMapping.UnmapDeviceNamed;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.scriptbuilder.domain.Statement;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Objects.ToStringHelper;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.hash.Hashing;
-import com.google.common.primitives.Bytes;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Objects.equal;
+import static com.google.common.base.Preconditions.*;
+import static com.google.common.base.Strings.emptyToNull;
 
 /**
  * Contains options supported in the {@code ComputeService#runNode} operation on
@@ -332,7 +329,15 @@ public class EC2TemplateOptions extends TemplateOptions implements Cloneable {
          EC2TemplateOptions options = new EC2TemplateOptions();
          return EC2TemplateOptions.class.cast(options.nodeNames(nodeNames));
       }
-      
+
+      /**
+       * @see TemplateOptions#networks(Iterable)
+       */
+      public static EC2TemplateOptions networks(Iterable<String> networks) {
+         EC2TemplateOptions options = new EC2TemplateOptions();
+         return EC2TemplateOptions.class.cast(options.networks(networks));
+      }
+
       public static EC2TemplateOptions overrideLoginUser(String user) {
          EC2TemplateOptions options = new EC2TemplateOptions();
          return options.overrideLoginUser(user);
@@ -535,6 +540,14 @@ public class EC2TemplateOptions extends TemplateOptions implements Cloneable {
    @Override
    public EC2TemplateOptions nodeNames(Iterable<String> nodeNames) {
       return EC2TemplateOptions.class.cast(super.nodeNames(nodeNames));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public EC2TemplateOptions networks(Iterable<String> networks) {
+      return EC2TemplateOptions.class.cast(super.networks(networks));
    }
 
    /**

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/compute/options/NovaTemplateOptions.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/compute/options/NovaTemplateOptions.java
@@ -306,6 +306,14 @@ public class NovaTemplateOptions extends TemplateOptions implements Cloneable {
       }
 
       /**
+       * @see TemplateOptions#networks(Iterable)
+       */
+      public static NovaTemplateOptions networks(Iterable<String> networks) {
+         NovaTemplateOptions options = new NovaTemplateOptions();
+         return NovaTemplateOptions.class.cast(options.networks(networks));
+      }
+
+      /**
        * @see TemplateOptions#overrideLoginUser
        */
       public static NovaTemplateOptions overrideLoginUser(String user) {
@@ -508,6 +516,13 @@ public class NovaTemplateOptions extends TemplateOptions implements Cloneable {
       return NovaTemplateOptions.class.cast(super.nodeNames(nodeNames));
    }
 
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public NovaTemplateOptions networks(Iterable<String> networks) {
+      return NovaTemplateOptions.class.cast(super.networks(networks));
+   }
 
    /**
     * User data as bytes (not base64-encoded)

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/compute/options/VCloudTemplateOptions.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/compute/options/VCloudTemplateOptions.java
@@ -230,6 +230,14 @@ public class VCloudTemplateOptions extends TemplateOptions implements Cloneable 
          return VCloudTemplateOptions.class.cast(options.nodeNames(nodeNames));
       }
 
+      /**
+       * @see TemplateOptions#networks(Iterable)
+       */
+      public static VCloudTemplateOptions networks(Iterable<String> networks) {
+         VCloudTemplateOptions options = new VCloudTemplateOptions();
+         return VCloudTemplateOptions.class.cast(options.networks(networks));
+      }
+
    }
 
    /**
@@ -329,6 +337,14 @@ public class VCloudTemplateOptions extends TemplateOptions implements Cloneable 
    @Override
    public VCloudTemplateOptions nodeNames(Iterable<String> nodeNames) {
       return VCloudTemplateOptions.class.cast(super.nodeNames(nodeNames));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudTemplateOptions networks(Iterable<String> networks) {
+      return VCloudTemplateOptions.class.cast(super.networks(networks));
    }
 
 }

--- a/compute/src/main/java/org/jclouds/compute/options/TemplateOptions.java
+++ b/compute/src/main/java/org/jclouds/compute/options/TemplateOptions.java
@@ -98,6 +98,8 @@ public class TemplateOptions extends RunScriptOptions implements Cloneable {
          to.overrideAuthenticateSudo(this.shouldAuthenticateSudo());
       if (this.getTaskName() != null)
          to.nameTask(this.getTaskName());
+      if (!this.getNetworks().isEmpty())
+         to.networks(this.getNetworks());
    }
 
    public static class ImmutableTemplateOptions extends TemplateOptions {
@@ -324,6 +326,16 @@ public class TemplateOptions extends RunScriptOptions implements Cloneable {
       }
 
       @Override
+      public TemplateOptions networks(Iterable<String> networks) {
+         throw new IllegalArgumentException("networks are immutable");
+      }
+
+      @Override
+      public TemplateOptions networks(String... networks) {
+         throw new IllegalArgumentException("networks are immutable");
+      }
+
+      @Override
       public TemplateOptions userMetadata(Map<String, String> userMetadata) {
          throw new IllegalArgumentException("userMetadata is immutable");
       }
@@ -362,6 +374,8 @@ public class TemplateOptions extends RunScriptOptions implements Cloneable {
 
    protected Set<String> nodeNames = ImmutableSet.of();
 
+   protected Set<String> networks = ImmutableSet.of();
+
    public boolean equals(Object o) {
       if (this == o)
          return true;
@@ -372,13 +386,13 @@ public class TemplateOptions extends RunScriptOptions implements Cloneable {
               && equal(this.publicKey, that.publicKey) && equal(this.privateKey, that.privateKey)
               && equal(this.blockUntilRunning, that.blockUntilRunning) && equal(this.tags, that.tags)
               && equal(this.securityGroups, that.securityGroups) && equal(this.userMetadata, that.userMetadata)
-              && equal(this.nodeNames, that.nodeNames);
+              && equal(this.nodeNames, that.nodeNames) && equal(this.networks, that.networks);
    }
 
    @Override
    public int hashCode() {
       return Objects.hashCode(super.hashCode(), inboundPorts, script, publicKey, privateKey, blockUntilRunning, tags,
-                              securityGroups, userMetadata, nodeNames);
+                              securityGroups, userMetadata, nodeNames, networks);
    }
 
    @Override
@@ -402,6 +416,8 @@ public class TemplateOptions extends RunScriptOptions implements Cloneable {
          toString.add("securityGroups", securityGroups);
       if (userMetadata.size() != 0)
          toString.add("userMetadata", userMetadata);
+      if (!networks.isEmpty())
+         toString.add("networks", networks);
       return toString;
    }
 
@@ -431,6 +447,10 @@ public class TemplateOptions extends RunScriptOptions implements Cloneable {
 
    public String getPublicKey() {
       return publicKey;
+   }
+
+   public Set<String> getNetworks() {
+      return networks;
    }
 
    /**
@@ -521,6 +541,21 @@ public class TemplateOptions extends RunScriptOptions implements Cloneable {
     */
    public TemplateOptions securityGroups(String... securityGroups) {
       return securityGroups(ImmutableSet.copyOf(securityGroups));
+   }
+
+   /**
+    * Assigns the created nodes to these networks
+    */
+   public TemplateOptions networks(Iterable<String> networks) {
+      this.networks = ImmutableSet.copyOf(checkNotNull(networks, "networks"));
+      return this;
+   }
+
+   /**
+    * @see TemplateOptions#networks(Iterable)
+    */
+   public TemplateOptions networks(String... networks) {
+      return networks(ImmutableSet.copyOf(networks));
    }
 
    /**
@@ -616,6 +651,22 @@ public class TemplateOptions extends RunScriptOptions implements Cloneable {
       public static TemplateOptions securityGroups(String... securityGroups) {
          TemplateOptions options = new TemplateOptions();
          return options.securityGroups(securityGroups);
+      }
+
+      /**
+       * @see TemplateOptions#networks
+       */
+      public static TemplateOptions networks(Iterable<String> networks) {
+         TemplateOptions options = new TemplateOptions();
+         return options.networks(networks);
+      }
+
+      /**
+       * @see TemplateOptions#networks
+       */
+      public static TemplateOptions networks(String... networks) {
+         TemplateOptions options = new TemplateOptions();
+         return options.networks(networks);
       }
 
       /**

--- a/compute/src/test/java/org/jclouds/compute/options/TemplateOptionsTest.java
+++ b/compute/src/test/java/org/jclouds/compute/options/TemplateOptionsTest.java
@@ -16,21 +16,15 @@
  */
 package org.jclouds.compute.options;
 
-import static org.jclouds.compute.options.TemplateOptions.Builder.authorizePublicKey;
-import static org.jclouds.compute.options.TemplateOptions.Builder.blockOnPort;
-import static org.jclouds.compute.options.TemplateOptions.Builder.blockUntilRunning;
-import static org.jclouds.compute.options.TemplateOptions.Builder.inboundPorts;
-import static org.jclouds.compute.options.TemplateOptions.Builder.installPrivateKey;
-import static org.jclouds.compute.options.TemplateOptions.Builder.nodeNames;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.util.Set;
 
-import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableSet;
+import static org.jclouds.compute.options.TemplateOptions.Builder.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Tests possible uses of TemplateOptions and TemplateOptions.Builder.*
@@ -195,5 +189,12 @@ public class TemplateOptionsTest {
       Set<String> nodeNames = ImmutableSet.of("first-node", "second-node");
       TemplateOptions options = nodeNames(nodeNames);
       assertTrue(options.getNodeNames().containsAll(nodeNames));
+   }
+
+   @Test
+   public void testNetworks() {
+      Set<String> networks = ImmutableSet.of("first-network", "second-network");
+      TemplateOptions options = networks(networks);
+      assertTrue(options.getNetworks().containsAll(networks));
    }
 }

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/AWSEC2TemplateOptions.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/AWSEC2TemplateOptions.java
@@ -488,6 +488,14 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
          AWSEC2TemplateOptions options = new AWSEC2TemplateOptions();
          return AWSEC2TemplateOptions.class.cast(options.nodeNames(nodeNames));
       }
+
+      /**
+       * @see TemplateOptions#networks(Iterable)
+       */
+      public static AWSEC2TemplateOptions networks(Iterable<String> networks) {
+         AWSEC2TemplateOptions options = new AWSEC2TemplateOptions();
+         return AWSEC2TemplateOptions.class.cast(options.networks(networks));
+      }
    }
 
    // methods that only facilitate returning the correct object type
@@ -522,6 +530,14 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
    @Override
    public AWSEC2TemplateOptions nodeNames(Iterable<String> nodeNames) {
       return AWSEC2TemplateOptions.class.cast(super.nodeNames(nodeNames));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public AWSEC2TemplateOptions networks(Iterable<String> networks) {
+      return AWSEC2TemplateOptions.class.cast(super.networks(networks));
    }
 
    /**

--- a/providers/glesys/src/main/java/org/jclouds/glesys/compute/options/GleSYSTemplateOptions.java
+++ b/providers/glesys/src/main/java/org/jclouds/glesys/compute/options/GleSYSTemplateOptions.java
@@ -216,6 +216,14 @@ public class GleSYSTemplateOptions extends TemplateOptions implements Cloneable 
          GleSYSTemplateOptions options = new GleSYSTemplateOptions();
          return GleSYSTemplateOptions.class.cast(options.nodeNames(nodeNames));
       }
+
+      /**
+       * @see TemplateOptions#networks(Iterable)
+       */
+      public static GleSYSTemplateOptions networks(Iterable<String> networks) {
+         GleSYSTemplateOptions options = new GleSYSTemplateOptions();
+         return GleSYSTemplateOptions.class.cast(options.networks(networks));
+      }
    }
 
    // methods that only facilitate returning the correct object type
@@ -274,6 +282,14 @@ public class GleSYSTemplateOptions extends TemplateOptions implements Cloneable 
    @Override
    public GleSYSTemplateOptions nodeNames(Iterable<String> nodeNames) {
       return GleSYSTemplateOptions.class.cast(super.nodeNames(nodeNames));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public GleSYSTemplateOptions networks(Iterable<String> networks) {
+      return GleSYSTemplateOptions.class.cast(super.networks(networks));
    }
 
    @Override

--- a/providers/gogrid/src/main/java/org/jclouds/gogrid/compute/options/GoGridTemplateOptions.java
+++ b/providers/gogrid/src/main/java/org/jclouds/gogrid/compute/options/GoGridTemplateOptions.java
@@ -105,6 +105,14 @@ public class GoGridTemplateOptions extends TemplateOptions implements Cloneable 
          GoGridTemplateOptions options = new GoGridTemplateOptions();
          return GoGridTemplateOptions.class.cast(options.nodeNames(nodeNames));
       }
+
+      /**
+       * @see TemplateOptions#networks(Iterable)
+       */
+      public static GoGridTemplateOptions networks(Iterable<String> networks) {
+         GoGridTemplateOptions options = new GoGridTemplateOptions();
+         return GoGridTemplateOptions.class.cast(options.networks(networks));
+      }
    }
 
    // methods that only facilitate returning the correct object type
@@ -163,5 +171,13 @@ public class GoGridTemplateOptions extends TemplateOptions implements Cloneable 
    @Override
    public GoGridTemplateOptions nodeNames(Iterable<String> nodeNames) {
       return GoGridTemplateOptions.class.cast(super.nodeNames(nodeNames));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public GoGridTemplateOptions networks(Iterable<String> networks) {
+      return GoGridTemplateOptions.class.cast(super.networks(networks));
    }
 }

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/compute/options/SoftLayerTemplateOptions.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/compute/options/SoftLayerTemplateOptions.java
@@ -138,6 +138,14 @@ public class SoftLayerTemplateOptions extends TemplateOptions implements Cloneab
          SoftLayerTemplateOptions options = new SoftLayerTemplateOptions();
          return SoftLayerTemplateOptions.class.cast(options.nodeNames(nodeNames));
       }
+
+      /**
+       * @see TemplateOptions#networks(Iterable)
+       */
+      public static SoftLayerTemplateOptions networks(Iterable<String> networks) {
+         SoftLayerTemplateOptions options = new SoftLayerTemplateOptions();
+         return SoftLayerTemplateOptions.class.cast(options.networks(networks));
+      }
    }
 
    // methods that only facilitate returning the correct object type
@@ -196,5 +204,13 @@ public class SoftLayerTemplateOptions extends TemplateOptions implements Cloneab
    @Override
    public SoftLayerTemplateOptions nodeNames(Iterable<String> nodeNames) {
       return SoftLayerTemplateOptions.class.cast(super.nodeNames(nodeNames));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public SoftLayerTemplateOptions networks(Iterable<String> networks) {
+      return SoftLayerTemplateOptions.class.cast(super.networks(networks));
    }
 }


### PR DESCRIPTION
- Adds networks field/methods to TemplateOptions.
- Adds them to children as well for legacy reasons.
- Deprecates CloudStackTemplateOptions#networkIds methods in favor of #networks.
- TODO: Modify compute abstraction layer for provisioning for nova,
  EC2, et al to take advantage of this.
