### PR TITLE
JCLOUDS-503 - Missing c3.large from AWSEC2HardwareSupplier

### DIFF
--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/suppliers/AWSEC2HardwareSupplier.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/suppliers/AWSEC2HardwareSupplier.java
@@ -22,6 +22,7 @@ import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.c3_2xlarge;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.c3_4xlarge;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.c3_8xlarge;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.c3_xlarge;
+import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.c3_large;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.cc1_4xlarge;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.cc2_8xlarge;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.cg1_4xlarge;
@@ -84,6 +85,7 @@ public class AWSEC2HardwareSupplier extends EC2HardwareSupplier {
       sizes.add(t1_micro().build());
       sizes.add(c1_medium().build());
       sizes.add(c1_xlarge().build());
+      sizes.add(c3_large().build());
       sizes.add(c3_xlarge().build());
       sizes.add(c3_2xlarge().build());
       sizes.add(c3_4xlarge().build());


### PR DESCRIPTION
When a NodeMetadata object represents an instance type c3.large, the hardware id is null. This failure occurs because the AWSEC2HardwareSupplier has no reference to the method org.jclouds.ec2.compute.domain.EC2HardwareBuilder.c3_large.

https://issues.apache.org/jira/browse/JCLOUDS-503
