### PR TITLE
Expecting 2 of 3 or the first flaky test to succeed

### DIFF
--- a/core/src/test/java/org/jclouds/rest/functions/PresentWhenApiVersionLexicographicallyAtOrAfterSinceApiVersionTest.java
+++ b/core/src/test/java/org/jclouds/rest/functions/PresentWhenApiVersionLexicographicallyAtOrAfterSinceApiVersionTest.java
@@ -118,6 +118,7 @@ public class PresentWhenApiVersionLexicographicallyAtOrAfterSinceApiVersionTest 
       assertEquals(fn.load(getVpcApi()), Optional.absent());
    }
 
+   @Test(invocationCount = 3, successPercentage = 66)
    public void testCacheIsFasterWhenNoAnnotationPresent() {
       InvocationSuccess keyPairApi = getKeyPairApi();
       ImplicitOptionalConverter fn = forApiVersion("2011-07-15");

--- a/core/src/test/java/org/jclouds/rest/functions/PresentWhenApiVersionLexicographicallyAtOrAfterSinceApiVersionTest.java
+++ b/core/src/test/java/org/jclouds/rest/functions/PresentWhenApiVersionLexicographicallyAtOrAfterSinceApiVersionTest.java
@@ -133,6 +133,7 @@ public class PresentWhenApiVersionLexicographicallyAtOrAfterSinceApiVersionTest 
             "lookup cache saved " + (first - cached) + " microseconds when no annotation present");
    }
 
+   @Test(invocationCount = 3, successPercentage = 66)
    public void testCacheIsFasterWhenAnnotationPresent() {
       InvocationSuccess floatingIpApi = getKeyPairApi();
       ImplicitOptionalConverter fn = forApiVersion("2011-07-15");


### PR DESCRIPTION
Really only opening a PR for this to gather some thoughts on this approach to dealing with flaky tests. It's easy to configure and makes use of out-of-the-box functionality of TestNG, but _does_ introduce the overhead of running this test three times on each run.

An approach an I also considered (similar to what's discussed in [this post](http://stackoverflow.com/questions/7803691/how-to-optimize-testng-and-seleniums-tests)) was to create a custom retry analyzer that would only run the test three times _if the first invocation failed_.

Given the relatively small number of consistently flaky tests we have, though, my thought was first to try the out-of-the-box approach, and to go for the custom code if we feel the total overhead imposed by running the flaky tests multiple times on each run gets too big.

Comments appreciated!