### PR TITLE
Allow Swift to set content type

### DIFF
--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/blobstore/functions/BlobToObject.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/blobstore/functions/BlobToObject.java
@@ -17,6 +17,7 @@
 package org.jclouds.openstack.swift.blobstore.functions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.openstack.swift.reference.SwiftHeaders.DETECT_CONTENT_TYPE;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -25,6 +26,7 @@ import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.openstack.swift.domain.SwiftObject;
 
 import com.google.common.base.Function;
+import com.google.common.collect.Multimap;
 
 /**
  * @author Adrian Cole
@@ -45,7 +47,14 @@ public class BlobToObject implements Function<Blob, SwiftObject> {
          return null;
       SwiftObject object = objectProvider.create(blob2ObjectMd.apply(from.getMetadata()));
       object.setPayload(checkNotNull(from.getPayload(), "payload: " + from));
-      object.setAllHeaders(from.getAllHeaders());
+
+      Multimap<String, String> headers = from.getAllHeaders();
+      // let Swift determine the content type...
+      if (from.getMetadata().getContentMetadata().getContentType().equals("application/unknown")) {
+         headers.put(DETECT_CONTENT_TYPE, "True");
+      }
+
+      object.setAllHeaders(headers);
       return object;
    }
 }

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/reference/SwiftHeaders.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/reference/SwiftHeaders.java
@@ -33,8 +33,9 @@ public interface SwiftHeaders {
 
    public static final String USER_METADATA_PREFIX = "X-Object-Meta-";
    public static final String OBJECT_COPY_FROM = "X-Copy-From";
-   
+
    public static final String CONTAINER_READ = "X-Container-Read";
    public static final String CONTAINER_WRITE = "X-Container-Write";
 
+   public static final String DETECT_CONTENT_TYPE = "X-Detect-Content-Type";
 }


### PR DESCRIPTION
This PR fixes the case where jclouds is assuming the blob content type to be `application/unknown`. The original discussion can be found [here](http://markmail.org/thread/qdxqrkhnjygjny4k).

If the user does not specify a content type, then the `X-Detect-Conent-Type` header should be added to the request headers to indicate that the server should detect the content type. 

This feature is supported in the Swift 1.9.1 through 1.13.1rc1 [releases](https://bugs.launchpad.net/openstack-api-site/+bug/1274988).

A test case is in the works now and I wanted to get some other eyes on it. DO NOT MERGE.
