### PR TITLE
JCLOUDS-686: Remove changesSince() query from base PaginationOptions

### DIFF
--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/v2_0/domain/PaginatedCollection.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/v2_0/domain/PaginatedCollection.java
@@ -30,9 +30,6 @@ import static org.jclouds.http.utils.Queries.queryParser;
 /**
  * Base class for a paginated collection in OpenStack.
  *
- * @see <a
- *      href="http://docs.openstack.org/api/openstack-identity-service/2.0/content/Paginated_Collections-d1e325.html">
- *      docs</a>
  */
 public class PaginatedCollection<T> extends IterableWithMarker<T> {
    private final Iterable<T> resources;

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/v2_0/options/PaginationOptions.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/v2_0/options/PaginationOptions.java
@@ -21,15 +21,13 @@ import static com.google.common.base.Preconditions.checkState;
 
 import java.util.Date;
 
-import com.google.common.collect.Multimap;
 import org.jclouds.http.options.BaseHttpRequestOptions;
+
+import com.google.common.collect.Multimap;
 
 /**
  * Options used to control paginated results (aka list commands).
- * 
- * @see <a href=
- *      "http://docs.openstack.org/api/openstack-compute/2/content/Paginated_Collections-d1e664.html"
- *      />
+ *
  */
 public class PaginationOptions extends BaseHttpRequestOptions {
    /**
@@ -43,10 +41,15 @@ public class PaginationOptions extends BaseHttpRequestOptions {
    }
 
    /**
-    * Only return objects changed since this time.
+    * Only return objects changed since a specified time.
+    *
+    * @deprecated The {@code changes-since} query does not apply to all OpenStack APIs. Please refer to the OpenStack
+    *             Nova {@code ListOptions.changesSince(Date)} and Glance {@code ListImageOptions.changesSince(Date)}.
+    *             This option will be removed in 2.1.
     */
-   public PaginationOptions changesSince(Date ifModifiedSince) {
-      this.queryParameters.put("changes-since", checkNotNull(ifModifiedSince, "ifModifiedSince").getTime() / 1000 + "");
+   @Deprecated
+   public PaginationOptions changesSince(Date changesSince) {
+      this.queryParameters.put("changes-since", checkNotNull(changesSince, "changesSince").getTime() / 1000 + "");
       return this;
    }
 
@@ -84,6 +87,18 @@ public class PaginationOptions extends BaseHttpRequestOptions {
       }
 
       /**
+       * @see PaginationOptions#changesSince(Date)
+       * @deprecated The {@code changes-since} query does not apply to all OpenStack APIs. Please refer to the OpenStack
+       *             Nova {@code ListOptions.changesSince(Date)} and Glance {@code ListImageOptions.changesSince(Date)}.
+       *             This option will be removed in 2.1.
+       */
+      @Deprecated
+      public static PaginationOptions changesSince(Date changesSince) {
+         PaginationOptions options = new PaginationOptions();
+         return options.changesSince(changesSince);
+      }
+
+      /**
        * @see PaginationOptions#marker(String)
        */
       public static PaginationOptions marker(String marker) {
@@ -92,20 +107,11 @@ public class PaginationOptions extends BaseHttpRequestOptions {
       }
 
       /**
-       * @see PaginationOptions#limit
+       * @see PaginationOptions#limit(int)
        */
       public static PaginationOptions limit(int limit) {
          PaginationOptions options = new PaginationOptions();
          return options.limit(limit);
       }
-
-      /**
-       * @see PaginationOptions#changesSince(Date)
-       */
-      public static PaginationOptions changesSince(Date since) {
-         PaginationOptions options = new PaginationOptions();
-         return options.changesSince(since);
-      }
-
    }
 }

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/options/PaginationOptionsTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/options/PaginationOptionsTest.java
@@ -16,12 +16,9 @@
  */
 package org.jclouds.openstack.v2_0.options;
 
-import static org.jclouds.openstack.v2_0.options.PaginationOptions.Builder.changesSince;
 import static org.jclouds.openstack.v2_0.options.PaginationOptions.Builder.limit;
 import static org.jclouds.openstack.v2_0.options.PaginationOptions.Builder.marker;
 import static org.testng.Assert.assertEquals;
-
-import java.util.Date;
 
 import org.testng.annotations.Test;
 
@@ -33,13 +30,6 @@ import com.google.common.collect.ImmutableList;
 @Test(groups = "unit", testName = "PaginationOptionsTest")
 public class PaginationOptionsTest {
 
-   public void testChangesSince() {
-      Date ifModifiedSince = new Date();
-      PaginationOptions options = new PaginationOptions().changesSince(ifModifiedSince);
-      assertEquals(ImmutableList.of(ifModifiedSince.getTime() / 1000 + ""),
-               options.buildQueryParameters().get("changes-since"));
-   }
-
    public void testMarker() {
       String marker = "52415800-8b69-11e0-9b19-734f6f006e54";
       PaginationOptions options = new PaginationOptions().marker(marker);
@@ -50,13 +40,6 @@ public class PaginationOptionsTest {
       int limit = 1;
       PaginationOptions options = new PaginationOptions().limit(limit);
       assertEquals(ImmutableList.of("1"), options.buildQueryParameters().get("limit"));
-   }
-
-   public void testChangesSinceStatic() {
-      Date ifModifiedSince = new Date();
-      PaginationOptions options = changesSince(ifModifiedSince);
-      assertEquals(ImmutableList.of(ifModifiedSince.getTime() / 1000 + ""),
-               options.buildQueryParameters().get("changes-since"));
    }
 
    public void testMarkerStatic() {

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/options/ListOptions.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/options/ListOptions.java
@@ -16,24 +16,23 @@
  */
 package org.jclouds.openstack.nova.v2_0.options;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.Date;
 
 import org.jclouds.openstack.v2_0.options.PaginationOptions;
 
 /**
  * Options used to control the amount of detail in the request.
- * 
+ *
  * @see PaginationOptions
- * @see <a href="http://wiki.openstack.org/OpenStackAPI_1-1" />
  */
 public class ListOptions extends PaginationOptions {
 
    public static final ListOptions NONE = new ListOptions();
 
    /**
-    * unless used, only the name and id will be returned per row.
-    * 
-    * @return
+    * Provides detailed results for list operations.
     */
    public ListOptions withDetails() {
       this.pathSuffix = "/detail";
@@ -44,19 +43,9 @@ public class ListOptions extends PaginationOptions {
     * {@inheritDoc}
     */
    @Override
-   public ListOptions changesSince(Date ifModifiedSince) {
-      super.changesSince(ifModifiedSince);
-      return this;
-   }
-
-   /**
-    * {@inheritDoc}
-    */
-   @Override
    public ListOptions limit(int limit) {
       super.limit(limit);
       return this;
-
    }
 
    /**
@@ -65,6 +54,14 @@ public class ListOptions extends PaginationOptions {
    @Override
    public ListOptions marker(String marker) {
       super.marker(marker);
+      return this;
+   }
+
+   /**
+    * Checks for any changes since the given date.
+    */
+   public ListOptions changesSince(Date changesSince) {
+      this.queryParameters.put("changes-since", checkNotNull(changesSince, "changesSince").getTime() / 1000 + "");
       return this;
    }
 
@@ -87,15 +84,25 @@ public class ListOptions extends PaginationOptions {
       }
 
       /**
-       * @see PaginationOptions#limit(long)
+       * @see PaginationOptions#limit(int)
        */
-      public static ListOptions maxResults(int maxKeys) {
+      public static ListOptions limit(int limit) {
          ListOptions options = new ListOptions();
-         return options.limit(maxKeys);
+         return options.limit(limit);
       }
 
       /**
-       * @see PaginationOptions#changesSince(Date)
+       *
+       * @see PaginationOptions#limit(int)
+       * @deprecated Please use {@link #limit(int)} as this builder method will be removed in 2.0.
+       */
+      @Deprecated
+      public static ListOptions maxResults(int maxKeys) {
+         return limit(maxKeys);
+      }
+
+      /**
+       * @see ListOptions#changesSince(Date)
        */
       public static ListOptions changesSince(Date since) {
          ListOptions options = new ListOptions();

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/options/ListOptionsTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/options/ListOptionsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.nova.v2_0.options;
+
+import static org.jclouds.openstack.nova.v2_0.options.ListOptions.Builder.changesSince;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Date;
+
+import org.jclouds.openstack.v2_0.options.PaginationOptions;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Tests behavior of {@code ListOptions}
+ */
+@Test(groups = "unit")
+public class ListOptionsTest {
+
+   public void testChangesSince() {
+      Date ifModifiedSince = new Date();
+      ListOptions options = new ListOptions().changesSince(ifModifiedSince);
+      assertEquals(ImmutableList.of(ifModifiedSince.getTime() / 1000 + ""),
+            options.buildQueryParameters().get("changes-since"));
+   }
+
+   public void testChangesSinceStatic() {
+      Date ifModifiedSince = new Date();
+      PaginationOptions options = changesSince(ifModifiedSince);
+      assertEquals(ImmutableList.of(ifModifiedSince.getTime() / 1000 + ""),
+               options.buildQueryParameters().get("changes-since"));
+   }
+
+}


### PR DESCRIPTION
This PR deprecates the `changesSince(Date ifModifiedSince)` method in PaginationOptions. `changes-since` is specific to Nova (and [Glance](https://github.com/jclouds/jclouds-labs-openstack/pull/137)) and has moved to the Nova `ListOptions` class. 

Nova `ListOptions.maxResults(int maxKeys)` has been deprecated in lieu of `limit(int limit)`.

Updated tests updated and cleaned up a few doc links.

JIRA: https://issues.apache.org/jira/browse/JCLOUDS-686
Related PR for Glance: https://github.com/jclouds/jclouds-labs-openstack/pull/137
