### PR TITLE
Import rackspace-cloudfiles from labs

### DIFF
--- a/allblobstore/pom.xml
+++ b/allblobstore/pom.xml
@@ -60,6 +60,21 @@
     </dependency>
     <dependency>
       <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>rackspace-cloudfiles</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.provider</groupId>
+      <artifactId>rackspace-cloudfiles-us</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.provider</groupId>
+      <artifactId>rackspace-cloudfiles-uk</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
       <artifactId>cloudfiles</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -49,6 +49,7 @@
     <module>openstack-trove</module>
     <module>cloudfiles</module>
     <module>cloudservers</module>
+    <module>rackspace-cloudfiles</module>
     <module>rackspace-cloudidentity</module>
     <module>rackspace-cloudloadbalancers</module>
     <module>rackspace-clouddns</module>

--- a/apis/rackspace-cloudfiles/README.md
+++ b/apis/rackspace-cloudfiles/README.md
@@ -1,0 +1,22 @@
+Rackspace Cloud Files
+==========================
+
+The new Rackspace Cloud Files multi-region based service API.
+
+This new "rackspace-cloudfiles" API supercedes the jclouds "cloudfiles" API, which will eventually be deprecated.
+
+With this multi-region support, each BlobStore can be isolated to a specific region:
+
+     RegionScopedBlobStoreContext ctx = 
+     	contextBuilder.buildView(RegionScopedBlobStoreContext.class);
+ 
+     Set<String> regionIds = ctx.configuredRegions();
+ 
+     // isolated to a specific region
+     BlobStore dfwBlobStore = ctx.blobStoreInRegion("DFW");
+     BlobStore iadBlobStore = ctx.blobStoreInRegion("IAD");
+
+Production ready?
+Beta
+
+This API is new to jclouds and hence is in Beta. That means we need people to use it and give us feedback. Based on that feedback, minor changes to the interfaces may happen. This code will replace org.jclouds.openstack.swift.SwiftClient in jclouds 2.0 and it is recommended you adopt it sooner than later.

--- a/apis/rackspace-cloudfiles/pom.xml
+++ b/apis/rackspace-cloudfiles/pom.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.jclouds</groupId>
+    <artifactId>jclouds-project</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../../project/pom.xml</relativePath>
+  </parent>
+
+  <groupId>org.apache.jclouds.api</groupId>
+  <artifactId>rackspace-cloudfiles</artifactId>
+  <name>jclouds rackspace-cloudfiles api</name>
+  <description>jclouds components to access Rackspace Cloud Files</description>
+  <packaging>bundle</packaging>
+
+  <properties>
+    <!-- identity endpoint -->
+    <test.rackspace-cloudfiles.endpoint>https://identity.api.rackspacecloud.com/v2.0/</test.rackspace-cloudfiles.endpoint>
+    <test.rackspace-cloudfiles.api-version>1</test.rackspace-cloudfiles.api-version>
+    <test.rackspace-cloudfiles.build-version />
+    <test.rackspace-cloudfiles.identity>FIXME_IDENTITY</test.rackspace-cloudfiles.identity>
+    <test.rackspace-cloudfiles.credential>FIXME_CREDENTIALS</test.rackspace-cloudfiles.credential>
+    <jclouds.osgi.export>org.jclouds.rackspace.cloudfiles.v1*;version="${project.version}"</jclouds.osgi.export>
+    <jclouds.osgi.import>org.jclouds*;version="${jclouds.version}",*</jclouds.osgi.import>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-swift</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-swift</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-keystone</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-keystone</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>rackspace-cloudidentity</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-core</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-core</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-blobstore</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.shrinkwrap</groupId>
+      <artifactId>shrinkwrap-depchain</artifactId>
+      <version>1.2.0</version>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.driver</groupId>
+      <artifactId>jclouds-slf4j</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>live</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>integration</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables>
+                    <jclouds.blobstore.httpstream.url>${jclouds.blobstore.httpstream.url}</jclouds.blobstore.httpstream.url>
+                    <jclouds.blobstore.httpstream.md5>${jclouds.blobstore.httpstream.md5}</jclouds.blobstore.httpstream.md5>
+                    <test.rackspace-cloudfiles.endpoint>${test.rackspace-cloudfiles.endpoint}</test.rackspace-cloudfiles.endpoint>
+                    <test.rackspace-cloudfiles.api-version>${test.rackspace-cloudfiles.api-version}</test.rackspace-cloudfiles.api-version>
+                    <test.rackspace-cloudfiles.build-version>${test.rackspace-cloudfiles.build-version}</test.rackspace-cloudfiles.build-version>
+                    <test.rackspace-cloudfiles.identity>${test.rackspace-cloudfiles.identity}</test.rackspace-cloudfiles.identity>
+                    <test.rackspace-cloudfiles.credential>${test.rackspace-cloudfiles.credential}</test.rackspace-cloudfiles.credential>
+                    <jclouds.blobstore.httpstream.url>${jclouds.blobstore.httpstream.url}</jclouds.blobstore.httpstream.url>
+                    <jclouds.blobstore.httpstream.md5>${jclouds.blobstore.httpstream.md5}</jclouds.blobstore.httpstream.md5>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/CloudFilesApi.java
+++ b/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/CloudFilesApi.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1;
+
+import org.jclouds.openstack.swift.v1.SwiftApi;
+import org.jclouds.rackspace.cloudfiles.v1.features.CDNApi;
+import org.jclouds.rackspace.cloudfiles.v1.functions.RegionToCDNEndpoint;
+import org.jclouds.rest.annotations.Delegate;
+import org.jclouds.rest.annotations.EndpointParam;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Rackspace Cloud Files is an affordable, redundant, scalable, and dynamic storage service
+ * offering. The core storage system is designed to provide a secure, network-accessible way to
+ * store an unlimited number of files. Each file can be as large as 5 gigabytes.
+ * <p/>
+ * Additionally, Cloud Files provides a simple yet powerful way to publish and distribute content
+ * behind a Content Distribution Network.
+ *
+ * @see CDNApi
+ * @see SwiftApi
+ */
+@Beta
+public interface CloudFilesApi extends SwiftApi {
+
+   /**
+    * Provides access to Cloud Files CDN features.
+    *
+    * @param region  the region to access the CDN API.
+    *
+    * @return the {@link CDNApi} for the specified region.
+    */
+   @Delegate
+   CDNApi getCDNApi(@EndpointParam(parser = RegionToCDNEndpoint.class) String region);
+
+}

--- a/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/CloudFilesApiMetadata.java
+++ b/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/CloudFilesApiMetadata.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1;
+
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+import static org.jclouds.reflect.Reflection2.typeToken;
+
+import java.net.URI;
+import java.util.Properties;
+
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
+import org.jclouds.openstack.swift.v1.SwiftApiMetadata;
+import org.jclouds.openstack.swift.v1.blobstore.RegionScopedBlobStoreContext;
+import org.jclouds.openstack.swift.v1.blobstore.config.SignUsingTemporaryUrls;
+import org.jclouds.openstack.swift.v1.blobstore.config.SwiftBlobStoreContextModule;
+import org.jclouds.openstack.swift.v1.config.SwiftTypeAdapters;
+import org.jclouds.openstack.v2_0.ServiceType;
+import org.jclouds.rackspace.cloudfiles.v1.config.CloudFilesHttpApiModule;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationApiModule;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationModule;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes;
+import org.jclouds.rest.internal.BaseHttpApiMetadata;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
+
+/**
+ * Implementation of {@link ApiMetadata} for Cloud Files.
+ */
+public class CloudFilesApiMetadata extends BaseHttpApiMetadata<CloudFilesApi> {
+
+   @Override
+   public Builder toBuilder() {
+      return new Builder().fromApiMetadata(this);
+   }
+
+   public CloudFilesApiMetadata() {
+      this(new Builder());
+   }
+
+   protected CloudFilesApiMetadata(Builder builder) {
+      super(builder);
+   }
+
+   public static Properties defaultProperties() {
+      Properties properties = SwiftApiMetadata.defaultProperties();
+      properties.setProperty(CREDENTIAL_TYPE, CloudIdentityCredentialTypes.API_KEY_CREDENTIALS);
+      properties.setProperty(SERVICE_TYPE, ServiceType.OBJECT_STORE);
+      return properties;
+   }
+
+   public static class Builder extends BaseHttpApiMetadata.Builder<CloudFilesApi, Builder> {
+
+      protected Builder() {
+          id("rackspace-cloudfiles")
+         .name("Rackspace Cloud Files API")
+         .identityName("${userName}")
+         .credentialName("${apiKey}")
+         .documentation(URI.create("http://docs.rackspace.com/files/api/v1/cf-devguide/content/index.html"))
+         .version("1.0")
+         .endpointName("Rackspace Cloud Identity service URL ending in /v2.0/")
+         .defaultEndpoint("https://identity.api.rackspacecloud.com/v2.0/")
+         .defaultProperties(CloudFilesApiMetadata.defaultProperties())
+         .view(typeToken(RegionScopedBlobStoreContext.class))
+         .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
+                                     .add(CloudIdentityAuthenticationApiModule.class)
+                                     .add(CloudIdentityAuthenticationModule.class)
+                                     .add(RegionModule.class)
+                                     .add(SwiftTypeAdapters.class)
+                                     .add(CloudFilesHttpApiModule.class)
+                                     .add(SwiftBlobStoreContextModule.class)
+                                     .add(SignUsingTemporaryUrls.class)
+                                     .build());
+      }
+
+      @Override
+      public CloudFilesApiMetadata build() {
+         return new CloudFilesApiMetadata(this);
+      }
+
+      @Override
+      protected Builder self() {
+         return this;
+      }
+   }
+}

--- a/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/binders/BindCDNPurgeEmailAddressesToHeaders.java
+++ b/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/binders/BindCDNPurgeEmailAddressesToHeaders.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.binders;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.List;
+
+import javax.inject.Singleton;
+
+import org.jclouds.http.HttpRequest;
+import org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders;
+import org.jclouds.rest.Binder;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMultimap;
+
+/**
+ * Binds a list of email addresses to request headers. 
+ * 
+ * @see {@link CDNApi#purgeObject(String, String, Iterable)}
+ */
+@Singleton
+public class BindCDNPurgeEmailAddressesToHeaders implements Binder {
+   @SuppressWarnings("unchecked")
+   @Override
+   public <R extends HttpRequest> R bindToRequest(R request, Object input) {
+      checkArgument(checkNotNull(input, "input") instanceof Iterable<?>, "this binder is only valid for Iterable!");
+      checkNotNull(request, "request");
+
+      Iterable<String> emails = (Iterable<String>) input;
+      String emailCSV = Joiner.on(", ").join((List<String>) emails);
+      ImmutableMultimap<String, String> headers = 
+            ImmutableMultimap.<String, String> of(CloudFilesHeaders.CDN_PURGE_OBJECT_EMAIL, emailCSV);
+      
+      return (R) request.toBuilder().replaceHeaders(headers).build();
+   }
+}

--- a/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/config/CloudFilesHttpApiModule.java
+++ b/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/config/CloudFilesHttpApiModule.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.config;
+
+import org.jclouds.http.HttpErrorHandler;
+import org.jclouds.http.annotation.ClientError;
+import org.jclouds.http.annotation.Redirection;
+import org.jclouds.http.annotation.ServerError;
+import org.jclouds.openstack.swift.v1.SwiftApi;
+import org.jclouds.openstack.swift.v1.config.BaseSwiftHttpApiModule;
+import org.jclouds.rackspace.cloudfiles.v1.CloudFilesApi;
+import org.jclouds.rackspace.cloudfiles.v1.handlers.CloudFilesErrorHandler;
+import org.jclouds.rest.ConfiguresHttpApi;
+
+import com.google.inject.Scopes;
+
+@ConfiguresHttpApi
+public class CloudFilesHttpApiModule extends BaseSwiftHttpApiModule<CloudFilesApi> {
+
+   public CloudFilesHttpApiModule() {
+      super(CloudFilesApi.class);
+   }
+
+   @Override
+   protected void configure() {
+      super.configure();
+      bind(SwiftApi.class).to(CloudFilesApi.class).in(Scopes.SINGLETON);
+   }
+   
+   @Override
+   protected void bindErrorHandlers() {
+      bind(HttpErrorHandler.class).annotatedWith(Redirection.class).to(CloudFilesErrorHandler.class);
+      bind(HttpErrorHandler.class).annotatedWith(ClientError.class).to(CloudFilesErrorHandler.class);
+      bind(HttpErrorHandler.class).annotatedWith(ServerError.class).to(CloudFilesErrorHandler.class);
+   }
+}

