### PR TITLE
Enable connecting to Rackspace Swift with Swift module through OpenStack Keystone 

### DIFF
--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/AuthenticationApi.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/AuthenticationApi.java
@@ -27,6 +27,7 @@ import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.openstack.keystone.v2_0.binders.BindAuthToJsonPayload;
 import org.jclouds.openstack.keystone.v2_0.domain.Access;
 import org.jclouds.openstack.keystone.v2_0.domain.ApiAccessKeyCredentials;
+import org.jclouds.openstack.keystone.v2_0.domain.ApiKeyCredentials;
 import org.jclouds.openstack.keystone.v2_0.domain.PasswordCredentials;
 import org.jclouds.rest.annotations.MapBinder;
 import org.jclouds.rest.annotations.PayloadParam;
@@ -100,4 +101,32 @@ public interface AuthenticationApi extends Closeable {
    @MapBinder(BindAuthToJsonPayload.class)
    Access authenticateWithTenantIdAndCredentials(@Nullable @PayloadParam("tenantId") String tenantId,
          ApiAccessKeyCredentials apiAccessKeyCredentials);
+
+   /**
+    * Authenticate to generate a token.
+    * 
+    * @return access with token
+    */
+   @Named("authenticate")
+   @POST
+   @SelectJson("access")
+   @Consumes(MediaType.APPLICATION_JSON)
+   @Path("/tokens")
+   @MapBinder(BindAuthToJsonPayload.class)
+   Access authenticateWithTenantNameAndCredentials(@Nullable @PayloadParam("tenantName") String tenantName,
+         ApiKeyCredentials apiKeyCredentials);
+
+   /**
+    * Authenticate to generate a token.
+    * 
+    * @return access with token
+    */
+   @Named("authenticate")
+   @POST
+   @SelectJson("access")
+   @Consumes(MediaType.APPLICATION_JSON)
+   @Path("/tokens")
+   @MapBinder(BindAuthToJsonPayload.class)
+   Access authenticateWithTenantIdAndCredentials(@Nullable @PayloadParam("tenantId") String tenantId,
+         ApiKeyCredentials apiKeyCredentials);
 }

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/AuthenticationAsyncApi.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/AuthenticationAsyncApi.java
@@ -27,6 +27,7 @@ import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.openstack.keystone.v2_0.binders.BindAuthToJsonPayload;
 import org.jclouds.openstack.keystone.v2_0.domain.Access;
 import org.jclouds.openstack.keystone.v2_0.domain.ApiAccessKeyCredentials;
+import org.jclouds.openstack.keystone.v2_0.domain.ApiKeyCredentials;
 import org.jclouds.openstack.keystone.v2_0.domain.PasswordCredentials;
 import org.jclouds.rest.annotations.MapBinder;
 import org.jclouds.rest.annotations.PayloadParam;
