### PR TITLE
Adding bcpkix to the jclouds-sshj driver. Required by sshj.

### DIFF
--- a/drivers/sshj/pom.xml
+++ b/drivers/sshj/pom.xml
@@ -91,6 +91,19 @@
       <artifactId>sshj</artifactId>
       <version>0.8.1</version>
     </dependency>
+    <!-- required by sshj -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.49</version>
+      <exclusions>
+        <!-- provided by the jclouds-bouncycastle driver -->
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
See [JCLOUDS-452](https://issues.apache.org/jira/browse/JCLOUDS-452).

@andreaturli: Turns out sshj 0.9.0 [breaks stuff](https://issues.apache.org/jira/browse/JCLOUDS-451), so now tryng the solution you [originally suggested](https://github.com/jclouds/jclouds/pull/273#issuecomment-33805542) ;-)