--- a/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/domain/CDNContainer.java
+++ b/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/domain/CDNContainer.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.domain;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.beans.ConstructorProperties;
+import java.net.URI;
+
+import javax.inject.Named;
+
+import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.common.base.Objects;
+
+/**
+ * Represents a CDN Container in Rackspace Cloud Files.
+ */
+public class CDNContainer implements Comparable<CDNContainer> {
+
+   private String name;
+   @Named("cdn_enabled")
+   private boolean enabled;
+   @Named("log_retention")
+   private boolean logRetention;
+   private int ttl;
+   @Named("cdn_uri")
+   private URI uri;
+   @Named("cdn_ssl_uri")
+   private URI sslUri;
+   @Named("cdn_streaming_uri")
+   private URI streamingUri;
+   @Named("cdn_ios_uri")
+   private URI iosUri;
+
+   @ConstructorProperties({ "name", "cdn_enabled", "log_retention", "ttl", "cdn_uri", "cdn_ssl_uri", "cdn_streaming_uri", "cdn_ios_uri"})
+   public CDNContainer(String name, boolean enabled, boolean logRetention, int ttl, URI uri, URI sslUri, URI streamingUri, URI iosUri) {
+      this.name = checkNotNull(name, "name required");
+      this.enabled = enabled;
+      this.logRetention = logRetention;
+      this.ttl = ttl;
+      this.uri = checkNotNull(uri, "uri required");
+      this.sslUri = checkNotNull(sslUri, "sslUri required");
+      this.streamingUri = checkNotNull(streamingUri, "streamingUri required");
+      this.iosUri = checkNotNull(iosUri, "iosUri required");
+   }
+
+   /**
+    * <h3>NOTE</h3>
+    * The container name is not available from HEAD CDN responses and will be null.
+    *
+    * @return The name of this CDN container.
+    */
+   public String getName() {
+      return name;
+   }
+
+   /**
+    * @return {@code true} if the container is CDN enabled, {@code false} if not.
+    */
+   public boolean isEnabled() {
+      return enabled;
+   }
+
+   /**
+    * @return {@code true} if the logs will be retained for this CDN container, {@code false} if not.
+    */
+   public boolean isLogRetentionEnabled() {
+      return logRetention;
+   }
+
+   /**
+    * @return the TTL for this CDN container.
+    */
+   public int getTtl() {
+      return ttl;
+   }
+
+   /**
+    * @return the {@link URI} for this CDN container.
+    */
+   public URI getUri() {
+      return uri;
+   }
+
+   /**
+    * @return the SSL {@link URI} for this CDN container.
+    */
+   public URI getSslUri() {
+      return sslUri;
+   }
+
+   /**
+    * @return the streaming {@link URI} for this CDN container.
+    */
+   public URI getStreamingUri() {
+      return streamingUri;
+   }
+
+   /**
+    * @return the iOS {@link URI} for this CDN container.
+    */
+   public URI getIosUri() {
+      return iosUri;
+   }
+   
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || getClass() != obj.getClass()) return false;
+      CDNContainer that = CDNContainer.class.cast(obj);
+      return Objects.equal(this.name, that.name)
+               && Objects.equal(this.enabled, that.enabled)
+               && Objects.equal(this.logRetention, that.logRetention)
+               && Objects.equal(this.ttl, that.ttl)
+               && Objects.equal(this.uri, that.uri)
+               && Objects.equal(this.sslUri, that.sslUri)
+               && Objects.equal(this.streamingUri, that.streamingUri)
+               && Objects.equal(this.iosUri, that.iosUri);
+   }
+   
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(getName(), isEnabled(), isLogRetentionEnabled(), getTtl(), getUri(), getSslUri(), getStreamingUri(), getIosUri());
+   }
+
+   @Override
+   public String toString() {
+      return string().toString();
+   }
+
+   protected ToStringHelper string() {
+      return toStringHelper("").omitNullValues()
+            .add("name", getName())
+            .add("enabled", isEnabled())
+            .add("logRetention", isLogRetentionEnabled())
+            .add("ttl", getTtl())
+            .add("uri", getUri())
+            .add("sslUri", getSslUri())
+            .add("streamingUri", getStreamingUri())
+            .add("iosUri", getIosUri());
+   }
+
+   @Override
+   public int compareTo(CDNContainer that) {
+      if (that == null)
+         return 1;
+      if (this == that)
+         return 0;
+      return this.getName().compareTo(that.getName());
+   }
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      
+      private String name;
+      private boolean enabled;
+      private boolean logRetention;
+      private int ttl;
+      private URI uri;
+      private URI sslUri;
+      private URI streamingUri;
+      private URI iosUri;
+      
+      /**
+       * @see CDNContainer#getName()
+       */
+      public Builder name(String name) {
+         this.name = checkNotNull(name, "name");
+         return this;
+      }
+
+      /**
+       * @see CDNContainer#isEnabled()
+       */
+      public Builder enabled(boolean enabled) {
+         this.enabled = enabled;
+         return this;
+      }
+
+      /**
+       * @see CDNContainer#isLogRetentionEnabled()
+       */
+      public Builder logRetention(boolean logRetention) {
+         this.logRetention = logRetention;
+         return this;
+      }
+
+      /**
+       * @see CDNContainer#getTtl()
+       */
+      public Builder ttl(int ttl) {
+         this.ttl = ttl;
+         return this;
+      }
+
+      /**
+       * @see CDNContainer#getUri()
+       */
+      public Builder uri(URI uri) {
+         this.uri = uri;
+         return this;
+      }
+
+      /**
+       * @see CDNContainer#getSslUri()
+       */
+      public Builder sslUri(URI sslUri) {
+         this.sslUri = sslUri;
+         return this;
+      }
+
+      /**
+       * @see CDNContainer#getStreamingUri()
+       */
+      public Builder streamingUri(URI streamingUri) {
+         this.streamingUri = streamingUri;
+         return this;
+      }
+
+      /**
+       * @see CDNContainer#getIosUri()
+       */
+      public Builder iosUri(URI iosUri) {
+         this.iosUri = iosUri;
+         return this;
+      }
+
+      public CDNContainer build() {
+         return new CDNContainer(name, enabled, logRetention, ttl, uri, sslUri, streamingUri, iosUri);
+      }
+
+      public Builder fromContainer(CDNContainer from) {
+         return name(from.getName())
+               .enabled(from.isEnabled())
+               .logRetention(from.isLogRetentionEnabled())
+               .ttl(from.getTtl())
+               .uri(from.getUri())
+               .sslUri(from.getSslUri())
+               .streamingUri(from.getStreamingUri())
+               .iosUri(from.getIosUri());
+      }
+   }
+}

--- a/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/features/CDNApi.java
+++ b/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/features/CDNApi.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.features;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_ENABLED;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_TTL;
+
+import java.io.Closeable;
+import java.net.URI;
+
+import javax.inject.Named;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import org.jclouds.Fallbacks.EmptyFluentIterableOnNotFoundOr404;
+import org.jclouds.Fallbacks.FalseOnNotFoundOr404;
+import org.jclouds.Fallbacks.NullOnNotFoundOr404;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.openstack.keystone.v2_0.filters.AuthenticateRequest;
+import org.jclouds.rackspace.cloudfiles.v1.binders.BindCDNPurgeEmailAddressesToHeaders;
+import org.jclouds.rackspace.cloudfiles.v1.domain.CDNContainer;
+import org.jclouds.rackspace.cloudfiles.v1.functions.ParseCDNContainerFromHeaders;
+import org.jclouds.rackspace.cloudfiles.v1.functions.ParseCDNContainerURIFromHeaders;
+import org.jclouds.rackspace.cloudfiles.v1.options.ListCDNContainerOptions;
+import org.jclouds.rackspace.cloudfiles.v1.options.UpdateCDNContainerOptions;
+import org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders;
+import org.jclouds.rest.annotations.BinderParam;
+import org.jclouds.rest.annotations.Fallback;
+import org.jclouds.rest.annotations.Headers;
+import org.jclouds.rest.annotations.QueryParams;
+import org.jclouds.rest.annotations.RequestFilters;
+import org.jclouds.rest.annotations.ResponseParser;
+
+import com.google.common.annotations.Beta;
+import com.google.common.collect.FluentIterable;
+/**
+ * Provides access to the Rackspace Cloud Files CDN API features.
+ *
+ * <h3>NOTE</h3>
+ * Before a container can be CDN enabled, it must exist in the storage system.
+ * To CDN enable the container, perform PUT request against it using the <code>publicURL</code>
+ * noted in the service catalog for Cloud Files during Authentication and set the
+ * <code>X-CDN-Enabled</code> header to <code>true</code>.
+ *
+ * @see {@link org.jclouds.rackspace.cloudfiles.v1.CloudFilesApi#getCDNApi(String)}
+ */
+@Beta
+@RequestFilters(AuthenticateRequest.class)
+@Consumes(APPLICATION_JSON)
+public interface CDNApi extends Closeable {
+
+   /**
+    * Lists up to 10,000 CDN containers.
+    *
+    * @return a list of CDN enabled containers ordered by name.
+    */
+   @Named("cdn:list")
+   @GET
+   @QueryParams(keys = {"format", "enabled_only"}, values = {"json", "true"})
+   @Fallback(EmptyFluentIterableOnNotFoundOr404.class)
+   @Path("/")
+   FluentIterable<CDNContainer> list();
+
+   /**
+    * Lists CDN containers, with the given options.
+    *
+    * @param options
+    *           the options to control output.
+    *
+    * @return a list of CDN enabled containers ordered by name.
+    */
+   @Named("cdn:list")
+   @GET
+   @QueryParams(keys = {"format", "enabled_only"}, values = {"json", "true"})
+   @Fallback(EmptyFluentIterableOnNotFoundOr404.class)
+   @Path("/")
+   FluentIterable<CDNContainer> list(ListCDNContainerOptions options);
+
+   /**
+    * Gets the specified CDN Container.
+    *
+    * @param containerName
+    *           the name of the CDN Container
+    *
+    * @return the CDNContainer or null, if not found.
+    */
+   @Named("cdn:get")
+   @HEAD
+   @ResponseParser(ParseCDNContainerFromHeaders.class)
+   @Fallback(NullOnNotFoundOr404.class)
+   @Path("/{container}")
+   @Nullable
+   CDNContainer get(@PathParam("container") String containerName);
+
+   /**
+    * Enables the {@link CDNContainer}.
+    *
+    * @param containerName
+    *           corresponds to {@link CDNContainer#getName()}.
+    *
+    * @return the CDN container {@link URI} or {@code null}, if not found.
+    */
+   @Named("cdn:enable")
+   @PUT
+   @ResponseParser(ParseCDNContainerURIFromHeaders.class)
+   @Fallback(NullOnNotFoundOr404.class)
+   @Path("/{containerName}")
+   @Headers(keys = CDN_ENABLED, values = "true")
+   @Nullable
+   URI enable(@PathParam("containerName") String containerName);
+
+   /**
+    * Enables the {@link CDNContainer} with a TTL.
+    *
+    * @param containerName
+    *           corresponds to {@link CDNContainer#getName()}.
+    * @param ttl
+    *           the TTL for the CDN Container.
+    *
+    * @return the CDN container {@link URI} or {@code null}, if not found.
+    */
+   @Named("cdn:enable")
+   @PUT
+   @ResponseParser(ParseCDNContainerURIFromHeaders.class)
+   @Fallback(NullOnNotFoundOr404.class)
+   @Path("/{containerName}")
+   @Headers(keys = CDN_ENABLED, values = "true")
+   @Nullable
+   URI enable(@PathParam("containerName") String containerName,
+         @HeaderParam(CDN_TTL) int ttl);
+
+   /**
+    * Disables the {@link CDNContainer}.
+    *
+    * @param containerName
+    *           corresponds to {@link CDNContainer#getName()}.
+    *
+    * @return {@code true} if the container was disabled, {@code false} if not.
+    */
+   @Named("cdn:disable")
+   @PUT
+   @Fallback(FalseOnNotFoundOr404.class)
+   @Path("/{containerName}")
+   @Headers(keys = CDN_ENABLED, values = "False")
+   boolean disable(@PathParam("containerName") String containerName);
+
+   /**
+    * Purges an object from the CDN.
+    *
+    * @param containerName
+    *           corresponds to {@link CDNContainer#getName()}.
+    * @param objectName
+    *           the object in the {@link CDNContainer} to purge.
+    * @param emails
+    *           the email addresses to notify after purging.
+    *
+    * @return {@code true} if the object was successfully purged, {@code false} if not.
+    */
+   @Named("cdn:purge")
+   @DELETE
+   @Fallback(FalseOnNotFoundOr404.class)
+   @Path("/{containerName}/{objectName}")
+   @Headers(keys = CloudFilesHeaders.CDN_PURGE_OBJECT_EMAIL, values = "{email}")
+   boolean purgeObject(@PathParam("containerName") String containerName,
+         @PathParam("objectName") String objectName,
+         @BinderParam(BindCDNPurgeEmailAddressesToHeaders.class) Iterable<String> emails);
+
+   /**
+    * Updates a CDN container with the supplied {@link UpdateCDNContainerOptions} options.
+    *
+    * @param containerName
+    *           corresponds to {@link CDNContainer#getName()}.
+    *
+    * @param options
+    *           the {@link UpdateCDNContainerOptions} options.
+    */
+   @Named("cdn:update")
+   @POST
+   @Fallback(FalseOnNotFoundOr404.class)
+   @Path("/{containerName}")
+   boolean update(@PathParam("containerName") String containerName, UpdateCDNContainerOptions options);
+}

--- a/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/functions/ParseCDNContainerFromHeaders.java
+++ b/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/functions/ParseCDNContainerFromHeaders.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.functions;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Lists.newArrayList;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_ENABLED;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_IOS_URI;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_LOG_RETENTION;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_SSL_URI;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_STREAMING_URI;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_TTL;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_URI;
+
+import java.net.URI;
+import java.util.List;
+
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpResponse;
+import org.jclouds.rackspace.cloudfiles.v1.domain.CDNContainer;
+import org.jclouds.rest.InvocationContext;
+
+import com.google.common.base.Function;
+import com.google.common.base.Splitter;
+
+/**
+ * Parses the {@link CDNContainer} from the response headers.
+ */
+public class ParseCDNContainerFromHeaders implements Function<HttpResponse, CDNContainer>,
+      InvocationContext<ParseCDNContainerFromHeaders> {
+
+   private HttpRequest request;
+
+   /**
+    * parses the http response headers to create a new {@link CDNContainer} object.
+    */
+   public CDNContainer apply(final HttpResponse from) {
+      String uri = checkNotNull(from.getFirstHeaderOrNull(CDN_URI), CDN_URI);
+      String sslUri = checkNotNull(from.getFirstHeaderOrNull(CDN_SSL_URI), CDN_SSL_URI);
+      String streamingUri = checkNotNull(from.getFirstHeaderOrNull(CDN_STREAMING_URI), CDN_STREAMING_URI);
+      String iosUri = checkNotNull(from.getFirstHeaderOrNull(CDN_IOS_URI), CDN_IOS_URI);
+      String enabled = checkNotNull(from.getFirstHeaderOrNull(CDN_ENABLED), CDN_ENABLED);
+      String logRetention = checkNotNull(from.getFirstHeaderOrNull(CDN_LOG_RETENTION), CDN_LOG_RETENTION);
+      String ttl = checkNotNull(from.getFirstHeaderOrNull(CDN_TTL), CDN_TTL);
+
+      // just need the name from the path
+      List<String> parts = newArrayList(Splitter.on('/').split(request.getEndpoint().getPath()));
+      checkArgument(!parts.isEmpty());
+
+      return CDNContainer.builder().name(parts.get(parts.size() - 1))
+            .enabled(Boolean.parseBoolean(enabled))
+            .logRetention(Boolean.parseBoolean(logRetention))
+            .ttl(Integer.parseInt(ttl))
+            .uri(URI.create(uri))
+            .sslUri(URI.create(sslUri))
+            .streamingUri(URI.create(streamingUri))
+            .iosUri(URI.create(iosUri))
+            .build();
+   }
+
+   @Override
+   public ParseCDNContainerFromHeaders setContext(HttpRequest request) {
+      this.request = request;
+      return this;
+   }
+}

--- a/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/functions/ParseCDNContainerURIFromHeaders.java
+++ b/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/functions/ParseCDNContainerURIFromHeaders.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.functions;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.net.URI;
+
+import org.jclouds.http.HttpResponse;
+import org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders;
+
+import com.google.common.base.Function;
+
+/**
+ * Parses the {@link CDNContainer} from the response headers.
+ */
+public class ParseCDNContainerURIFromHeaders implements Function<HttpResponse, URI> {
+
+   /**
+    * parses the http response headers to provide the CDN URI string.
+    */
+   public URI apply(final HttpResponse from) {
+      String cdnUri = checkNotNull(from.getFirstHeaderOrNull(CloudFilesHeaders.CDN_URI),
+               CloudFilesHeaders.CDN_URI);
+      return URI.create(cdnUri);
+   }
+}