@@ -91,4 +92,27 @@ public interface AuthenticationAsyncApi extends Closeable {
    @MapBinder(BindAuthToJsonPayload.class)
    ListenableFuture<Access> authenticateWithTenantIdAndCredentials(@Nullable @PayloadParam("tenantId") String tenantId,
             ApiAccessKeyCredentials apiAccessKeyCredentials);
+   
+
+   /**
+    * @see AuthenticationApi#authenticateWithTenantNameAndCredentials(String,ApiKeyCredentials)
+    */
+   @POST
+   @SelectJson("access")
+   @Consumes(MediaType.APPLICATION_JSON)
+   @Path("/tokens")
+   @MapBinder(BindAuthToJsonPayload.class)
+   ListenableFuture<Access> authenticateWithTenantNameAndCredentials(@Nullable @PayloadParam("tenantName") String tenantName,
+            ApiKeyCredentials apiKeyCredentials);
+   
+   /**
+    * @see AuthenticationApi#authenticateWithTenantIdAndCredentials(String,ApiKeyCredentials)
+    */
+   @POST
+   @SelectJson("access")
+   @Consumes(MediaType.APPLICATION_JSON)
+   @Path("/tokens")
+   @MapBinder(BindAuthToJsonPayload.class)
+   ListenableFuture<Access> authenticateWithTenantIdAndCredentials(@Nullable @PayloadParam("tenantId") String tenantId,
+            ApiKeyCredentials apiKeyCredentials);
 }

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/CredentialTypes.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/CredentialTypes.java
@@ -30,25 +30,29 @@ import com.google.common.collect.Maps;
  */
 public class CredentialTypes {
 
-   public static final String API_ACCESS_KEY_CREDENTIALS = "apiAccessKeyCredentials";
+	public static final String API_ACCESS_KEY_CREDENTIALS = "apiAccessKeyCredentials";
 
-   public static final String PASSWORD_CREDENTIALS = "passwordCredentials";
+	public static final String API_KEY_CREDENTIALS = "RAX-KSKEY:apiKeyCredentials";
 
-   public static <T> String credentialTypeOf(T input) {
-      Class<?> authenticationType = input.getClass();
-      checkArgument(authenticationType.isAnnotationPresent(CredentialType.class),
-               "programming error: %s should have annotation %s", authenticationType, CredentialType.class.getName());
-      return authenticationType.getAnnotation(CredentialType.class).value();
-   }
+	public static final String PASSWORD_CREDENTIALS = "passwordCredentials";
 
-   public static <T> Map<String, T> indexByCredentialType(Iterable<T> iterable) {
-      return Maps.uniqueIndex(iterable, new Function<T, String>() {
+	public static <T> String credentialTypeOf(T input) {
+		Class<?> authenticationType = input.getClass();
+		checkArgument(
+				authenticationType.isAnnotationPresent(CredentialType.class),
+				"programming error: %s should have annotation %s",
+				authenticationType, CredentialType.class.getName());
+		return authenticationType.getAnnotation(CredentialType.class).value();
+	}
 
-         @Override
-         public String apply(T input) {
-            return credentialTypeOf(input);
-         }
+	public static <T> Map<String, T> indexByCredentialType(Iterable<T> iterable) {
+		return Maps.uniqueIndex(iterable, new Function<T, String>() {
 
-      });
-   }
+			@Override
+			public String apply(T input) {
+				return credentialTypeOf(input);
+			}
+
+		});
+	}
 }

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneAuthenticationModule.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneAuthenticationModule.java
@@ -47,6 +47,7 @@ import org.jclouds.location.suppliers.implicit.FirstZone;
 import org.jclouds.openstack.keystone.v2_0.domain.Access;
 import org.jclouds.openstack.keystone.v2_0.domain.Endpoint;
 import org.jclouds.openstack.keystone.v2_0.functions.AuthenticateApiAccessKeyCredentials;
+import org.jclouds.openstack.keystone.v2_0.functions.AuthenticateApiKeyCredentials;
 import org.jclouds.openstack.keystone.v2_0.functions.AuthenticatePasswordCredentials;
 import org.jclouds.openstack.keystone.v2_0.handlers.RetryOnRenew;
 import org.jclouds.openstack.keystone.v2_0.suppliers.LocationIdToURIFromAccessForTypeAndVersion;
