### PR TITLE
Fix Keystone response for testing to not include Glance version

### DIFF
--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/parse/ParseAccessTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/parse/ParseAccessTest.java
@@ -84,7 +84,7 @@ public class ParseAccessTest extends BaseItemParserTest<Access> {
             .service(Service.builder().name("Image Management").type(IMAGE)
                   .endpoint(Endpoint.builder()
                         .tenantId("40806637803162")
-                        .publicURL("https://glance.jclouds.org:9292/v1.0")
+                        .publicURL("https://glance.jclouds.org:9292/")
                         .region("az-1.region-a.geo-1")
                         .id("1.0").build()).build())
             .service(Service.builder().name("Compute").type(COMPUTE)

--- a/apis/openstack-keystone/src/test/resources/keystoneAuthResponse.json
+++ b/apis/openstack-keystone/src/test/resources/keystoneAuthResponse.json
@@ -71,7 +71,7 @@
                 "endpoints": [
                     {
                         "tenantName": "40806637803162",
-                        "publicURL": "https://glance.jclouds.org:9292/v1.0",
+                        "publicURL": "https://glance.jclouds.org:9292/",
                         "region": "az-1.region-a.geo-1",
                         "id": "1.0"
                     }


### PR DESCRIPTION
This changes the Keystone catalog response used for testing to only include the base Glance endpoint, since clients should be performing version negotiation with Glance.

Please see this ticket: https://issues.apache.org/jira/browse/JCLOUDS-494

As well as this PR: https://github.com/jclouds/jclouds-labs-openstack/pull/82
