### PR TITLE
jclouds has to use git core.autocrlf false (or LF line endings) to pass tests.

### DIFF
--- a/resources/checkstyle.xml
+++ b/resources/checkstyle.xml
@@ -21,8 +21,10 @@
 
 <module name="Checker">
     <property name="severity" value="warning"/>
-    <module name="NewlineAtEndOfFile"/>
-    <module name="TreeWalker">
+        <module name="NewlineAtEndOfFile">
+            <property name="lineSeparator" value="lf"/>
+        </module>
+        <module name="TreeWalker">
         <module name="AvoidStarImport"/>
         <module name="EmptyStatement"/>
         <module name="IllegalInstantiation">


### PR DESCRIPTION
Without this checkstyle setting, checkstyle fails on windows (looking for CRLF).