@@ -201,6 +202,7 @@ public class KeystoneAuthenticationModule extends AbstractModule {
       Builder<Function<Credentials, Access>> fns = ImmutableSet.<Function<Credentials, Access>> builder();
       fns.add(i.getInstance(AuthenticatePasswordCredentials.class));
       fns.add(i.getInstance(AuthenticateApiAccessKeyCredentials.class));
+      fns.add(i.getInstance(AuthenticateApiKeyCredentials.class));
       return CredentialTypes.indexByCredentialType(fns.build());
    }
 

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/domain/ApiKeyCredentials.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/domain/ApiKeyCredentials.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.keystone.v2_0.domain;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.beans.ConstructorProperties;
+
+import org.jclouds.openstack.keystone.v2_0.config.CredentialType;
+import org.jclouds.openstack.keystone.v2_0.config.CredentialTypes;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Objects.ToStringHelper;
+
+/**
+ * Api Key Credentials
+ *
+ * @see <a href="http://docs.openstack.org/api/openstack-identity-service/2.0/content/POST_authenticate_v2.0_tokens_Service_API_Api_Operations.html#d662e583"
+/>
+ * @author Adrian Cole
+ */
+@CredentialType(CredentialTypes.API_KEY_CREDENTIALS)
+public class ApiKeyCredentials {
+
+	   public static Builder<?> builder() {
+	      return new ConcreteBuilder();
+	   }
+
+	   public Builder<?> toBuilder() {
+	      return new ConcreteBuilder().fromApiKeyCredentials(this);
+	   }
+
+	   public static ApiKeyCredentials createWithUsernameAndApiKey(String username, String apiKey) {
+	      return new ApiKeyCredentials(username, apiKey);
+	   }
+
+	   public abstract static class Builder<T extends Builder<T>>  {
+	      protected abstract T self();
+
+	      protected String username;
+	      protected String apiKey;
+
+	      /**
+	       * @see ApiKeyCredentials#getUsername()
+	       */
+	      public T username(String username) {
+	         this.username = username;
+	         return self();
+	      }
+
+	      /**
+	       * @see ApiKeyCredentials#getApiKey()
+	       */
+	      public T apiKey(String apiKey) {
+	         this.apiKey = apiKey;
+	         return self();
+	      }
+
+	      public ApiKeyCredentials build() {
+	         return new ApiKeyCredentials(username, apiKey);
+	      }
+
+	      public T fromApiKeyCredentials(ApiKeyCredentials in) {
+	         return this
+	               .username(in.getUsername())
+	               .apiKey(in.getApiKey());
+	      }
+	   }
+
+	   private static class ConcreteBuilder extends Builder<ConcreteBuilder> {
+	      @Override
+	      protected ConcreteBuilder self() {
+	         return this;
+	      }
+	   }
+
+	   private final String username;
+	   private final String apiKey;
+
+	   @ConstructorProperties({
+	         "username", "apiKey"
+	   })
+	   protected ApiKeyCredentials(String username, String apiKey) {
+	      this.username = checkNotNull(username, "username");
+	      this.apiKey = checkNotNull(apiKey, "apiKey");
+	   }
+
+	   /**
+	    * @return the username
+	    */
+	   public String getUsername() {
+	      return this.username;
+	   }
+
+	   /**
+	    * @return the apiKey
+	    */
+	   public String getApiKey() {
+	      return this.apiKey;
+	   }
+
+	   @Override
+	   public int hashCode() {
+	      return Objects.hashCode(username, apiKey);
+	   }
+
+	   @Override
+	   public boolean equals(Object obj) {
+	      if (this == obj) return true;
+	      if (obj == null || getClass() != obj.getClass()) return false;
+	      ApiKeyCredentials that = ApiKeyCredentials.class.cast(obj);
+	      return Objects.equal(this.username, that.username)
+	            && Objects.equal(this.apiKey, that.apiKey);
+	   }
+
+	   protected ToStringHelper string() {
+	      return Objects.toStringHelper(this)
+	            .add("username", username).add("apiKey", apiKey);
+	   }
+
+	   @Override
+	   public String toString() {
+	      return string().toString();
+	   }
+
+
+}

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/functions/AuthenticateApiKeyCredentials.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/functions/AuthenticateApiKeyCredentials.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.keystone.v2_0.functions;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jclouds.openstack.keystone.v2_0.AuthenticationApi;
+import org.jclouds.openstack.keystone.v2_0.config.CredentialType;
+import org.jclouds.openstack.keystone.v2_0.config.CredentialTypes;
+import org.jclouds.openstack.keystone.v2_0.domain.Access;
+import org.jclouds.openstack.keystone.v2_0.domain.ApiAccessKeyCredentials;
+import org.jclouds.openstack.keystone.v2_0.domain.ApiKeyCredentials;
+import org.jclouds.openstack.keystone.v2_0.functions.internal.BaseAuthenticator;
+
+import com.google.common.base.Optional;
+
+@CredentialType(CredentialTypes.API_KEY_CREDENTIALS)
+@Singleton
+public class AuthenticateApiKeyCredentials extends BaseAuthenticator<ApiKeyCredentials> {
+	   protected final AuthenticationApi api;
+
+	   @Inject
+	   public AuthenticateApiKeyCredentials(AuthenticationApi api) {
+	      this.api = api;
+	   }
+
+	   @Override
+	   protected Access authenticateWithTenantName(Optional<String> tenantId, ApiKeyCredentials apiKeyCredentials) {
+	      return api.authenticateWithTenantNameAndCredentials(tenantId.orNull(), apiKeyCredentials);
+	   }
+
+	   @Override
+	   protected Access authenticateWithTenantId(Optional<String> tenantId, ApiKeyCredentials apiKeyCredentials) {
+	      return api.authenticateWithTenantIdAndCredentials(tenantId.orNull(), apiKeyCredentials);
+	   }
+
+	   @Override
+	   public ApiKeyCredentials createCredentials(String identity, String credential) {
+	      return ApiKeyCredentials.createWithUsernameAndApiKey(identity, credential);
+	   }
+
+	   @Override
+	   public String toString() {
+	      return "authenticateApiKeyCredentials()";
+	   }
+	}


### PR DESCRIPTION
This adds the ability to connect to Rackspace keystone using OpenStack keystone module, thus enabling a general region support for Rackspace Swift for example.  