--- a/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/functions/RegionToCDNEndpoint.java
+++ b/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/functions/RegionToCDNEndpoint.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.functions;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import java.net.URI;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.location.suppliers.RegionIdToURISupplier;
+import org.jclouds.rackspace.cloudidentity.v2_0.ServiceType;
+import org.jclouds.rest.annotations.ApiVersion;
+
+import com.google.common.base.Function;
+import com.google.common.base.Supplier;
+
+/**
+ * This class ensures that the correct Cloud Files CDN endpoint is retrieved from the endpoint
+ * supplier. The CDN API should never be instantiated directly, but rather accessed through the
+ * {@link CloudFilesApi#cdnApiInRegion(String)} API.
+ * <p/>
+ * <h3>NOTE</h3>
+ * The Cloud Files Service Type will always default to OpenStack Object Storage ("object-storage").
+ * <p/>
+ *
+ *
+ * @see CloudFilesApi#cdnApiInRegion(String)
+ * @see CDNApi
+ * @see RegionToEndpoint
+ * @see org.jclouds.openstack.v2_0.ServiceType#OBJECT_STORE
+ * @see org.jclouds.rackspace.cloudidentity.v2_0.ServiceType#OBJECT_CDN
+ * @see <a
+ *      href="http://docs.rackspace.com/files/api/v1/cf-devguide/content/Service-Access-Endpoints-d1e003.html">
+ *      Service Access Endpoints</a>
+ */
+@Singleton
+public class RegionToCDNEndpoint implements Function<Object, URI> {
+
+   private final Supplier<Map<String, Supplier<URI>>> endpointsSupplier;
+
+   @Inject
+   public RegionToCDNEndpoint(@ApiVersion final String apiVersion, final RegionIdToURISupplier.Factory factory) {
+      this.endpointsSupplier = factory.createForApiTypeAndVersion(ServiceType.OBJECT_CDN, apiVersion);
+   }
+
+   public URI apply(@Nullable Object from) {
+      checkArgument(from != null && from instanceof String, "you must specify a region, as a String argument");
+      Map<String, Supplier<URI>> regionToEndpoint = endpointsSupplier.get();
+      checkState(!regionToEndpoint.isEmpty(), "no region name to endpoint mappings configured!");
+      checkArgument(regionToEndpoint.containsKey(from),
+            "requested location %s, which is not in the configured locations: %s", from, regionToEndpoint);
+      return regionToEndpoint.get(from).get();
+   }
+}

--- a/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/handlers/CloudFilesErrorHandler.java
+++ b/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/handlers/CloudFilesErrorHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.handlers;
+
+import static org.jclouds.http.HttpUtils.closeClientButKeepContentStream;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jclouds.blobstore.ContainerNotFoundException;
+import org.jclouds.blobstore.KeyNotFoundException;
+import org.jclouds.http.HttpCommand;
+import org.jclouds.http.HttpErrorHandler;
+import org.jclouds.http.HttpResponse;
+import org.jclouds.http.HttpResponseException;
+import org.jclouds.openstack.swift.v1.CopyObjectException;
+import org.jclouds.openstack.swift.v1.reference.SwiftHeaders;
+import org.jclouds.rest.AuthorizationException;
+import org.jclouds.rest.InsufficientResourcesException;
+
+// TODO: is there error spec someplace? let's type errors, etc.
+public class CloudFilesErrorHandler implements HttpErrorHandler {
+   public static final String PREFIX = "^/v[0-9][^/]*/[a-zA-Z]+_[^/]+/";
+   public static final Pattern CONTAINER_PATH = Pattern.compile(PREFIX + "([^/]+)$");
+   public static final Pattern CONTAINER_KEY_PATH = Pattern.compile(PREFIX + "([^/]+)/(.*)");
+
+   public void handleError(HttpCommand command, HttpResponse response) {
+      // it is important to always read fully and close streams
+      byte[] data = closeClientButKeepContentStream(response);
+      String message = data != null ? new String(data) : null;
+
+      Exception exception = message != null ? new HttpResponseException(command, response, message)
+               : new HttpResponseException(command, response);
+      message = message != null ? message : String.format("%s -> %s", command.getCurrentRequest().getRequestLine(),
+               response.getStatusLine());
+      switch (response.getStatusCode()) {
+         case 401:
+            exception = new AuthorizationException(exception.getMessage(), exception);
+            break;
+         case 404:
+            Exception oldException = exception;
+            String sourcePath = command.getCurrentRequest().getFirstHeaderOrNull(SwiftHeaders.OBJECT_COPY_FROM);
+            if (sourcePath != null) {
+               // the path returned here is in the form "/v1/tenant-id/destContainer/destObject"
+               String path = command.getCurrentRequest().getEndpoint().getPath();
+               int startOfDestinationPath = path.lastIndexOf("/", path.lastIndexOf("/") - 1);
+               // get the "/destContainer/destObject" portion of the path
+               String destinationPath = path.substring(startOfDestinationPath);
+               
+               exception = new CopyObjectException(sourcePath, destinationPath, message);
+               exception.initCause(oldException);
+            } else if (!command.getCurrentRequest().getMethod().equals("DELETE")) {
+               String path = command.getCurrentRequest().getEndpoint().getPath();
+               Matcher matcher = CONTAINER_PATH.matcher(path);
+               
+               if (matcher.find()) {
+                  exception = new ContainerNotFoundException(matcher.group(1), message);
+                  exception.initCause(oldException);
+               } else {
+                  matcher = CONTAINER_KEY_PATH.matcher(path);
+                  if (matcher.find()) {
+                     exception = new KeyNotFoundException(matcher.group(1), matcher.group(2), message);
+                     exception.initCause(oldException);
+                  }
+               }
+            }
+            break;
+         case 409:
+            exception = new IllegalStateException(exception.getMessage(), exception);
+            break;
+         case 413:
+            exception = new InsufficientResourcesException(exception.getMessage(), exception);
+            break;
+      }
+      command.setException(exception);
+   }
+}

--- a/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/options/ListCDNContainerOptions.java
+++ b/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/options/ListCDNContainerOptions.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.options;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import org.jclouds.http.options.BaseHttpRequestOptions;
+
+/**
+ * Options for listing containers. 
+ * 
+ * @see {@link org.jclouds.rackspace.cloudfiles.v1.features.CDNAp#list(ListCDNContainerOptions) CDNApi.list(ListCDNContainerOptions)}
+ */
+public class ListCDNContainerOptions extends BaseHttpRequestOptions {
+
+   /** 
+    * For an integer value <i>n</i>, limits the number of results to <i>n</n>. 
+    */
+   public ListCDNContainerOptions limit(int limit) {
+      checkState(limit >= 0, "limit must be >= 0");
+      checkState(limit <= 10000, "limit must be <= 10000");
+      queryParameters.put("limit", Integer.toString(limit));
+      return this;
+   }
+
+   /** 
+    * Given a string value <i>x</i>, returns container names greater in value than the specified
+    * {@code marker}. Only strings using UTF-8 encoding are valid. Using {@code marker} provides
+    * a mechanism for iterating through the entire list of containers.
+    */
+   public ListCDNContainerOptions marker(String marker) {
+      queryParameters.put("marker", checkNotNull(marker, "marker"));
+      return this;
+   }
+
+   /** 
+    * Given a string value <i>x</i>, returns container names lesser in value than the specified 
+    * end marker. Only strings using UTF-8 encoding are valid.
+    */
+   public ListCDNContainerOptions endMarker(String endMarker) {
+      queryParameters.put("end_marker", checkNotNull(endMarker, "endMarker"));
+      return this;
+   }
+
+   public static class Builder {
+
+      /** 
+       * @see ListCDNContainerOptions#limit
+       */
+      public static ListCDNContainerOptions limit(int limit) {
+         ListCDNContainerOptions options = new ListCDNContainerOptions();
+         return options.limit(limit);
+      }
+
+      /** 
+       * @see ListCDNContainerOptions#marker
+       */
+      public static ListCDNContainerOptions marker(String marker) {
+         ListCDNContainerOptions options = new ListCDNContainerOptions();
+         return options.marker(marker);
+      }
+
+      /** 
+       * @see ListCDNContainerOptions#endMarker
+       */
+      public static ListCDNContainerOptions endMarker(String endMarker) {
+         ListCDNContainerOptions options = new ListCDNContainerOptions();
+         return options.endMarker(endMarker);
+      }
+   }
+}

--- a/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/options/UpdateCDNContainerOptions.java
+++ b/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/options/UpdateCDNContainerOptions.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.options;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.STATIC_WEB_DIRECTORY_TYPE;
+import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.STATIC_WEB_ERROR;
+import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.STATIC_WEB_INDEX;
+import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.STATIC_WEB_LISTINGS;
+import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.STATIC_WEB_LISTINGS_CSS;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesConstants.CDN_TTL_MAX;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesConstants.CDN_TTL_MIN;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_ENABLED;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_LOG_RETENTION;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_TTL;
+
+import org.jclouds.http.options.BaseHttpRequestOptions;
+
+import com.google.common.net.MediaType;
+
+/**
+ * Options supported for updating CDN containers.
+ */
+public class UpdateCDNContainerOptions extends BaseHttpRequestOptions {
+   public static final UpdateCDNContainerOptions NONE = new UpdateCDNContainerOptions();
+
+   /** 
+    * Updates TTL
+    */
+   public UpdateCDNContainerOptions ttl(int ttl) {
+      checkState(ttl >= Integer.valueOf(CDN_TTL_MIN), "ttl must be >= " + CDN_TTL_MIN);
+      checkState(ttl <= Integer.valueOf(CDN_TTL_MAX), "ttl must be <= " + CDN_TTL_MAX);
+      headers.put(CDN_TTL, Integer.toString(ttl));
+      return this;
+   }
+
+   /** 
+    * Enables or disables log retention
+    */
+   public UpdateCDNContainerOptions logRetention(boolean logRetention) {
+      headers.put(CDN_LOG_RETENTION, Boolean.toString(logRetention));
+      return this;
+   }
+
+   /** 
+    * Enables or disables the CDN Container
+    */
+   public UpdateCDNContainerOptions enabled(boolean enabled) {
+      headers.put(CDN_ENABLED, Boolean.toString(enabled));
+      return this;
+   }
+
+   /**
+    * Sets the directory marker type for the Static Website.
+    */
+   public UpdateCDNContainerOptions staticWebsiteDirectoryType(MediaType directoryType) {
+      checkNotNull(directoryType, "directoryType cannot be null");
+      headers.put(STATIC_WEB_DIRECTORY_TYPE, directoryType.toString());
+      return this;
+   }
+
+   /**
+    * Sets the error page for the Static Website.
+    */
+   public UpdateCDNContainerOptions staticWebsiteErrorPage(String errorPage) {
+      checkNotNull(errorPage, "error page cannot be null");
+      headers.put(STATIC_WEB_ERROR, errorPage);
+      return this;
+   }
+
+   /**
+    * Sets the index page for the Static Website.
+    */
+   public UpdateCDNContainerOptions staticWebsiteIndexPage(String indexPage) {
+      checkNotNull(indexPage, "index page cannot be null");
+      headers.put(STATIC_WEB_INDEX, indexPage);
+      return this;
+   }
+
+   /**
+    * Enables or disables listings for the Static Website.
+    */
+   public UpdateCDNContainerOptions staticWebsiteListings(boolean listings) {
+      headers.put(STATIC_WEB_LISTINGS, Boolean.toString(listings));
+      return this;
+   }
+
+   /**
+    * Sets the listings CSS page for the Static Website.
+    */
+   public UpdateCDNContainerOptions staticWebsiteListingsCSS(String listingsCSS) {
+      checkNotNull(listingsCSS, "listingsCSS page cannot be null");
+      headers.put(STATIC_WEB_LISTINGS_CSS, listingsCSS);
+      return this;
+   }
+
+   public static class Builder {
+      /**
+       * @see UpdateCDNContainerOptions#ttl
+       */
+      public static UpdateCDNContainerOptions ttl(int ttl) {
+         UpdateCDNContainerOptions options = new UpdateCDNContainerOptions();
+         return options.ttl(ttl);
+      }
+
+      /**
+       * @see UpdateCDNContainerOptions#logRetention
+       */
+      public static UpdateCDNContainerOptions logRetention(boolean logRetention) {
+         UpdateCDNContainerOptions options = new UpdateCDNContainerOptions();
+         return options.logRetention(logRetention);
+      }
+
+      /**
+       * @see UpdateCDNContainerOptions#enabled
+       */
+      public static UpdateCDNContainerOptions enabled(boolean enabled) {
+         UpdateCDNContainerOptions options = new UpdateCDNContainerOptions();
+         return options.enabled(enabled);
+      }
+
+      /**
+       * @see UpdateCDNContainerOptions#staticWebsiteDirectoryType
+       */
+      public static UpdateCDNContainerOptions staticWebsiteDirectoryType(MediaType directoryType) {
+         UpdateCDNContainerOptions options = new UpdateCDNContainerOptions();
+         return options.staticWebsiteDirectoryType(directoryType);
+      }
+
+      /**
+       * @see UpdateCDNContainerOptions#staticWebsiteErrorPage
+       */
+      public static UpdateCDNContainerOptions staticWebsiteErrorPage(String errorPage) {
+         UpdateCDNContainerOptions options = new UpdateCDNContainerOptions();
+         return options.staticWebsiteErrorPage(errorPage);
+      }
+
+      /**
+       * @see UpdateCDNContainerOptions#staticWebsiteIndexPage
+       */
+      public static UpdateCDNContainerOptions staticWebsiteIndexPage(String indexPage) {
+         UpdateCDNContainerOptions options = new UpdateCDNContainerOptions();
+         return options.staticWebsiteIndexPage(indexPage);
+      }
+
+      /**
+       * @see UpdateCDNContainerOptions#staticWebsiteListings
+       */
+      public static UpdateCDNContainerOptions staticWebsiteListings(boolean enabled) {
+         UpdateCDNContainerOptions options = new UpdateCDNContainerOptions();
+         return options.staticWebsiteListings(enabled);
+      }
+
+      /**
+       * @see UpdateCDNContainerOptions#staticWebsiteListingsCSS
+       */
+      public static UpdateCDNContainerOptions staticWebsiteListingsCSS(String cssPage) {
+         UpdateCDNContainerOptions options = new UpdateCDNContainerOptions();
+         return options.staticWebsiteListingsCSS(cssPage);
+      }
+   }
+}

