### PR TITLE
Removing jsch.agentproxy deps that pull in net.java.dev.jna:jna

### DIFF
--- a/drivers/jsch/pom.xml
+++ b/drivers/jsch/pom.xml
@@ -95,6 +95,16 @@
       <groupId>com.jcraft</groupId>
       <artifactId>jsch.agentproxy.connector-factory</artifactId>
       <version>0.0.7</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.jcraft</groupId>
+          <artifactId>jsch.agentproxy.usocket-jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.jcraft</groupId>
+          <artifactId>jsch.agentproxy.pageant</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/drivers/sshj/pom.xml
+++ b/drivers/sshj/pom.xml
@@ -113,6 +113,16 @@
       <groupId>com.jcraft</groupId>
       <artifactId>jsch.agentproxy.connector-factory</artifactId>
       <version>0.0.7</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.jcraft</groupId>
+          <artifactId>jsch.agentproxy.usocket-jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.jcraft</groupId>
+          <artifactId>jsch.agentproxy.pageant</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
The included jna version is only LGPL-licensed. Compare #525 
