### PR TITLE
Adding bcpkix to the jclouds-sshj driver. Required by sshj. (1.6.x backport)

### DIFF
--- a/drivers/sshj/pom.xml
+++ b/drivers/sshj/pom.xml
@@ -91,6 +91,19 @@
       <artifactId>sshj</artifactId>
       <version>0.8.1</version>
     </dependency>
+    <!-- required by sshj -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.49</version>
+      <exclusions>
+        <!-- provided by the jclouds-bouncycastle driver -->
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
Thanks to Andrea Turli and Ignasi Barrera for research and testing!