--- a/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/reference/CloudFilesConstants.java
+++ b/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/reference/CloudFilesConstants.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.reference;
+
+
+/**
+ * Constants specified by Rackspace Cloud Files.
+ */
+public final class CloudFilesConstants {
+   public static final int CDN_TTL_MIN = 900;
+   public static final int CDN_TTL_MAX = 31536000;
+   public static final int CDN_TTL_DEFAULT = 259200;
+
+   private CloudFilesConstants() {
+      throw new AssertionError("intentionally unimplemented");
+   }
+}

--- a/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/reference/CloudFilesHeaders.java
+++ b/apis/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/reference/CloudFilesHeaders.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.reference;
+
+import org.jclouds.openstack.swift.v1.reference.SwiftHeaders;
+
+/**
+ * Additional headers specified by Rackspace Cloud Files.
+ */
+public final class CloudFilesHeaders {
+   // Access logs
+   public static final String CONTAINER_ACCESS_LOG_DELIVERY = SwiftHeaders.CONTAINER_METADATA_PREFIX + "Access-Log-Delivery";
+
+   // Common CDN Headers
+   public static final String CDN_ENABLED = "X-Cdn-Enabled";
+   public static final String CDN_LOG_RETENTION = "X-Log-Retention";
+   public static final String CDN_TTL = "X-Ttl";
+   public static final String CDN_URI = "X-Cdn-Uri";
+   public static final String CDN_SSL_URI = "X-Cdn-Ssl-Uri";
+   public static final String CDN_STREAMING_URI = "X-Cdn-Streaming-Uri";
+   public static final String CDN_IOS_URI = "X-Cdn-Ios-Uri";
+
+   // CDN Purge
+   public static final String CDN_PURGE_OBJECT_EMAIL = "X-Purge-Email";
+   public static final String CDN_PURGE_OBJECT_FAILED = "X-Purge-Failed-Reason";
+
+   private CloudFilesHeaders() {
+      throw new AssertionError("intentionally unimplemented");
+   }
+}

