### PR TITLE
Removes legacy Google MWS dependency

### DIFF
--- a/apis/s3/pom.xml
+++ b/apis/s3/pom.xml
@@ -86,9 +86,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.mockwebserver</groupId>
+      <groupId>com.squareup.okhttp</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <!-- provided by the jclouds-bouncycastle driver -->
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/apis/s3/src/test/java/org/jclouds/s3/S3ClientMockTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/S3ClientMockTest.java
@@ -37,9 +37,9 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
-import com.google.mockwebserver.MockResponse;
-import com.google.mockwebserver.MockWebServer;
-import com.google.mockwebserver.RecordedRequest;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 @Test(singleThreaded = true)
 public class S3ClientMockTest {

--- a/apis/swift/pom.xml
+++ b/apis/swift/pom.xml
@@ -109,7 +109,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.mockwebserver</groupId>
+      <groupId>com.squareup.okhttp</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/blobstore/strategy/internal/SequentialMultipartUploadStrategyMockTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/blobstore/strategy/internal/SequentialMultipartUploadStrategyMockTest.java
@@ -39,10 +39,10 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Atomics;
 import com.google.inject.Module;
-import com.google.mockwebserver.MockResponse;
-import com.google.mockwebserver.MockWebServer;
-import com.google.mockwebserver.QueueDispatcher;
-import com.google.mockwebserver.RecordedRequest;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.QueueDispatcher;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 @Test(singleThreaded = true)
 public class SequentialMultipartUploadStrategyMockTest {

--- a/drivers/sshj/pom.xml
+++ b/drivers/sshj/pom.xml
@@ -91,19 +91,6 @@
       <artifactId>sshj</artifactId>
       <version>0.8.1</version>
     </dependency>
-    <!-- required by sshj -->
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.49</version>
-      <exclusions>
-        <!-- provided by the jclouds-bouncycastle driver -->
-        <exclusion>
-          <groupId>org.bouncycastle</groupId>
-          <artifactId>bcprov-jdk15on</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch.agentproxy.sshj</artifactId>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -84,7 +84,7 @@
     <url>https://git-wip-us.apache.org/repos/asf?p=jclouds.git</url>
     <tag>HEAD</tag>
   </scm>
-  
+
   <repositories>
     <repository>
       <id>apache-snapshots</id>
@@ -278,11 +278,6 @@
         <artifactId>logback-core</artifactId>
         <version>1.0.9</version>
       </dependency>
-      <dependency>
-        <groupId>com.google.mockwebserver</groupId>
-        <artifactId>mockwebserver</artifactId>
-        <version>20121111</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -346,7 +341,7 @@
           <arguments>-Pdoc -Papache-release ${arguments}</arguments>
         </configuration>
       </plugin>
-      
+
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
@@ -367,7 +362,7 @@
             <exclude>**/src/test/resources/**/*.txt</exclude>
             <exclude>**/src/test/resources/**/*.gz</exclude>
             <exclude>**/src/test/resources/**/*.xml</exclude>
-            
+
             <!-- META-INF/services files -->
             <exclude>**/services/*LoggingModule</exclude>
             <exclude>**/services/*ApiMetadata</exclude>
@@ -932,7 +927,7 @@
                 <configuration>
                   <descriptors>
                     <descriptor>src-descriptor.xml</descriptor>
-                    <descriptor>provided-dependencies-descriptor.xml</descriptor>                                        
+                    <descriptor>provided-dependencies-descriptor.xml</descriptor>
                     <descriptor>jar-with-dependencies-no-core-no-apis-descriptor.xml</descriptor>
                   </descriptors>
                 </configuration>
@@ -948,7 +943,7 @@
           </plugin>
         </plugins>
       </build>
-    </profile>        
+    </profile>
     <profile>
       <id>site</id>
       <build>
@@ -1033,7 +1028,7 @@
               <configLocation>resources/checkstyle.xml</configLocation>
             </configuration>
           </plugin>
-        </plugins>            
+        </plugins>
       </build>
     </profile>
     <profile>

--- a/providers/aws-s3/pom.xml
+++ b/providers/aws-s3/pom.xml
@@ -112,9 +112,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.mockwebserver</groupId>
+      <groupId>com.squareup.okhttp</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <!-- provided by the jclouds-bouncycastle driver -->
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/providers/aws-s3/src/test/java/org/jclouds/aws/s3/blobstore/strategy/internal/SequentialMultipartUploadStrategyMockTest.java
+++ b/providers/aws-s3/src/test/java/org/jclouds/aws/s3/blobstore/strategy/internal/SequentialMultipartUploadStrategyMockTest.java
@@ -37,9 +37,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
 import com.google.inject.Module;
-import com.google.mockwebserver.MockResponse;
-import com.google.mockwebserver.MockWebServer;
-import com.google.mockwebserver.RecordedRequest;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 @Test(singleThreaded = true)
 public class SequentialMultipartUploadStrategyMockTest {

--- a/providers/dynect/pom.xml
+++ b/providers/dynect/pom.xml
@@ -60,11 +60,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.mockwebserver</groupId>
-      <artifactId>mockwebserver</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.jclouds.driver</groupId>
       <artifactId>jclouds-slf4j</artifactId>
       <version>${project.version}</version>
@@ -75,8 +70,13 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
-  
+
   <profiles>
     <profile>
       <id>live</id>

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/DynectApiMockTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/DynectApiMockTest.java
@@ -32,11 +32,12 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
-import com.google.mockwebserver.MockResponse;
-import com.google.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+
 @Test(singleThreaded = true)
 public class DynectApiMockTest {
-   
+
    private static final Set<Module> modules = ImmutableSet.<Module> of(
          new ExecutorServiceModule(sameThreadExecutor(), sameThreadExecutor()));
 

--- a/providers/hpcloud-objectstorage/pom.xml
+++ b/providers/hpcloud-objectstorage/pom.xml
@@ -91,7 +91,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.mockwebserver</groupId>
+      <groupId>com.squareup.okhttp</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>

--- a/providers/hpcloud-objectstorage/src/test/java/org/jclouds/hpcloud/objectstorage/HPCloudObjectStorageApiMockTest.java
+++ b/providers/hpcloud-objectstorage/src/test/java/org/jclouds/hpcloud/objectstorage/HPCloudObjectStorageApiMockTest.java
@@ -22,9 +22,9 @@ import org.jclouds.hpcloud.objectstorage.internal.BaseHPCloudObjectStorageMockTe
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.mockwebserver.MockResponse;
-import com.google.mockwebserver.MockWebServer;
-import com.google.mockwebserver.RecordedRequest;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 @Test
 public class HPCloudObjectStorageApiMockTest extends BaseHPCloudObjectStorageMockTest {

--- a/providers/hpcloud-objectstorage/src/test/java/org/jclouds/hpcloud/objectstorage/internal/BaseHPCloudObjectStorageMockTest.java
+++ b/providers/hpcloud-objectstorage/src/test/java/org/jclouds/hpcloud/objectstorage/internal/BaseHPCloudObjectStorageMockTest.java
@@ -31,10 +31,10 @@ import org.jclouds.hpcloud.objectstorage.HPCloudObjectStorageApi;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
-import com.google.mockwebserver.MockResponse;
-import com.google.mockwebserver.MockWebServer;
-import com.google.mockwebserver.QueueDispatcher;
-import com.google.mockwebserver.RecordedRequest;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.QueueDispatcher;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 public class BaseHPCloudObjectStorageMockTest {
 


### PR DESCRIPTION
This PR replaces dependencies on `com.google.mockwebserver` with the okhttp  `com.squareup.mockwebserver` dependency. Relevant pom group ids and tests have been updated.
