### PR TITLE
JCLOUDS-549: Fix NPE in LoginCredentials.toString

### DIFF
--- a/core/src/main/java/org/jclouds/domain/LoginCredentials.java
+++ b/core/src/main/java/org/jclouds/domain/LoginCredentials.java
@@ -207,7 +207,8 @@ public class LoginCredentials extends Credentials {
 
    @Override
    public String toString() {
-      return "[user=" + getUser() + ", passwordPresent=" + password.isPresent() + ", privateKeyPresent="
-            + privateKey.isPresent() + ", shouldAuthenticateSudo=" + authenticateSudo + "]";
+      return "[user=" + getUser() + ", passwordPresent=" + (password != null ? password.isPresent() : false) 
+            + ", privateKeyPresent=" + (privateKey != null ? privateKey.isPresent() : false) 
+            + ", shouldAuthenticateSudo=" + authenticateSudo + "]";
    }
 }

--- a/core/src/test/java/org/jclouds/domain/LoginCredentialsTest.java
+++ b/core/src/test/java/org/jclouds/domain/LoginCredentialsTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.domain;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 import org.testng.annotations.Test;
 
@@ -50,5 +51,15 @@ public class LoginCredentialsTest {
       LoginCredentials toTest = LoginCredentials.builder().user("user").password("password").privateKey("key").build();
       assertEquals(toTest.getOptionalPassword(), Optional.of("password"));
       assertEquals(toTest.getOptionalPrivateKey(), Optional.of("key"));
+   }
+   
+   public void testToStringWhenNullPasswordAndKey() {
+      LoginCredentials toTest = LoginCredentials.builder().user("myuser").build();
+      assertNotNull(toTest.toString());
+   }
+   
+   public void testToString() {
+      LoginCredentials toTest = LoginCredentials.builder().user("myuser").password("password").privateKey("key").build();
+      assertNotNull(toTest.toString());
    }
 }


### PR DESCRIPTION
Was seeing NPE if LoginCredentials was constructed with a null password or null privateKey (rather than `Optional.Absent`).

I briefly toyed with the idea of having the field `password` never being null (i.e. in constructor, set to `Optional.absent` if null is passed in), but that would also change behaviour of the public `getOptionalPassword` (and same for `getOptionalPrivateKey`) which are explicitly marked as `@Nullable`.

Therefore this trivial fix seems best + safest for the 1.7.x branch.
