### PR TITLE
JCLOUDS-671: Modify AzureBlobUploadStrategy to use Iterable payload

### DIFF
--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/strategy/AzureBlobBlockUploadStrategy.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/strategy/AzureBlobBlockUploadStrategy.java
@@ -29,13 +29,13 @@ import org.jclouds.logging.Logger;
 
 import javax.annotation.Resource;
 import javax.inject.Named;
-
-import java.security.SecureRandom;
 import java.util.List;
+import java.util.UUID;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+
 
 /**
  * Decomposes a blob into blocks for upload and assembly through PutBlock and PutBlockList
@@ -60,25 +60,20 @@ public class AzureBlobBlockUploadStrategy implements MultipartUploadStrategy {
       Payload payload = blob.getPayload();
       Long length = payload.getContentMetadata().getContentLength();
       checkNotNull(length,
-            "please invoke payload.getContentMetadata().setContentLength(length) prior to azure block upload");
+              "please invoke payload.getContentMetadata().setContentLength(length) prior to azure block upload");
       checkArgument(length <= (MAX_NUMBER_OF_BLOCKS * MAX_BLOCK_SIZE));
-      long offset = 0L;
       List<String> blockIds = Lists.newArrayList();
       long bytesWritten = 0;
-      while (offset < length) {
-         long chunkSize = MAX_BLOCK_SIZE;
-         if (length - offset < MAX_BLOCK_SIZE) {
-            chunkSize = length % MAX_BLOCK_SIZE;
-         }
-         bytesWritten += chunkSize;
-         Payload block = slicer.slice(payload, offset, chunkSize);
-         offset += MultipartUploadStrategy.MAX_BLOCK_SIZE;
-         String blockName = blobName + "-" + offset + "-" + new SecureRandom().nextInt();
+
+      for (Payload block : slicer.slice(payload, MAX_BLOCK_SIZE)) {
+         String blockName = blobName + "-" + UUID.randomUUID().toString();
          byte blockIdBytes[] = Hashing.md5().hashBytes(blockName.getBytes()).asBytes();
          String blockId = BaseEncoding.base64().encode(blockIdBytes);
          blockIds.add(blockId);
          client.putBlock(container, blobName, blockId, block);
+         bytesWritten += block.getContentMetadata().getContentLength();
       }
+
       checkState(bytesWritten == length, "Wrote %s bytes, but we wanted to write %s bytes", bytesWritten, length);
       return client.putBlockList(container, blobName, blockIds);
    }


### PR DESCRIPTION
Payload slicer has a method that returns an iterable of payloads that works on non-repeatable
InputStreams that was introduced to fix multi-part uploads in swift (JCLOUDS-356). This commit
applies the same method to fix multi-part uploads for azure blob store.

https://issues.apache.org/jira/browse/JCLOUDS-671

For a multipart upload to azure blob storage, the payload is uploaded as a number of blocks with a maximum size of 4mb. Before this change, AzureBlobUploadStrategy was responsible for calculating offsets into the stream and requesting 4mb at a time from the BasePayloadSlicer The BasePayloadSlicer was using the offset to skip bytes in the stream and this would fail for non-repeatable InputStreams.

JCLOUDS-365 introduced a new method to the BasePayloadSlicer that pulled in the responsibility of calculating offsets and reading chunks into a block payload and encapsulated it behind an PayloadIterator which returns a payload for each chunk. This pull request modifies the AzureBlobUploadStrategy to use this higher-level method and removes the code for calculating chunk sizes and offsets as the BasePayloadSlicer takes care of that now.
