### PR TITLE
Throw sane error if one of security groups is null

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/compute/options/NovaTemplateOptions.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/compute/options/NovaTemplateOptions.java
@@ -179,6 +179,8 @@ public class NovaTemplateOptions extends TemplateOptions implements Cloneable {
     */
    @Deprecated
    public NovaTemplateOptions securityGroupNames(String... securityGroupNames) {
+      for (String groupName : checkNotNull(securityGroupNames, "securityGroupNames"))
+         checkNotNull(emptyToNull(groupName), "all security groups must be non-empty");
       return securityGroupNames(ImmutableSet.copyOf(checkNotNull(securityGroupNames, "securityGroupNames")));
    }
 

--- a/compute/src/main/java/org/jclouds/compute/options/TemplateOptions.java
+++ b/compute/src/main/java/org/jclouds/compute/options/TemplateOptions.java
@@ -530,6 +530,8 @@ public class TemplateOptions extends RunScriptOptions implements Cloneable {
     * assigns the created nodes to these security groups
     */
    public TemplateOptions securityGroups(Iterable<String> securityGroups) {
+      for (String groupName : checkNotNull(securityGroups, "securityGroups"))
+         checkNotNull(groupName, "all security groups must be not null");
       this.securityGroups = ImmutableSet.copyOf(checkNotNull(securityGroups, "securityGroups"));
       return this;
    }
@@ -538,6 +540,8 @@ public class TemplateOptions extends RunScriptOptions implements Cloneable {
     * @see TemplateOptions#securityGroups(Iterable<String>)
     */
    public TemplateOptions securityGroups(String... securityGroups) {
+      for (String groupName : checkNotNull(securityGroups, "securityGroups"))
+         checkNotNull(groupName, "all security groups must be not null");
       return securityGroups(ImmutableSet.copyOf(securityGroups));
    }
 


### PR DESCRIPTION
"vararg" methods for both `NovaTemplateOptions` and `TemplateOptions` does not check values for nullness, resulting in `NullPointerException: null` from `ImmutableSet.copyOf`.