--- a/apis/rackspace-cloudfiles/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
+++ b/apis/rackspace-cloudfiles/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.jclouds.rackspace.cloudfiles.v1.CloudFilesApiMetadata

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/CloudFilesApiLiveTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/CloudFilesApiLiveTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1;
+
+import org.jclouds.rackspace.cloudfiles.v1.internal.BaseCloudFilesApiLiveTest;
+import org.testng.annotations.Test;
+
+/**
+ * Tests live behavior of {@code CloudFilesApi}.
+ */
+@Test(groups = "live", testName = "CloudFilesApiLiveTest")
+public class CloudFilesApiLiveTest extends BaseCloudFilesApiLiveTest {
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/CloudFilesApiMetadataTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/CloudFilesApiMetadataTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1;
+
+import org.jclouds.View;
+import org.jclouds.apis.internal.BaseApiMetadataTest;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.TypeToken;
+
+/**
+ * Tests the behavior of {@link CloudFilesApiMetadata}.
+ */
+@Test(groups = "unit", testName = "CloudFilesApiMetadataTest")
+public class CloudFilesApiMetadataTest extends BaseApiMetadataTest {
+   public CloudFilesApiMetadataTest() {
+      super(new CloudFilesApiMetadata(), ImmutableSet.<TypeToken<? extends View>> of());
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/binders/BindCDNPurgeEmailAddressesToHeadersMockTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/binders/BindCDNPurgeEmailAddressesToHeadersMockTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.binders;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.List;
+
+import org.jclouds.http.HttpRequest;
+import org.jclouds.openstack.v2_0.internal.BaseOpenStackMockTest;
+import org.jclouds.rackspace.cloudfiles.v1.CloudFilesApi;
+import org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Tests the behavior of {@code BindCDNPurgeEmailAddressesToHeaders}.
+ */
+@Test(groups = "unit", testName = "BindCDNPurgeEmailAddressesToHeadersMockTest")
+public class BindCDNPurgeEmailAddressesToHeadersMockTest extends BaseOpenStackMockTest<CloudFilesApi> {
+
+   BindCDNPurgeEmailAddressesToHeaders binder = new BindCDNPurgeEmailAddressesToHeaders();
+
+   public void testEmailBind() throws Exception {
+      List<String> emails = ImmutableList.of("foo@bar.com", "bar@foo.com");
+
+      HttpRequest request = purgeRequest();
+      
+      HttpRequest actualRequest = binder.bindToRequest(request, emails);
+      
+      HttpRequest expectedRequest = HttpRequest.builder()
+            .method("DELETE")
+            .endpoint("https://storage101.dfw1.clouddrive.com/v1/MossoCloudFS_XXXXXX/")
+            .addHeader(CloudFilesHeaders.CDN_PURGE_OBJECT_EMAIL, "foo@bar.com, bar@foo.com")
+            .build();
+      
+      assertEquals(actualRequest, expectedRequest);
+      
+   }
+
+   @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "input")
+   public void testNullList() {
+      HttpRequest request = purgeRequest();
+      binder.bindToRequest(request, null);
+   }
+
+   @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "request")
+   public void testNullRequest() {
+      List<String> emails = ImmutableList.of("foo@bar.com", "bar@foo.com");
+      binder.bindToRequest(null, emails);
+   }
+   
+   private static HttpRequest purgeRequest() {
+      return HttpRequest.builder()
+                .method("DELETE")
+                .endpoint("https://storage101.dfw1.clouddrive.com/v1/MossoCloudFS_XXXXXX/")
+                .build();
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/blobstore/CloudFilesRegionScopedBlobStoreContextLiveTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/blobstore/CloudFilesRegionScopedBlobStoreContextLiveTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.blobstore;
+
+import static org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes.API_KEY_CREDENTIALS;
+
+import java.util.Properties;
+
+import org.jclouds.openstack.swift.v1.blobstore.RegionScopedBlobStoreContextLiveTest;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the live behavior of the {@link RegionScopedBlobStoreContext}.
+ */
+@Test(groups = "live")
+public class CloudFilesRegionScopedBlobStoreContextLiveTest extends RegionScopedBlobStoreContextLiveTest {
+
+   public CloudFilesRegionScopedBlobStoreContextLiveTest() {
+      provider = "rackspace-cloudfiles";
+   }
+
+   @Override
+   protected Properties setupProperties() {
+      Properties props = super.setupProperties();
+      setIfTestSystemPropertyPresent(props, API_KEY_CREDENTIALS);
+      return props;
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/blobstore/integration/CloudFilesBlobIntegrationLiveTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/blobstore/integration/CloudFilesBlobIntegrationLiveTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.blobstore.integration;
+
+import static org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes.API_KEY_CREDENTIALS;
+
+import java.util.Properties;
+
+import org.jclouds.openstack.swift.v1.blobstore.integration.SwiftBlobIntegrationLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesBlobIntegrationLiveTest")
+public class CloudFilesBlobIntegrationLiveTest extends SwiftBlobIntegrationLiveTest {
+
+   public CloudFilesBlobIntegrationLiveTest() {
+      provider = "rackspace-cloudfiles";
+   }
+   
+   @Override
+   protected Properties setupProperties() {
+      Properties props = super.setupProperties();
+      setIfTestSystemPropertyPresent(props, API_KEY_CREDENTIALS);
+      return props;
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/blobstore/integration/CloudFilesBlobLiveTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/blobstore/integration/CloudFilesBlobLiveTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.blobstore.integration;
+
+import static org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes.API_KEY_CREDENTIALS;
+
+import java.util.Properties;
+
+import org.jclouds.openstack.swift.v1.blobstore.integration.SwiftBlobLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesBlobLiveTest")
+public class CloudFilesBlobLiveTest extends SwiftBlobLiveTest {
+
+   public CloudFilesBlobLiveTest() {
+      provider = "rackspace-cloudfiles";
+   }
+
+   @Override
+   protected Properties setupProperties() {
+      Properties props = super.setupProperties();
+      setIfTestSystemPropertyPresent(props, API_KEY_CREDENTIALS);
+      return props;
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/blobstore/integration/CloudFilesBlobSignerLiveTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/blobstore/integration/CloudFilesBlobSignerLiveTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.blobstore.integration;
+
+import static org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes.API_KEY_CREDENTIALS;
+
+import java.util.Properties;
+
+import org.jclouds.openstack.swift.v1.blobstore.integration.SwiftBlobSignerLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesBlobSignerLiveTest")
+public class CloudFilesBlobSignerLiveTest extends SwiftBlobSignerLiveTest {
+
+   public CloudFilesBlobSignerLiveTest() {
+      provider = "rackspace-cloudfiles";
+   }
+
+   @Override
+   protected Properties setupProperties() {
+      Properties props = super.setupProperties();
+      setIfTestSystemPropertyPresent(props, API_KEY_CREDENTIALS);
+      return props;
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/blobstore/integration/CloudFilesContainerIntegrationLiveTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/blobstore/integration/CloudFilesContainerIntegrationLiveTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.blobstore.integration;
+
+import static org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes.API_KEY_CREDENTIALS;
+
+import java.util.Properties;
+
+import org.jclouds.openstack.swift.v1.blobstore.integration.SwiftContainerIntegrationLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesContainerIntegrationLiveTest")
+public class CloudFilesContainerIntegrationLiveTest extends SwiftContainerIntegrationLiveTest {
+
+   public CloudFilesContainerIntegrationLiveTest() {
+      provider = "rackspace-cloudfiles";
+   }
+
+   @Override
+   protected Properties setupProperties() {
+      Properties props = super.setupProperties();
+      setIfTestSystemPropertyPresent(props, API_KEY_CREDENTIALS);
+      return props;
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/blobstore/integration/CloudFilesContainerLiveTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/blobstore/integration/CloudFilesContainerLiveTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.blobstore.integration;
+
+import static org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes.API_KEY_CREDENTIALS;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.Properties;
+
+import org.jclouds.openstack.swift.v1.blobstore.integration.SwiftContainerLiveTest;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesContainerLiveTest")
+public class CloudFilesContainerLiveTest extends SwiftContainerLiveTest {
+
+   public CloudFilesContainerLiveTest() {
+      provider = "rackspace-cloudfiles";
+   }
+
+   @Override
+   public void testPublicAccess() throws InterruptedException, MalformedURLException, IOException {
+      throw new SkipException("public access only supported through CDN");
+   }
+   
+   @Override
+   public void testPublicAccessInNonDefaultLocationWithBigBlob() throws InterruptedException, MalformedURLException, IOException {
+      throw new SkipException("public access only supported through CDN");
+   }
+   
+   public void testPublicAccessInNonDefaultLocation() throws InterruptedException, MalformedURLException, IOException {
+      throw new SkipException("public access only supported through CDN");
+   }
+   
+   @Override
+   protected Properties setupProperties() {
+      Properties props = super.setupProperties();
+      setIfTestSystemPropertyPresent(props, API_KEY_CREDENTIALS);
+      return props;
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/blobstore/integration/CloudFilesServiceIntegrationLiveTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/blobstore/integration/CloudFilesServiceIntegrationLiveTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.blobstore.integration;
+
+import static org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes.API_KEY_CREDENTIALS;
+
+import java.util.Properties;
+
+import org.jclouds.openstack.swift.v1.blobstore.integration.SwiftServiceIntegrationLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesServiceIntegrationLiveTest")
+public class CloudFilesServiceIntegrationLiveTest extends SwiftServiceIntegrationLiveTest {
+
+   public CloudFilesServiceIntegrationLiveTest() {
+      provider = "rackspace-cloudfiles";
+   }
+
+   @Override
+   protected Properties setupProperties() {
+      Properties props = super.setupProperties();
+      setIfTestSystemPropertyPresent(props, API_KEY_CREDENTIALS);
+      return props;
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesAccountApiLiveTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesAccountApiLiveTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.features;
+
+import static org.testng.Assert.assertTrue;
+
+import org.jclouds.openstack.swift.v1.domain.Account;
+import org.jclouds.openstack.swift.v1.features.AccountApi;
+import org.jclouds.openstack.swift.v1.features.AccountApiLiveTest;
+import org.jclouds.rackspace.cloudfiles.v1.CloudFilesApi;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the live behavior of the OpenStack Object Storage {@link AccountApi}
+ * via the {@link CloudFilesApi}.
+ */
+@Test(groups = "live", testName = "CloudFilesAccountApiLiveTest")
+public class CloudFilesAccountApiLiveTest extends AccountApiLiveTest {
+
+   public CloudFilesAccountApiLiveTest() {
+      provider = "rackspace-cloudfiles";
+   }
+
+   public void testUrlKeyExists() throws Exception {
+      for (String regionId : regions) {
+         Account account = api.getAccountApi(regionId).get();
+         assertTrue(account.getTemporaryUrlKey().isPresent());
+      }
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesBulkApiLiveTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesBulkApiLiveTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.features;
+
+import org.jclouds.openstack.swift.v1.features.BulkApiLiveTest;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the live behavior of the OpenStack Object Storage {@link BulkApi}
+ * via the {@link CloudFilesApi}.
+ */
+@Test(groups = "live", testName = "CloudFilesBulkApiLiveTest")
+public class CloudFilesBulkApiLiveTest extends BulkApiLiveTest {
+   public CloudFilesBulkApiLiveTest() {
+      provider = "rackspace-cloudfiles";
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesCDNApiLiveTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesCDNApiLiveTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.features;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+
+import org.jclouds.http.options.GetOptions;
+import org.jclouds.io.Payload;
+import org.jclouds.io.Payloads;
+import org.jclouds.openstack.swift.v1.features.ObjectApi;
+import org.jclouds.rackspace.cloudfiles.v1.domain.CDNContainer;
+import org.jclouds.rackspace.cloudfiles.v1.internal.BaseCloudFilesApiLiveTest;
+import org.jclouds.rackspace.cloudfiles.v1.options.ListCDNContainerOptions;
+import org.jclouds.rackspace.cloudfiles.v1.options.UpdateCDNContainerOptions;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteSource;
+
+
+/**
+ * Tests the live behavior of the {@code CloudFilesCDNApi}.
+ */
+@Test(groups = "live", testName = "CloudFilesCDNApiLiveTest")
+public class CloudFilesCDNApiLiveTest extends BaseCloudFilesApiLiveTest {
+
+   private String name = getClass().getSimpleName();
+
+   public CloudFilesCDNApiLiveTest() {
+      super();
+   }
+
+   public void testEnable() throws Exception {
+      for (String regionId : regions) {
+         assertNotNull(api.getCDNApi(regionId).enable(name));
+
+         CDNContainer container = api.getCDNApi(regionId).get(name);
+         assertCDNContainerNotNull(container);
+         assertTrue(container.isEnabled());
+      }
+   }
+
+   public void testEnableWithTTL() throws Exception {
+      for (String regionId : regions) {
+         assertNotNull(api.getCDNApi(regionId).enable(name, 777777));
+
+         CDNContainer container = api.getCDNApi(regionId).get(name);
+         assertCDNContainerNotNull(container);
+         assertTrue(container.isEnabled());
+         assertTrue(container.getTtl() == 777777);
+      }
+   }
+
+   public void testDisable() throws Exception {
+      for (String regionId : regions) {
+         assertTrue(api.getCDNApi(regionId).disable(name));
+
+         CDNContainer container = api.getCDNApi(regionId).get(name);
+         assertFalse(container.isEnabled());
+      }
+   }
+
+   public void testList() throws Exception {
+      for (String regionId : regions) {
+         List<CDNContainer> cdnResponse = api.getCDNApi(regionId).list().toList();
+         assertNotNull(cdnResponse);
+
+         for (CDNContainer cdnContainer : cdnResponse) {
+            assertCDNContainerNotNull(cdnContainer);
+            assertTrue(cdnContainer.isEnabled());
+         }
+      }
+   }
+
+   public void testListWithOptions() throws Exception {
+      String lexicographicallyBeforeName = name.substring(0, name.length() - 1);
+      for (String regionId : regions) {
+         ListCDNContainerOptions options = new ListCDNContainerOptions().marker(lexicographicallyBeforeName);
+
+         CDNContainer cdnContainer = api.getCDNApi(regionId).list(options).get(0);
+         assertCDNContainerNotNull(cdnContainer);
+         assertTrue(cdnContainer.isEnabled());
+      }
+   }
+
+   public void testGet() throws Exception {
+      for (String regionId : regions) {
+         CDNContainer container = api.getCDNApi(regionId).get(name);
+         assertCDNContainerNotNull(container);
+         assertTrue(container.isEnabled());
+      }
+   }
+
+   public void testPurgeObject() throws Exception {
+      for (String regionId : regions) {
+         String objectName = "testPurge";
+         Payload payload = Payloads.newByteSourcePayload(ByteSource.wrap(new byte[] {1, 2, 3}));
+         ObjectApi objectApi = api.getObjectApi(regionId, name);
+
+         // create a new object
+         objectApi.put(objectName, payload);
+
+         CDNApi cdnApi = api.getCDNApi(regionId);
+         assertTrue(cdnApi.purgeObject(name, "testPurge", ImmutableList.<String>of()));
+
+         // delete the object
+         objectApi.delete(objectName);
+         assertNull(objectApi.get(objectName, GetOptions.NONE));
+      }
+   }
+
+   public void testUpdate() throws Exception {
+      for (String regionId : regions) {
+         // enable with a ttl
+         assertNotNull(api.getCDNApi(regionId).enable(name, 777777));
+
+         // now get the container
+         CDNContainer original = api.getCDNApi(regionId).get(name);
+         assertTrue(original.isEnabled());
+         assertCDNContainerNotNull(original);
+
+         // update options
+         UpdateCDNContainerOptions opts = new UpdateCDNContainerOptions()
+                                                .ttl(1234567)
+                                                .logRetention(true)
+                                                .enabled(false);
+         // update the container
+         assertTrue(api.getCDNApi(regionId).update(name, opts));
+
+         // now get the updated container
+         CDNContainer updated = api.getCDNApi(regionId).get(name);
+         assertFalse(updated.isEnabled());
+         assertCDNContainerNotNull(updated);
+
+         assertNotEquals(original.getTtl(), updated.getTtl());
+         assertTrue(updated.isLogRetentionEnabled());
+      }
+   }
+
+   private static void assertCDNContainerNotNull(CDNContainer container) {
+      assertNotNull(container);
+      assertNotNull(container.getName());
+      assertNotNull(container.getTtl());
+      assertNotNull(container.getUri());
+      assertNotNull(container.getIosUri());
+      assertNotNull(container.getSslUri());
+      assertNotNull(container.getStreamingUri());
+      assertNotNull(container.isLogRetentionEnabled());
+   }
+
+   @BeforeClass(groups = "live")
+   public void setup() {
+      super.setup();
+      for (String regionId : regions) {
+         api.getContainerApi(regionId).create(name);
+      }
+   }
+
+   @Override
+   @AfterClass(groups = "live")
+   public void tearDown() {
+      for (String regionId : regions) {
+         api.getCDNApi(regionId).disable(name);
+         api.getContainerApi(regionId).deleteIfEmpty(name);
+      }
+      super.tearDown();
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesCDNApiMockTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesCDNApiMockTest.java
@@ -1,0 +1,523 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.features;
+
+import static com.google.common.net.HttpHeaders.CONTENT_LENGTH;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static org.jclouds.rackspace.cloudfiles.v1.options.UpdateCDNContainerOptions.Builder.enabled;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_ENABLED;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_IOS_URI;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_LOG_RETENTION;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_SSL_URI;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_STREAMING_URI;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_TTL;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_URI;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.net.URI;
+import java.util.List;
+
+import org.jclouds.openstack.v2_0.internal.BaseOpenStackMockTest;
+import org.jclouds.rackspace.cloudfiles.v1.CloudFilesApi;
+import org.jclouds.rackspace.cloudfiles.v1.domain.CDNContainer;
+import org.jclouds.rackspace.cloudfiles.v1.options.ListCDNContainerOptions;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+
+/**
+ * Tests the behavior of the {@link CloudFilesCDNApi}.
+ */
+@Test(groups = "unit", testName = "CloudFilesCDNApiMockTest")
+public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesApi> {
+
+   List<String> emails = ImmutableList.of("foo@bar.com", "bar@foo.com");
+
+   public void testList() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/cdn_container_list.json"))));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+         CDNApi cdnApi = api.getCDNApi("DFW");
+
+         ImmutableList<CDNContainer> cdnContainers = cdnApi.list().toList();
+
+         assertEquals(cdnContainers, mockContainers);
+
+         assertEquals(server.getRequestCount(), 2);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "GET", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/?format=json&enabled_only=true");
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testListIsEmpty() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+         CDNApi cdnApi = api.getCDNApi("DFW");
+
+         List<CDNContainer> cdnContainers = cdnApi.list().toList();
+
+         assertEquals(server.getRequestCount(), 2);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "GET", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/?format=json&enabled_only=true");
+
+         assertTrue(cdnContainers.isEmpty());
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testListWithOptions() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/cdn_container_list_at.json"))));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+         ListCDNContainerOptions options = new ListCDNContainerOptions().marker("cdn-container-3");
+         ImmutableList<CDNContainer> containers = api.getCDNApi("DFW").list(options).toList();
+
+         for (CDNContainer container : containers) {
+            assertCDNContainerNotNull(container);
+         }
+
+         assertEquals(containers, mockContainers.subList(2, mockContainers.size()));
+
+         assertEquals(server.getRequestCount(), 2);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "GET", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/?format=json&enabled_only=true&marker=cdn-container-3");
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testListWithOptionsIsEmpty() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+         ListCDNContainerOptions options = ListCDNContainerOptions.Builder.marker("cdn-container-3");
+         FluentIterable<CDNContainer> containers = api.getCDNApi("DFW").list(options);
+
+         assertEquals(server.getRequestCount(), 2);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "GET", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/?format=json&enabled_only=true&marker=cdn-container-3");
+
+         assertNotNull(containers);
+         assertTrue(containers.isEmpty());
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testEnable() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(enabledResponse().setResponseCode(201)));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+
+         // enable a CDN Container
+         URI enabledContainer = api.getCDNApi("DFW").enable("container-1");
+         assertNotNull(enabledContainer);
+
+         assertEquals(server.getRequestCount(), 2);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "PUT", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/container-1");
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testEnableFail() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(enabledResponse().setResponseCode(404)));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+         // enable a CDN Container
+         assertNull(api.getCDNApi("DFW").enable("container-1"));
+
+         assertEquals(server.getRequestCount(), 2);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "PUT", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/container-1");
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testEnableWithTTL() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(enabledResponse().setResponseCode(201)));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+
+         // enable a CDN Container with a TTL
+         URI enabledContainer = api.getCDNApi("DFW").enable("container-1", 777777);
+         assertNotNull(enabledContainer);
+
+         assertEquals(server.getRequestCount(), 2);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "PUT", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/container-1");
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testEnableWithTTLFail() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(enabledResponse().setResponseCode(404)));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+
+         // enable a CDN Container with a TTL
+         URI enabledContainer = api.getCDNApi("DFW").enable("container-1", 777777);
+         assertNull(enabledContainer);
+
+         assertEquals(server.getRequestCount(), 2);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "PUT", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/container-1");
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testDisable() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(enabledResponse().setResponseCode(201)));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+
+         // disable a CDN Container
+         assertTrue(api.getCDNApi("DFW").disable("container-1"));
+
+         assertEquals(server.getRequestCount(), 2);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "PUT", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/container-1");
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testDisableFail() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(enabledResponse().setResponseCode(404)));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+
+         // disable a CDN Container
+         boolean disbledContainer = api.getCDNApi("DFW").disable("container-1");
+         assertFalse(disbledContainer);
+
+         assertEquals(server.getRequestCount(), 2);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "PUT", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/container-1");
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testGet() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(enabledResponse().setResponseCode(201)));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+
+         CDNContainer cdnContainer = api.getCDNApi("DFW").get("container-1");
+         assertCDNContainerNotNull(cdnContainer);
+         assertEquals(mockCDNContainer, cdnContainer);
+
+         assertEquals(server.getRequestCount(), 2);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "HEAD", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/container-1");
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testGetCDNContainerWithSpaces() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(enabledResponse().setResponseCode(201)));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+
+         CDNContainer cdnContainer = api.getCDNApi("DFW").get("cdn-container with spaces");
+         assertCDNContainerNotNull(cdnContainer);
+         assertEquals(mockCDNContainerWithSpaces, cdnContainer);
+
+         assertEquals(server.getRequestCount(), 2);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "HEAD", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/cdn-container%20with%20spaces");
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testGetFail() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+
+         CDNContainer cdnContainer = api.getCDNApi("DFW").get("container-1");
+
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "HEAD", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/container-1");
+         assertNull(cdnContainer);
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testPurgeObject() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201)));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+
+         // purge the object
+         assertTrue(api.getCDNApi("DFW").purgeObject("myContainer", "myObject", emails));
+
+         assertEquals(server.getRequestCount(), 2);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "DELETE", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer/myObject");
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testPurgeObjectFail() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+
+         // purge the object
+         assertFalse(api.getCDNApi("DFW").purgeObject("myContainer", "myObject", emails));
+
+         assertEquals(server.getRequestCount(), 2);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "DELETE", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer/myObject");
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testUpdate() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json")).setResponseCode(200)));
+      server.enqueue(addCommonHeaders(enabledResponse().setResponseCode(200)));
+      server.enqueue(addCommonHeaders(updatedResponse().setResponseCode(204)));
+      server.enqueue(addCommonHeaders(updatedResponse().setResponseCode(200)));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+
+         CDNContainer cdnContainer = api.getCDNApi("DFW").get("container-1");
+         assertCDNContainerNotNull(cdnContainer);
+
+         // update the CDN Container
+         assertTrue(api.getCDNApi("DFW").update("container-1", enabled(false).logRetention(true).ttl(7654321)));
+
+         cdnContainer = api.getCDNApi("DFW").get("container-1");
+         assertCDNContainerNotNull(cdnContainer);
+
+         CDNContainer updatedContainer = CDNContainer.builder()
+               .name("container-1")
+               .enabled(false)
+               .logRetention(true)
+               .ttl(7654321)
+               .uri(URI.create("http://id-1.cdn.rackspace.com"))
+               .sslUri(URI.create("https://ssl-id-1.ssl.rackspace.com"))
+               .streamingUri(URI.create("http://streaming-id-1.stream.rackspace.com"))
+               .iosUri(URI.create("http://ios-id-1.iosr.rackspace.com"))
+               .build();
+
+         assertEquals(updatedContainer, cdnContainer);
+
+         assertEquals(server.getRequestCount(), 4);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "HEAD", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/container-1");
+         assertRequest(server.takeRequest(), "POST", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/container-1");
+         assertRequest(server.takeRequest(), "HEAD", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/container-1");
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testUpdateFail() throws Exception {
+      MockWebServer server = mockOpenStackServer();
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json")).setResponseCode(200)));
+      server.enqueue(addCommonHeaders(enabledResponse().setResponseCode(200)));
+      server.enqueue(addCommonHeaders(updatedResponse().setResponseCode(404)));
+
+      try {
+         CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
+
+         CDNContainer cdnContainer = api.getCDNApi("DFW").get("container-1");
+         assertCDNContainerNotNull(cdnContainer);
+
+         // update the CDN Container
+         assertFalse(api.getCDNApi("DFW").update("container-1", enabled(false).logRetention(true).ttl(7654321)));
+
+         assertEquals(server.getRequestCount(), 3);
+         assertAuthentication(server);
+         assertRequest(server.takeRequest(), "HEAD", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/container-1");
+         assertRequest(server.takeRequest(), "POST", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/container-1");
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   private static void assertCDNContainerNotNull(CDNContainer container) {
+      assertNotNull(container.getName());
+      assertNotNull(container.isEnabled());
+      assertNotNull(container.isLogRetentionEnabled());
+      assertNotNull(container.getTtl());
+      assertNotNull(container.getUri());
+      assertNotNull(container.getSslUri());
+      assertNotNull(container.getStreamingUri());
+      assertNotNull(container.getIosUri());
+   }
+
+   private static final CDNContainer mockCDNContainer = CDNContainer.builder()
+         .name("container-1")
+         .enabled(true)
+         .logRetention(false)
+         .ttl(777777)
+         .uri(URI.create("http://id-1.cdn.rackspace.com"))
+         .sslUri(URI.create("https://ssl-id-1.ssl.rackspace.com"))
+         .streamingUri(URI.create("http://streaming-id-1.stream.rackspace.com"))
+         .iosUri(URI.create("http://ios-id-1.iosr.rackspace.com"))
+         .build();
+
+   private static final CDNContainer mockCDNContainerWithSpaces = CDNContainer.builder()
+         .name("cdn-container with spaces")
+         .enabled(true)
+         .logRetention(false)
+         .ttl(777777)
+         .uri(URI.create("http://id-1.cdn.rackspace.com"))
+         .sslUri(URI.create("https://ssl-id-1.ssl.rackspace.com"))
+         .streamingUri(URI.create("http://streaming-id-1.stream.rackspace.com"))
+         .iosUri(URI.create("http://ios-id-1.iosr.rackspace.com"))
+         .build();
+
+   private static MockResponse enabledResponse() {
+      return new MockResponse()
+            .addHeader(CDN_ENABLED, "true")
+            .addHeader(CDN_LOG_RETENTION, "false")
+            .addHeader(CDN_TTL, "777777")
+            .addHeader(CDN_URI, "http://id-1.cdn.rackspace.com")
+            .addHeader(CDN_SSL_URI, "https://ssl-id-1.ssl.rackspace.com")
+            .addHeader(CDN_STREAMING_URI, "http://streaming-id-1.stream.rackspace.com")
+            .addHeader(CDN_IOS_URI, "http://ios-id-1.iosr.rackspace.com")
+            .addHeader(CONTENT_LENGTH, "0")
+            .addHeader(CONTENT_TYPE, "text/plain; charset=UTF-8");
+   }
+
+   private static MockResponse updatedResponse() {
+      return new MockResponse()
+            .addHeader(CDN_ENABLED, "false")
+            .addHeader(CDN_LOG_RETENTION, "true")
+            .addHeader(CDN_TTL, "7654321")
+            .addHeader(CDN_URI, "http://id-1.cdn.rackspace.com")
+            .addHeader(CDN_SSL_URI, "https://ssl-id-1.ssl.rackspace.com")
+            .addHeader(CDN_STREAMING_URI, "http://streaming-id-1.stream.rackspace.com")
+            .addHeader(CDN_IOS_URI, "http://ios-id-1.iosr.rackspace.com")
+            .addHeader(CONTENT_LENGTH, "0")
+            .addHeader(CONTENT_TYPE, "text/plain; charset=UTF-8");
+   }
+
+   private static final ImmutableList<CDNContainer> mockContainers = ImmutableList.of(
+         CDNContainer.builder()
+               .name("cdn-container-1")
+               .enabled(true)
+               .logRetention(false)
+               .ttl(259200)
+               .uri(URI.create("http://id-1.cdn.rackspace.com"))
+               .sslUri(URI.create("https://ssl-id-1.ssl.rackspace.com"))
+               .streamingUri(URI.create("http://streaming-id-1.stream.rackspace.com"))
+               .iosUri(URI.create("http://ios-id-1.iosr.rackspace.com"))
+               .build(),
+         CDNContainer.builder()
+               .name("cdn-container-2")
+               .enabled(true)
+               .logRetention(true)
+               .ttl(259200)
+               .uri(URI.create("http://id-2.cdn.rackspace.com"))
+               .sslUri(URI.create("https://ssl-id-2.ssl.rackspace.com"))
+               .streamingUri(URI.create("http://streaming-id-2.stream.rackspace.com"))
+               .iosUri(URI.create("http://ios-id-2.iosr.rackspace.com"))
+               .build(),
+         CDNContainer.builder()
+               .name("cdn-container-3")
+               .enabled(true)
+               .logRetention(false)
+               .ttl(259200)
+               .uri(URI.create("http://id-3.cdn.rackspace.com"))
+               .sslUri(URI.create("https://ssl-id-3.ssl.rackspace.com"))
+               .streamingUri(URI.create("http://streaming-id-3.stream.rackspace.com"))
+               .iosUri(URI.create("http://ios-id-3.iosr.rackspace.com"))
+               .build(),
+         CDNContainer.builder()
+               .name("cdn-container-4 with spaces")
+               .enabled(true)
+               .logRetention(true)
+               .ttl(777777)
+               .uri(URI.create("http://id-4.cdn.rackspace.com"))
+               .sslUri(URI.create("https://ssl-id-4.ssl.rackspace.com"))
+               .streamingUri(URI.create("http://streaming-id-4.stream.rackspace.com"))
+               .iosUri(URI.create("http://ios-id-4.iosr.rackspace.com"))
+               .build());
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesContainerApiLiveTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesContainerApiLiveTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.features;
+
+import org.jclouds.openstack.swift.v1.features.ContainerApiLiveTest;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the live behavior of the OpenStack Object Storage {@link ContainerApi}
+ * via the {@link CloudFilesApi}.
+ */
+@Test(groups = "live", testName = "CloudFilesContainerApiLiveTest")
+public class CloudFilesContainerApiLiveTest extends ContainerApiLiveTest {
+   public CloudFilesContainerApiLiveTest() {
+      provider = "rackspace-cloudfiles";
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesObjectApiLiveTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesObjectApiLiveTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.features;
+
+import org.jclouds.openstack.swift.v1.features.ObjectApiLiveTest;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the live behavior of the OpenStack Object Storage {@link ObjectApi}
+ * via the {@link CloudFilesApi}.
+ */
+@Test(groups = "live", testName = "CloudFilesObjectApiLiveTest")
+public class CloudFilesObjectApiLiveTest extends ObjectApiLiveTest {
+   public CloudFilesObjectApiLiveTest() {
+      provider = "rackspace-cloudfiles";
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/internal/BaseCloudFilesApiLiveTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/internal/BaseCloudFilesApiLiveTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.internal;
+
+import org.jclouds.openstack.swift.v1.internal.BaseSwiftApiLiveTest;
+import org.jclouds.rackspace.cloudfiles.v1.CloudFilesApi;
+import org.testng.annotations.Test;
+
+/**
+ * Base class for all {@link CloudFilesApi} live tests.
+ */
+@Test(groups = "live", testName = "BaseCloudFilesApiLiveTest")
+public abstract class BaseCloudFilesApiLiveTest extends BaseSwiftApiLiveTest<CloudFilesApi> {
+   protected BaseCloudFilesApiLiveTest() {
+      provider = "rackspace-cloudfiles";
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/options/UpdateCDNContainerOptionsTest.java
+++ b/apis/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/options/UpdateCDNContainerOptionsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.options;
+
+import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.STATIC_WEB_DIRECTORY_TYPE;
+import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.STATIC_WEB_ERROR;
+import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.STATIC_WEB_INDEX;
+import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.STATIC_WEB_LISTINGS;
+import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.STATIC_WEB_LISTINGS_CSS;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesConstants.CDN_TTL_MAX;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesConstants.CDN_TTL_MIN;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_LOG_RETENTION;
+import static org.jclouds.rackspace.cloudfiles.v1.reference.CloudFilesHeaders.CDN_TTL;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.net.MediaType;
+
+/**
+ * Tests behavior of {@link UpdateCDNContainerOptions}.
+ */
+@Test(groups = "unit")
+public class UpdateCDNContainerOptionsTest {
+
+   public void testTTLInRange() {
+      UpdateCDNContainerOptions options = 
+            new UpdateCDNContainerOptions().ttl(123456);
+      assertEquals(ImmutableList.of("123456"), options.buildRequestHeaders().get(CDN_TTL));
+   }
+
+   @Test(expectedExceptions = IllegalStateException.class)
+   public void testTTLLessThanMin() {
+      UpdateCDNContainerOptions options = 
+            new UpdateCDNContainerOptions().ttl(CDN_TTL_MIN - 1);
+      options.buildRequestHeaders().get(CDN_TTL);
+   }
+
+   @Test(expectedExceptions = IllegalStateException.class)
+   public void testTTLGreaterThanMax() {
+      UpdateCDNContainerOptions options = 
+            new UpdateCDNContainerOptions().ttl(CDN_TTL_MAX + 1);
+      options.buildRequestHeaders().get(CDN_TTL);
+   }
+
+   public void testEnableLogRetention() {
+      UpdateCDNContainerOptions options = 
+            new UpdateCDNContainerOptions().logRetention(true);
+      assertEquals(ImmutableList.of("true"), options.buildRequestHeaders().get(CDN_LOG_RETENTION));
+   }
+
+   public void testDisableLogRetention() {
+      UpdateCDNContainerOptions options = 
+            new UpdateCDNContainerOptions().logRetention(false);
+      assertEquals(ImmutableList.of("false"), options.buildRequestHeaders().get(CDN_LOG_RETENTION));
+   }
+
+   public void testStaticWebsiteDirectoryType() {
+      MediaType appDir = MediaType.create("application", "directory");
+      UpdateCDNContainerOptions options = 
+            new UpdateCDNContainerOptions().staticWebsiteDirectoryType(appDir);
+      assertEquals(ImmutableList.of(appDir.toString()), options.buildRequestHeaders().get(STATIC_WEB_DIRECTORY_TYPE));
+   }
+
+   public void testStaticWebsiteIndexPage() {
+      UpdateCDNContainerOptions options = 
+            new UpdateCDNContainerOptions().staticWebsiteIndexPage("index.html");
+      assertEquals(ImmutableList.of("index.html"), options.buildRequestHeaders().get(STATIC_WEB_INDEX));
+   }
+
+   public void testStaticWebsiteErrorPage() {
+      UpdateCDNContainerOptions options = 
+            new UpdateCDNContainerOptions().staticWebsiteErrorPage("error.html");
+      assertEquals(ImmutableList.of("error.html"), options.buildRequestHeaders().get(STATIC_WEB_ERROR));
+   }
+
+   public void testEnableStaticWebsiteListings() {
+      UpdateCDNContainerOptions options = 
+            new UpdateCDNContainerOptions().staticWebsiteListings(true);
+      assertEquals(ImmutableList.of("true"), options.buildRequestHeaders().get(STATIC_WEB_LISTINGS));
+   }
+
+   public void testDiableStaticWebsiteListings() {
+      UpdateCDNContainerOptions options = 
+            new UpdateCDNContainerOptions().staticWebsiteListings(false);
+      assertEquals(ImmutableList.of("false"), options.buildRequestHeaders().get(STATIC_WEB_LISTINGS));
+   }
+
+   public void testStaticWebsiteListingsCSS() {
+      UpdateCDNContainerOptions options = 
+            new UpdateCDNContainerOptions().staticWebsiteListingsCSS("listings.css");
+      assertEquals(ImmutableList.of("listings.css"), options.buildRequestHeaders().get(STATIC_WEB_LISTINGS_CSS));
+   }
+}

--- a/apis/rackspace-cloudfiles/src/test/resources/cdn_container_list.json
+++ b/apis/rackspace-cloudfiles/src/test/resources/cdn_container_list.json
@@ -1,0 +1,42 @@
+[
+    {
+        "cdn_streaming_uri": "http://streaming-id-1.stream.rackspace.com",
+        "name": "cdn-container-1",
+        "cdn_ios_uri": "http://ios-id-1.iosr.rackspace.com",
+        "cdn_ssl_uri": "https://ssl-id-1.ssl.rackspace.com",
+        "cdn_enabled": true,
+        "ttl": 259200,
+        "log_retention": false,
+        "cdn_uri": "http://id-1.cdn.rackspace.com"
+    },
+    {
+        "cdn_streaming_uri": "http://streaming-id-2.stream.rackspace.com",
+        "name": "cdn-container-2",
+        "cdn_ios_uri": "http://ios-id-2.iosr.rackspace.com",
+        "cdn_ssl_uri": "https://ssl-id-2.ssl.rackspace.com",
+        "cdn_enabled": true,
+        "ttl": 259200,
+        "log_retention": true,
+        "cdn_uri": "http://id-2.cdn.rackspace.com"
+    },
+    {
+        "cdn_streaming_uri": "http://streaming-id-3.stream.rackspace.com",
+        "name": "cdn-container-3",
+        "cdn_ios_uri": "http://ios-id-3.iosr.rackspace.com",
+        "cdn_ssl_uri": "https://ssl-id-3.ssl.rackspace.com",
+        "cdn_enabled": true,
+        "ttl": 259200,
+        "log_retention": false,
+        "cdn_uri": "http://id-3.cdn.rackspace.com"
+    },
+    {
+        "cdn_streaming_uri": "http://streaming-id-4.stream.rackspace.com",
+        "name": "cdn-container-4 with spaces",
+        "cdn_ios_uri": "http://ios-id-4.iosr.rackspace.com",
+        "cdn_ssl_uri": "https://ssl-id-4.ssl.rackspace.com",
+        "cdn_enabled": true,
+        "ttl": 777777,
+        "log_retention": true,
+        "cdn_uri": "http://id-4.cdn.rackspace.com"
+    }
+]

--- a/apis/rackspace-cloudfiles/src/test/resources/cdn_container_list_at.json
+++ b/apis/rackspace-cloudfiles/src/test/resources/cdn_container_list_at.json
@@ -1,0 +1,22 @@
+[
+    {
+        "cdn_streaming_uri": "http://streaming-id-3.stream.rackspace.com",
+        "name": "cdn-container-3",
+        "cdn_ios_uri": "http://ios-id-3.iosr.rackspace.com",
+        "cdn_ssl_uri": "https://ssl-id-3.ssl.rackspace.com",
+        "cdn_enabled": true,
+        "ttl": 259200,
+        "log_retention": false,
+        "cdn_uri": "http://id-3.cdn.rackspace.com"
+    },
+    {
+        "cdn_streaming_uri": "http://streaming-id-4.stream.rackspace.com",
+        "name": "cdn-container-4 with spaces",
+        "cdn_ios_uri": "http://ios-id-4.iosr.rackspace.com",
+        "cdn_ssl_uri": "https://ssl-id-4.ssl.rackspace.com",
+        "cdn_enabled": true,
+        "ttl": 777777,
+        "log_retention": true,
+        "cdn_uri": "http://id-4.cdn.rackspace.com"
+    }
+]

--- a/apis/rackspace-cloudfiles/src/test/resources/logback.xml
+++ b/apis/rackspace-cloudfiles/src/test/resources/logback.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration scan="false">
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="WIREFILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds-wire.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="BLOBSTOREFILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds-blobstore.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+    
+    <root>
+        <level value="warn" />
+    </root>
+
+    <logger name="org.jclouds">
+        <level value="DEBUG" />
+        <appender-ref ref="FILE" />
+    </logger>
+
+<!--
+    <logger name="jclouds.wire">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+-->
+
+    <logger name="jclouds.headers">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+    <logger name="jclouds.blobstore">
+        <level value="DEBUG" />
+        <appender-ref ref="BLOBSTOREFILE" />
+    </logger>
+
+</configuration>

--- a/providers/pom.xml
+++ b/providers/pom.xml
@@ -61,6 +61,8 @@
     <module>rackspace-clouddns-uk</module>
     <module>rackspace-clouddatabases-us</module>
     <module>rackspace-clouddatabases-uk</module>
+    <module>rackspace-cloudfiles-us</module>
+    <module>rackspace-cloudfiles-uk</module>
     <module>rackspace-cloudloadbalancers-us</module>
     <module>rackspace-cloudloadbalancers-uk</module>
     <module>rackspace-cloudservers-us</module>

--- a/providers/rackspace-cloudfiles-uk/README.md
+++ b/providers/rackspace-cloudfiles-uk/README.md
@@ -1,0 +1,21 @@
+Rackspace Cloud Files UK
+========================
+
+The new Rackspace Cloud Files UK multi-region based provider.
+
+This new "rackspace-cloudfiles-uk" provider supercedes the jclouds "cloudfiles-uk" provider, which will eventually be deprecated.
+
+With this multi-region support, a BlobStore can be isolated to a specific region:
+
+     RegionScopedBlobStoreContext ctx = 
+     	contextBuilder.buildView(RegionScopedBlobStoreContext.class);
+ 
+     Set<String> regionIds = ctx.configuredRegions();
+ 
+     // isolated to the only UK region
+     BlobStore dfwBlobStore = ctx.blobStoreInRegion("LON");
+
+Production ready?
+Beta
+
+This API is new to jclouds and hence is in Beta. That means we need people to use it and give us feedback. Based on that feedback, minor changes to the interfaces may happen. This code will replace org.jclouds.openstack.swift.SwiftClient in jclouds 2.0 and it is recommended you adopt it sooner than later.

--- a/providers/rackspace-cloudfiles-uk/pom.xml
+++ b/providers/rackspace-cloudfiles-uk/pom.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.jclouds</groupId>
+    <artifactId>jclouds-project</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../../project/pom.xml</relativePath>
+  </parent>
+
+  <groupId>org.apache.jclouds.provider</groupId>
+  <artifactId>rackspace-cloudfiles-uk</artifactId>
+  <name>jclouds Rackspace Cloud Files UK provider</name>
+  <description>OpenStack Object Storage implementation targeted to Rackspace Cloud Files UK</description>
+  <packaging>bundle</packaging>
+
+  <properties>
+    <!-- identity endpoint -->
+    <test.rackspace-cloudfiles-uk.endpoint>https://lon.identity.api.rackspacecloud.com/v2.0/</test.rackspace-cloudfiles-uk.endpoint>
+    <test.rackspace-cloudfiles-uk.api-version>1</test.rackspace-cloudfiles-uk.api-version>
+    <test.rackspace-cloudfiles-uk.build-version />
+    <test.rackspace-cloudfiles-uk.identity>${test.rackspace-uk.identity}</test.rackspace-cloudfiles-uk.identity>
+    <test.rackspace-cloudfiles-uk.credential>${test.rackspace-uk.credential}</test.rackspace-cloudfiles-uk.credential>
+    <jclouds.osgi.export>org.jclouds.rackspace.cloudfiles.uk*;version="${project.version}"</jclouds.osgi.export>
+    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-swift</artifactId>
+      <version>${parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-swift</artifactId>
+      <version>${parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>rackspace-cloudfiles</artifactId>
+      <version>${parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>rackspace-cloudfiles</artifactId>
+      <version>${parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-keystone</artifactId>
+      <version>${parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-keystone</artifactId>
+      <version>${parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-blobstore</artifactId>
+      <version>${parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-core</artifactId>
+      <version>${parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-core</artifactId>
+      <version>${parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.driver</groupId>
+      <artifactId>jclouds-slf4j</artifactId>
+      <version>${parent.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+    	<groupId>org.apache.jclouds.api</groupId>
+    	<artifactId>rackspace-cloudidentity</artifactId>
+      <version>${parent.version}</version>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>live</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>integration</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables>
+                    <jclouds.blobstore.httpstream.url>${jclouds.blobstore.httpstream.url}</jclouds.blobstore.httpstream.url>
+                    <jclouds.blobstore.httpstream.md5>${jclouds.blobstore.httpstream.md5}</jclouds.blobstore.httpstream.md5>
+                    <test.rackspace-cloudfiles-uk.endpoint>${test.rackspace-cloudfiles-uk.endpoint}</test.rackspace-cloudfiles-uk.endpoint>
+                    <test.rackspace-cloudfiles-uk.api-version>${test.rackspace-cloudfiles-uk.api-version}</test.rackspace-cloudfiles-uk.api-version>
+                    <test.rackspace-cloudfiles-uk.build-version>${test.rackspace-cloudfiles-uk.build-version}</test.rackspace-cloudfiles-uk.build-version>
+                    <test.rackspace-cloudfiles-uk.identity>${test.rackspace-cloudfiles-uk.identity}</test.rackspace-cloudfiles-uk.identity>
+                    <test.rackspace-cloudfiles-uk.credential>${test.rackspace-cloudfiles-uk.credential}</test.rackspace-cloudfiles-uk.credential>
+                    <jclouds.blobstore.httpstream.url>${jclouds.blobstore.httpstream.url}</jclouds.blobstore.httpstream.url>
+                    <jclouds.blobstore.httpstream.md5>${jclouds.blobstore.httpstream.md5}</jclouds.blobstore.httpstream.md5>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/providers/rackspace-cloudfiles-uk/src/main/java/org/jclouds/rackspace/cloudfiles/uk/CloudFilesUKProviderMetadata.java
+++ b/providers/rackspace-cloudfiles-uk/src/main/java/org/jclouds/rackspace/cloudfiles/uk/CloudFilesUKProviderMetadata.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.uk;
+
+import static org.jclouds.location.reference.LocationConstants.ISO3166_CODES;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGION;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+import static org.jclouds.reflect.Reflection2.typeToken;
+
+import java.net.URI;
+import java.util.Properties;
+
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
+import org.jclouds.openstack.swift.v1.blobstore.RegionScopedBlobStoreContext;
+import org.jclouds.openstack.swift.v1.blobstore.config.SignUsingTemporaryUrls;
+import org.jclouds.openstack.swift.v1.blobstore.config.SwiftBlobStoreContextModule;
+import org.jclouds.openstack.swift.v1.config.SwiftTypeAdapters;
+import org.jclouds.openstack.v2_0.ServiceType;
+import org.jclouds.providers.ProviderMetadata;
+import org.jclouds.providers.internal.BaseProviderMetadata;
+import org.jclouds.rackspace.cloudfiles.v1.CloudFilesApiMetadata;
+import org.jclouds.rackspace.cloudfiles.v1.config.CloudFilesHttpApiModule;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationApiModule;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationModule;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
+
+public class CloudFilesUKProviderMetadata extends BaseProviderMetadata {
+   
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   @Override
+   public Builder toBuilder() {
+      return builder().fromProviderMetadata(this);
+   }
+
+   public CloudFilesUKProviderMetadata() {
+      this(new Builder());
+   }
+
+   protected CloudFilesUKProviderMetadata(Builder builder) {
+      super(builder);
+   }
+
+   public static Properties defaultProperties() {
+      Properties properties = new Properties();
+      properties.setProperty(CREDENTIAL_TYPE, CloudIdentityCredentialTypes.API_KEY_CREDENTIALS);
+      properties.setProperty(SERVICE_TYPE, ServiceType.OBJECT_STORE); 
+
+      properties.setProperty(PROPERTY_REGIONS, "LON");
+      properties.setProperty(PROPERTY_REGION + ".LON." + ISO3166_CODES, "GB-SLG");
+
+      return properties;
+   }
+
+   public static class Builder extends BaseProviderMetadata.Builder {
+
+      protected Builder() {
+         id("rackspace-cloudfiles-uk")
+         .name("Rackspace Cloud Files UK")
+         .apiMetadata(new CloudFilesApiMetadata().toBuilder()
+               .identityName("${userName}")
+               .credentialName("${apiKey}")
+               .defaultEndpoint("https://lon.identity.api.rackspacecloud.com/v2.0/")
+               .documentation(URI.create("http://docs.rackspace.com/files/api/v1/cf-devguide/content/index.html"))
+               .endpointName("Rackspace Cloud Identity service URL ending in /v2.0/")
+               .version("1.0")
+               .view(typeToken(RegionScopedBlobStoreContext.class))
+               .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
+                     .add(CloudIdentityAuthenticationApiModule.class)
+                     .add(CloudIdentityAuthenticationModule.class)
+                     .add(RegionModule.class)
+                     .add(SwiftTypeAdapters.class)
+                     .add(CloudFilesHttpApiModule.class)
+                     .add(SwiftBlobStoreContextModule.class)
+                     .add(SignUsingTemporaryUrls.class)
+                     .build())
+               .build())
+         .homepage(URI.create("http://www.rackspace.co.uk/cloud/files/"))
+         .console(URI.create("https://mycloud.rackspace.co.uk"))
+         .linkedServices("rackspace-autoscale-uk", "rackspace-cloudblockstorage-uk",
+                         "rackspace-clouddatabases-uk", "rackspace-clouddns-uk",
+                         "rackspace-cloudidentity", "rackspace-cloudloadbalancers-uk",
+                         "rackspace-cloudqueues-uk")
+         .iso3166Codes("GB-SLG")
+         .defaultProperties(CloudFilesUKProviderMetadata.defaultProperties());
+         
+      }
+
+      @Override
+      public CloudFilesUKProviderMetadata build() {
+         return new CloudFilesUKProviderMetadata(this);
+      }
+
+      @Override
+      public Builder fromProviderMetadata(ProviderMetadata in) {
+         super.fromProviderMetadata(in);
+         return this;
+      }
+   }
+}

--- a/providers/rackspace-cloudfiles-uk/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/providers/rackspace-cloudfiles-uk/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.jclouds.rackspace.cloudfiles.uk.CloudFilesUKProviderMetadata

--- a/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/CloudFilesUKProviderTest.java
+++ b/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/CloudFilesUKProviderTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.uk;
+
+import org.jclouds.providers.internal.BaseProviderMetadataTest;
+import org.jclouds.rackspace.cloudfiles.v1.CloudFilesApiMetadata;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "CloudFilesUKProviderTest")
+public class CloudFilesUKProviderTest extends BaseProviderMetadataTest {
+   public CloudFilesUKProviderTest() {
+      super(new CloudFilesUKProviderMetadata(), new CloudFilesApiMetadata());
+   }
+}

--- a/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/blobstore/integration/CloudFilesUKBlobIntegrationLiveTest.java
+++ b/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/blobstore/integration/CloudFilesUKBlobIntegrationLiveTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.uk.blobstore.integration;
+
+import org.jclouds.rackspace.cloudfiles.v1.blobstore.integration.CloudFilesBlobIntegrationLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesUKBlobIntegrationLiveTest")
+public class CloudFilesUKBlobIntegrationLiveTest extends CloudFilesBlobIntegrationLiveTest {
+   public CloudFilesUKBlobIntegrationLiveTest() {
+      provider = "rackspace-cloudfiles-uk";
+   }
+}

--- a/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/blobstore/integration/CloudFilesUKBlobLiveTest.java
+++ b/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/blobstore/integration/CloudFilesUKBlobLiveTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.uk.blobstore.integration;
+
+import org.jclouds.rackspace.cloudfiles.v1.blobstore.integration.CloudFilesBlobLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesUKBlobLiveTest")
+public class CloudFilesUKBlobLiveTest extends CloudFilesBlobLiveTest {
+   public CloudFilesUKBlobLiveTest() {
+      provider = "rackspace-cloudfiles-uk";
+   }
+}

--- a/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/blobstore/integration/CloudFilesUKBlobSignerLiveTest.java
+++ b/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/blobstore/integration/CloudFilesUKBlobSignerLiveTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.uk.blobstore.integration;
+
+import org.jclouds.rackspace.cloudfiles.v1.blobstore.integration.CloudFilesBlobSignerLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesUKBlobSignerLiveTest")
+public class CloudFilesUKBlobSignerLiveTest extends CloudFilesBlobSignerLiveTest {
+   public CloudFilesUKBlobSignerLiveTest() {
+      provider = "rackspace-cloudfiles-uk";
+   }
+}

--- a/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/blobstore/integration/CloudFilesUKContainerIntegrationLiveTest.java
+++ b/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/blobstore/integration/CloudFilesUKContainerIntegrationLiveTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.uk.blobstore.integration;
+
+import org.jclouds.rackspace.cloudfiles.v1.blobstore.integration.CloudFilesContainerIntegrationLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesUKContainerIntegrationLiveTest")
+public class CloudFilesUKContainerIntegrationLiveTest extends CloudFilesContainerIntegrationLiveTest {
+   public CloudFilesUKContainerIntegrationLiveTest() {
+      provider = "rackspace-cloudfiles-uk";
+   }
+}

--- a/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/blobstore/integration/CloudFilesUKContainerLiveTest.java
+++ b/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/blobstore/integration/CloudFilesUKContainerLiveTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.uk.blobstore.integration;
+
+import org.jclouds.rackspace.cloudfiles.v1.blobstore.integration.CloudFilesContainerLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesUKContainerLiveTest")
+public class CloudFilesUKContainerLiveTest extends CloudFilesContainerLiveTest {
+   public CloudFilesUKContainerLiveTest() {
+      provider = "rackspace-cloudfiles-uk";
+   }
+}

--- a/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/blobstore/integration/CloudFilesUKServiceIntegrationLiveTest.java
+++ b/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/blobstore/integration/CloudFilesUKServiceIntegrationLiveTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.uk.blobstore.integration;
+
+import java.util.Set;
+
+import org.jclouds.rackspace.cloudfiles.v1.blobstore.integration.CloudFilesServiceIntegrationLiveTest;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+@Test(groups = "live", testName = "CloudFilesUKServiceIntegrationLiveTest")
+public class CloudFilesUKServiceIntegrationLiveTest extends CloudFilesServiceIntegrationLiveTest {
+   public CloudFilesUKServiceIntegrationLiveTest() {
+      provider = "rackspace-cloudfiles-uk";
+   }
+
+   @Override
+   protected Set<String> getIso3166Codes() {
+      return ImmutableSet.<String> of("GB-SLG");
+   }
+}

--- a/providers/rackspace-cloudfiles-uk/src/test/resources/logback.xml
+++ b/providers/rackspace-cloudfiles-uk/src/test/resources/logback.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration scan="false">
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="WIREFILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds-wire.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="BLOBSTOREFILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds-blobstore.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+    
+    <root>
+        <level value="warn" />
+    </root>
+
+    <logger name="org.jclouds">
+        <level value="DEBUG" />
+        <appender-ref ref="FILE" />
+    </logger>
+
+<!--
+    <logger name="jclouds.wire">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+-->
+
+    <logger name="jclouds.headers">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+    <logger name="jclouds.blobstore">
+        <level value="DEBUG" />
+        <appender-ref ref="BLOBSTOREFILE" />
+    </logger>
+
+</configuration>

--- a/providers/rackspace-cloudfiles-us/README.md
+++ b/providers/rackspace-cloudfiles-us/README.md
@@ -1,0 +1,22 @@
+Rackspace Cloud Files US
+========================
+
+The new Rackspace Cloud Files US multi-region based provider.
+
+This new "rackspace-cloudfiles-us" provider supercedes the jclouds "cloudfiles-us" provider, which will eventually be deprecated.
+
+With this multi-region support, each BlobStore can be isolated to a specific region:
+
+     RegionScopedBlobStoreContext ctx = 
+     	contextBuilder.buildView(RegionScopedBlobStoreContext.class);
+ 
+     Set<String> regionIds = ctx.configuredRegions();
+ 
+     // isolated to a specific region
+     BlobStore dfwBlobStore = ctx.blobStoreInRegion("DFW");
+     BlobStore iadBlobStore = ctx.blobStoreInRegion("IAD");
+
+Production ready?
+Beta
+
+This API is new to jclouds and hence is in Beta. That means we need people to use it and give us feedback. Based on that feedback, minor changes to the interfaces may happen. This code will replace org.jclouds.openstack.swift.SwiftClient in jclouds 2.0 and it is recommended you adopt it sooner than later.

--- a/providers/rackspace-cloudfiles-us/pom.xml
+++ b/providers/rackspace-cloudfiles-us/pom.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.jclouds</groupId>
+    <artifactId>jclouds-project</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../../project/pom.xml</relativePath>
+  </parent>
+
+  <groupId>org.apache.jclouds.provider</groupId>
+  <artifactId>rackspace-cloudfiles-us</artifactId>
+  <name>jclouds Rackspace Cloud Files US provider</name>
+  <description>OpenStack Object Storage implementation targeted to Rackspace Cloud Files US</description>
+  <packaging>bundle</packaging>
+
+  <properties>
+    <!-- identity endpoint -->
+    <test.rackspace-cloudfiles-us.endpoint>https://identity.api.rackspacecloud.com/v2.0/</test.rackspace-cloudfiles-us.endpoint>
+    <test.rackspace-cloudfiles-us.api-version>1</test.rackspace-cloudfiles-us.api-version>
+    <test.rackspace-cloudfiles-us.build-version />
+    <test.rackspace-cloudfiles-us.identity>${test.rackspace-us.identity}</test.rackspace-cloudfiles-us.identity>
+    <test.rackspace-cloudfiles-us.credential>${test.rackspace-us.credential}</test.rackspace-cloudfiles-us.credential>
+    <jclouds.osgi.export>org.jclouds.rackspace.cloudfiles.us*;version="${project.version}"</jclouds.osgi.export>
+    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-swift</artifactId>
+      <version>${parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-swift</artifactId>
+      <version>${parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>rackspace-cloudfiles</artifactId>
+      <version>${parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>rackspace-cloudfiles</artifactId>
+      <version>${parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-keystone</artifactId>
+      <version>${parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-keystone</artifactId>
+      <version>${parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-blobstore</artifactId>
+      <version>${parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-core</artifactId>
+      <version>${parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-core</artifactId>
+      <version>${parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.driver</groupId>
+      <artifactId>jclouds-slf4j</artifactId>
+      <version>${parent.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+    	<groupId>org.apache.jclouds.api</groupId>
+    	<artifactId>rackspace-cloudidentity</artifactId>
+      <version>${parent.version}</version>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>live</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>integration</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables>
+                    <jclouds.blobstore.httpstream.url>${jclouds.blobstore.httpstream.url}</jclouds.blobstore.httpstream.url>
+                    <jclouds.blobstore.httpstream.md5>${jclouds.blobstore.httpstream.md5}</jclouds.blobstore.httpstream.md5>
+                    <test.rackspace-cloudfiles-us.endpoint>${test.rackspace-cloudfiles-us.endpoint}</test.rackspace-cloudfiles-us.endpoint>
+                    <test.rackspace-cloudfiles-us.api-version>${test.rackspace-cloudfiles-us.api-version}</test.rackspace-cloudfiles-us.api-version>
+                    <test.rackspace-cloudfiles-us.build-version>${test.rackspace-cloudfiles-us.build-version}</test.rackspace-cloudfiles-us.build-version>
+                    <test.rackspace-cloudfiles-us.identity>${test.rackspace-cloudfiles-us.identity}</test.rackspace-cloudfiles-us.identity>
+                    <test.rackspace-cloudfiles-us.credential>${test.rackspace-cloudfiles-us.credential}</test.rackspace-cloudfiles-us.credential>
+                    <jclouds.blobstore.httpstream.url>${jclouds.blobstore.httpstream.url}</jclouds.blobstore.httpstream.url>
+                    <jclouds.blobstore.httpstream.md5>${jclouds.blobstore.httpstream.md5}</jclouds.blobstore.httpstream.md5>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/providers/rackspace-cloudfiles-us/src/main/java/org/jclouds/rackspace/cloudfiles/us/CloudFilesUSProviderMetadata.java
+++ b/providers/rackspace-cloudfiles-us/src/main/java/org/jclouds/rackspace/cloudfiles/us/CloudFilesUSProviderMetadata.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.us;
+
+import static org.jclouds.location.reference.LocationConstants.ISO3166_CODES;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGION;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+import static org.jclouds.reflect.Reflection2.typeToken;
+
+import java.net.URI;
+import java.util.Properties;
+
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
+import org.jclouds.openstack.swift.v1.blobstore.RegionScopedBlobStoreContext;
+import org.jclouds.openstack.swift.v1.blobstore.config.SignUsingTemporaryUrls;
+import org.jclouds.openstack.swift.v1.blobstore.config.SwiftBlobStoreContextModule;
+import org.jclouds.openstack.swift.v1.config.SwiftTypeAdapters;
+import org.jclouds.openstack.v2_0.ServiceType;
+import org.jclouds.providers.ProviderMetadata;
+import org.jclouds.providers.internal.BaseProviderMetadata;
+import org.jclouds.rackspace.cloudfiles.v1.CloudFilesApiMetadata;
+import org.jclouds.rackspace.cloudfiles.v1.config.CloudFilesHttpApiModule;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationApiModule;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationModule;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
+
+/**
+ * Implementation of {@link ProviderMetadata} for Rackspace Cloud Files US regions.
+ */
+public class CloudFilesUSProviderMetadata extends BaseProviderMetadata {
+   
+   /**
+    * @return The Builder object.
+    */
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   @Override
+   public Builder toBuilder() {
+      return builder().fromProviderMetadata(this);
+   }
+
+   /**
+    * Provider constructor.
+    */
+   public CloudFilesUSProviderMetadata() {
+      this(new Builder());
+   }
+
+   /**
+    * @param builder the Builder for the provider.
+    */
+   protected CloudFilesUSProviderMetadata(Builder builder) {
+      super(builder);
+   }
+
+   /**
+    * @return a {@link Properties} object containing the default provider properties.
+    */
+   public static Properties defaultProperties() {
+      Properties properties = new Properties();
+      properties.setProperty(CREDENTIAL_TYPE, CloudIdentityCredentialTypes.API_KEY_CREDENTIALS);
+      properties.setProperty(SERVICE_TYPE, ServiceType.OBJECT_STORE); 
+
+      properties.setProperty(PROPERTY_REGIONS, "ORD,DFW,IAD,SYD,HKG");
+      properties.setProperty(PROPERTY_REGION + ".ORD." + ISO3166_CODES, "US-IL");
+      properties.setProperty(PROPERTY_REGION + ".DFW." + ISO3166_CODES, "US-TX");
+      properties.setProperty(PROPERTY_REGION + ".IAD." + ISO3166_CODES, "US-VA");
+      properties.setProperty(PROPERTY_REGION + ".SYD." + ISO3166_CODES, "AU-NSW");
+      properties.setProperty(PROPERTY_REGION + ".HKG." + ISO3166_CODES, "HK");
+
+      return properties;
+   }
+
+   /**
+    * Builder pattern class.
+    */
+   public static class Builder extends BaseProviderMetadata.Builder {
+
+      protected Builder() {
+         id("rackspace-cloudfiles-us")
+         .name("Rackspace Cloud Files US")
+         .apiMetadata(new CloudFilesApiMetadata().toBuilder()
+               .identityName("${userName}")
+               .credentialName("${apiKey}")
+               .defaultEndpoint("https://identity.api.rackspacecloud.com/v2.0/")
+               .documentation(URI.create("http://docs.rackspace.com/files/api/v1/cf-devguide/content/index.html"))
+               .endpointName("Rackspace Cloud Identity service URL ending in /v2.0/")
+               .version("1.0")
+               .view(typeToken(RegionScopedBlobStoreContext.class))
+               .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
+                     .add(CloudIdentityAuthenticationApiModule.class)
+                     .add(CloudIdentityAuthenticationModule.class)
+                     .add(RegionModule.class)
+                     .add(SwiftTypeAdapters.class)
+                     .add(CloudFilesHttpApiModule.class)
+                     .add(SwiftBlobStoreContextModule.class)
+                     .add(SignUsingTemporaryUrls.class)
+                     .build())
+               .build())
+         .homepage(URI.create("http://www.rackspace.com/cloud/files"))
+         .console(URI.create("https://mycloud.rackspace.com"))
+         .linkedServices("rackspace-autoscale-us", "rackspace-cloudblockstorage-us",
+                         "rackspace-clouddatabases-us", "rackspace-clouddns-us",
+                         "rackspace-cloudidentity", "rackspace-cloudloadbalancers-us",
+                         "rackspace-cloudqueues-us")
+         .iso3166Codes("US-IL", "US-TX", "US-VA", "AU-NSW", "HK")
+         .defaultProperties(CloudFilesUSProviderMetadata.defaultProperties());
+         
+      }
+
+      @Override
+      public CloudFilesUSProviderMetadata build() {
+         return new CloudFilesUSProviderMetadata(this);
+      }
+
+      @Override
+      public Builder fromProviderMetadata(ProviderMetadata in) {
+         super.fromProviderMetadata(in);
+         return this;
+      }
+   }
+}

--- a/providers/rackspace-cloudfiles-us/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/providers/rackspace-cloudfiles-us/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.jclouds.rackspace.cloudfiles.us.CloudFilesUSProviderMetadata

--- a/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/CloudFilesUSProviderTest.java
+++ b/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/CloudFilesUSProviderTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.us;
+
+import org.jclouds.providers.internal.BaseProviderMetadataTest;
+import org.jclouds.rackspace.cloudfiles.v1.CloudFilesApiMetadata;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "CloudFilesUSProviderTest")
+public class CloudFilesUSProviderTest extends BaseProviderMetadataTest {
+   public CloudFilesUSProviderTest() {
+      super(new CloudFilesUSProviderMetadata(), new CloudFilesApiMetadata());
+   }
+}

--- a/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/blobstore/integration/CloudFilesUSBlobIntegrationLiveTest.java
+++ b/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/blobstore/integration/CloudFilesUSBlobIntegrationLiveTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.us.blobstore.integration;
+
+import org.jclouds.rackspace.cloudfiles.v1.blobstore.integration.CloudFilesBlobIntegrationLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesUSBlobIntegrationLiveTest")
+public class CloudFilesUSBlobIntegrationLiveTest extends CloudFilesBlobIntegrationLiveTest {
+   public CloudFilesUSBlobIntegrationLiveTest() {
+      provider = "rackspace-cloudfiles-us";
+   }
+}

--- a/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/blobstore/integration/CloudFilesUSBlobLiveTest.java
+++ b/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/blobstore/integration/CloudFilesUSBlobLiveTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.us.blobstore.integration;
+
+import org.jclouds.rackspace.cloudfiles.v1.blobstore.integration.CloudFilesBlobLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesUSBlobLiveTest")
+public class CloudFilesUSBlobLiveTest extends CloudFilesBlobLiveTest {
+   public CloudFilesUSBlobLiveTest() {
+      provider = "rackspace-cloudfiles-us";
+   }
+}

--- a/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/blobstore/integration/CloudFilesUSBlobSignerLiveTest.java
+++ b/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/blobstore/integration/CloudFilesUSBlobSignerLiveTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.us.blobstore.integration;
+
+import org.jclouds.rackspace.cloudfiles.v1.blobstore.integration.CloudFilesBlobSignerLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesUSBlobSignerLiveTest")
+public class CloudFilesUSBlobSignerLiveTest extends CloudFilesBlobSignerLiveTest {
+   public CloudFilesUSBlobSignerLiveTest() {
+      provider = "rackspace-cloudfiles-us";
+   }
+}

--- a/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/blobstore/integration/CloudFilesUSContainerIntegrationLiveTest.java
+++ b/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/blobstore/integration/CloudFilesUSContainerIntegrationLiveTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.us.blobstore.integration;
+
+import org.jclouds.rackspace.cloudfiles.v1.blobstore.integration.CloudFilesContainerIntegrationLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesUSContainerIntegrationLiveTest")
+public class CloudFilesUSContainerIntegrationLiveTest extends CloudFilesContainerIntegrationLiveTest {
+   public CloudFilesUSContainerIntegrationLiveTest() {
+      provider = "rackspace-cloudfiles-us";
+   }
+}

--- a/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/blobstore/integration/CloudFilesUSContainerLiveTest.java
+++ b/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/blobstore/integration/CloudFilesUSContainerLiveTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.us.blobstore.integration;
+
+import org.jclouds.rackspace.cloudfiles.v1.blobstore.integration.CloudFilesContainerLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "CloudFilesUSContainerLiveTest")
+public class CloudFilesUSContainerLiveTest extends CloudFilesContainerLiveTest {
+   public CloudFilesUSContainerLiveTest() {
+      provider = "rackspace-cloudfiles-us";
+   }
+}

--- a/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/blobstore/integration/CloudFilesUSServiceIntegrationLiveTest.java
+++ b/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/blobstore/integration/CloudFilesUSServiceIntegrationLiveTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.us.blobstore.integration;
+
+import java.util.Set;
+
+import org.jclouds.rackspace.cloudfiles.v1.blobstore.integration.CloudFilesServiceIntegrationLiveTest;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+@Test(groups = "live", testName = "CloudFilesUSServiceIntegrationLiveTest")
+public class CloudFilesUSServiceIntegrationLiveTest extends CloudFilesServiceIntegrationLiveTest {
+   public CloudFilesUSServiceIntegrationLiveTest() {
+      provider = "rackspace-cloudfiles-us";
+   }
+
+   @Override
+   protected Set<String> getIso3166Codes() {
+      return ImmutableSet.<String> of("US-IL", "US-TX", "US-VA", "AU-NSW", "HK");
+   }
+}

--- a/providers/rackspace-cloudfiles-us/src/test/resources/logback.xml
+++ b/providers/rackspace-cloudfiles-us/src/test/resources/logback.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration scan="false">
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="WIREFILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds-wire.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="BLOBSTOREFILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds-blobstore.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+    
+    <root>
+        <level value="warn" />
+    </root>
+
+    <logger name="org.jclouds">
+        <level value="DEBUG" />
+        <appender-ref ref="FILE" />
+    </logger>
+
+<!--
+    <logger name="jclouds.wire">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+-->
+
+    <logger name="jclouds.headers">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+    <logger name="jclouds.blobstore">
+        <level value="DEBUG" />
+        <appender-ref ref="BLOBSTOREFILE" />
+    </logger>
+
+</configuration>


### PR DESCRIPTION
This PR imports the `rackspace-cloudfiles` API and `rackspace-cloudfiles-uk/s` providers from the `jclouds-labs-openstack` repository.