### PR TITLE
JCLOUDS-642: InternalUrl fallback

### DIFF
--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/functions/InternalURL.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/functions/InternalURL.java
@@ -26,14 +26,14 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 
 /**
- * Select internal URL endpoints services
- * 
+ * Select internal URL endpoints services. If the {@code internalURL} is not present
+ * in the service catalog, this class will fallback to use the {@code publicURL}.
  */
 @Singleton
 public class InternalURL implements EndpointToSupplierURI {
    @Override
    public Supplier<URI> apply(Endpoint input) {
-      return Suppliers.ofInstance(input.getInternalURL());
+      return Suppliers.ofInstance(input.getInternalURL() != null ? input.getInternalURL() : input.getPublicURL());
    }
 
    @Override

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/functions/InternalURLTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/functions/InternalURLTest.java
@@ -23,17 +23,37 @@ import java.net.URI;
 import org.jclouds.openstack.keystone.v2_0.domain.Endpoint;
 import org.testng.annotations.Test;
 
-/**
- */
 @Test(groups = "unit", testName = "InternalURLTest")
 public class InternalURLTest {
    private final InternalURL fn = new InternalURL();
 
-   public void testInternalURL() {
+   public void testInternalURLExists() {
       assertEquals(
-            fn.apply(
-                  Endpoint.builder().region("regionOne").versionId("2.0")
-                        .internalURL(URI.create("https://ericsson.com/v2/1900e98b-7272-4cbd-8e95-0b8c2a9266c0"))
-                        .build()).get(), URI.create("https://ericsson.com/v2/1900e98b-7272-4cbd-8e95-0b8c2a9266c0"));
+            fn.apply(Endpoint.builder().region("regionOne").versionId("2.0")
+               .internalURL(URI.create("https://internal.ericsson.com/v2/1900e98b-7272-4cbd-8e95-0b8c2a9266c0"))
+                  .build()).get(),
+            URI.create("https://internal.ericsson.com/v2/1900e98b-7272-4cbd-8e95-0b8c2a9266c0"));
    }
+
+   public void testInternalURLAbsent() {
+      assertEquals(
+            fn.apply(Endpoint.builder().region("regionOne").versionId("2.0")
+               .publicURL(URI.create("https://ericsson.com/v2/1900e98b-7272-4cbd-8e95-0b8c2a9266c0"))
+                  .build()).get(),
+            URI.create("https://ericsson.com/v2/1900e98b-7272-4cbd-8e95-0b8c2a9266c0"));
+   }
+
+   /**
+    * If the {@code internalURL} is absent, then {@link InternalURL} will fallback to
+    * use the {@code publicURL}
+    */
+   public void testInternalURLAbsentAndFallbackToPublicURL() {
+      assertEquals(
+            fn.apply(Endpoint.builder().region("regionOne").versionId("2.0")
+               .publicURL(URI.create("https://ericsson.com/v2/1900e98b-7272-4cbd-8e95-0b8c2a9266c0"))
+               .adminURL(URI.create("https://admin.ericsson.com/v2/1900e98b-7272-4cbd-8e95-0b8c2a9266c0"))
+                  .build()).get(),
+            URI.create("https://ericsson.com/v2/1900e98b-7272-4cbd-8e95-0b8c2a9266c0"));
+   }
+
 }


### PR DESCRIPTION
This PR provides the necessary changes for [JCLOUDS-642](https://issues.apache.org/jira/browse/JCLOUDS-642). `InternalURL` should fallback to use `publicUrl` if the `internalUrl` is not present for the endpoint.
 
This is a WIP pending testing and could use feedback on the changes in the meantime. DO NOT MERGE! Thx!