### PR TITLE
Update the GUEST_MASK so that the global identifier is retrieved for private images.

### DIFF
--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/features/AccountApi.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/features/AccountApi.java
@@ -43,7 +43,7 @@ import org.jclouds.softlayer.domain.VirtualGuestBlockDeviceTemplateGroup;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AccountApi {
 
-   String GUEST_MASK = "children.blockDevices.diskImage.softwareReferences.softwareDescription";
+   String GUEST_MASK = "mask[globalIdentifier,children.blockDevices.diskImage.softwareReferences.softwareDescription]";
    String LIST_GUEST_MASK = "powerState;operatingSystem.passwords;datacenter;billingItem;blockDevices" +
            ".diskImage;tagReferences";
 


### PR DESCRIPTION
private images.
Creating a virtual guest from private images is not working without the above fix. The code hashes the retrived images using the globalIdentifier. Apparently the globalIdentifier is not retrieved for private images and so it throws NPE.
