### PR TITLE
BACKPORT JCLOUDS-621: add missing t2.micro, t2.small and t2.medium instance types EC2

### DIFF
--- a/apis/ec2/src/main/java/org/jclouds/ec2/compute/domain/EC2HardwareBuilder.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/compute/domain/EC2HardwareBuilder.java
@@ -239,6 +239,33 @@ public class EC2HardwareBuilder extends HardwareBuilder {
    }
 
    /**
+    * @see InstanceType#T2_MICRO
+    */
+   public static EC2HardwareBuilder t2_micro() {
+      return new EC2HardwareBuilder(InstanceType.T2_MICRO)
+            .ram(1024)
+            .processors(ImmutableList.of(new Processor(1.0, 0.1))).rootDeviceType(RootDeviceType.EBS);
+   }
+
+   /**
+    * @see InstanceType#T2_SMALL
+    */
+   public static EC2HardwareBuilder t2_small() {
+      return new EC2HardwareBuilder(InstanceType.T2_SMALL)
+            .ram(2048)
+            .processors(ImmutableList.of(new Processor(1.0, 0.2))).rootDeviceType(RootDeviceType.EBS);
+   }
+
+   /**
+    * @see InstanceType#T2_MEDIUM
+    */
+   public static EC2HardwareBuilder t2_medium() {
+      return new EC2HardwareBuilder(InstanceType.T2_MEDIUM)
+            .ram(4096)
+            .processors(ImmutableList.of(new Processor(1.0, 0.4))).rootDeviceType(RootDeviceType.EBS);
+   }
+
+   /**
     * @see InstanceType#M1_LARGE
     */
    public static EC2HardwareBuilder m1_large() {

--- a/apis/ec2/src/main/java/org/jclouds/ec2/domain/InstanceType.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/domain/InstanceType.java
@@ -40,6 +40,39 @@ public class InstanceType {
    public static final String T1_MICRO = "t1.micro";
 
    /**
+    * Micro Burstable Performance Instance
+    * <ul>
+    * <li>1 GB memory</li>
+    * <li>1 vCPU / 10% baseline performance</li>
+    * <li>No instance storage (EBS storage only)</li>
+    * <li>64-bit platform</li>
+    * </ul>
+    */
+   public static final String T2_MICRO = "t2.micro";
+
+   /**
+    * Micro Burstable Performance Instance
+    * <ul>
+    * <li>2 GB memory</li>
+    * <li>1 vCPU / 20% baseline performance</li>
+    * <li>No instance storage (EBS storage only)</li>
+    * <li>64-bit platform</li>
+    * </ul>
+    */
+   public static final String T2_SMALL = "t2.small";
+
+   /**
+    * Micro Burstable Performance Instance
+    * <ul>
+    * <li>4 GB memory</li>
+    * <li>2 vCPU / 40% baseline performance</li>
+    * <li>No instance storage (EBS storage only)</li>
+    * <li>64-bit platform</li>
+    * </ul>
+    */
+   public static final String T2_MEDIUM = "t2.medium";
+
+    /**
     * Small Instance
     * <ul>
     * <li>1.7 GB memory</li>

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/suppliers/AWSEC2HardwareSupplier.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/suppliers/AWSEC2HardwareSupplier.java
@@ -45,6 +45,9 @@ import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.m3_large;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.m3_medium;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.m3_xlarge;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.t1_micro;
+import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.t2_micro;
+import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.t2_small;
+import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.t2_medium;
 
 import java.util.Set;
 
@@ -83,6 +86,9 @@ public class AWSEC2HardwareSupplier extends EC2HardwareSupplier {
       sizes.add(g2_2xlarge().supportsImageIds(ccAmis).build());
 
       sizes.add(t1_micro().build());
+      sizes.add(t2_micro().build());
+      sizes.add(t2_small().build());
+      sizes.add(t2_medium().build());
       sizes.add(c1_medium().build());
       sizes.add(c1_xlarge().build());
       sizes.add(c3_large().build());


### PR DESCRIPTION
Backport of #605 for 1.7.x branch, no code change at all.
