### PR TITLE
JCLOUDS-670 Option force no password when launching images on providers

### DIFF
--- a/compute/src/main/java/org/jclouds/compute/strategy/PrioritizeCredentialsFromTemplate.java
+++ b/compute/src/main/java/org/jclouds/compute/strategy/PrioritizeCredentialsFromTemplate.java
@@ -45,9 +45,15 @@ public class PrioritizeCredentialsFromTemplate {
          if (credsFromParameters.getUser() != null)
             builder.user(credsFromParameters.getUser());
          if (credsFromParameters.getOptionalPassword().isPresent())
-            builder.password(credsFromParameters.getOptionalPassword().get());
+            if (credsFromParameters.getOptionalPassword().get().isEmpty())
+               builder.noPassword();
+            else
+               builder.password(credsFromParameters.getOptionalPassword().get());
          if (credsFromParameters.getOptionalPrivateKey().isPresent())
-            builder.privateKey(credsFromParameters.getOptionalPrivateKey().get());
+            if (credsFromParameters.getOptionalPassword().get().isEmpty())
+               builder.noPassword();
+            else
+               builder.privateKey(credsFromParameters.getOptionalPrivateKey().get());
          if (credsFromParameters.shouldAuthenticateSudo())
             builder.authenticateSudo(true);
          creds = builder.build();

--- a/compute/src/main/java/org/jclouds/compute/strategy/PrioritizeCredentialsFromTemplate.java
+++ b/compute/src/main/java/org/jclouds/compute/strategy/PrioritizeCredentialsFromTemplate.java
@@ -50,8 +50,8 @@ public class PrioritizeCredentialsFromTemplate {
             else
                builder.password(credsFromParameters.getOptionalPassword().get());
          if (credsFromParameters.getOptionalPrivateKey().isPresent())
-            if (credsFromParameters.getOptionalPassword().get().isEmpty())
-               builder.noPassword();
+            if (credsFromParameters.getOptionalPrivateKey().get().isEmpty())
+               builder.noPrivateKey();
             else
                builder.privateKey(credsFromParameters.getOptionalPrivateKey().get());
          if (credsFromParameters.shouldAuthenticateSudo())


### PR DESCRIPTION
Adds the option to override whatever password is given from the provider for the image.

See [jira](https://issues.apache.org/jira/browse/JCLOUDS-670)