### PR TITLE
Backport Chef Map ordering to 1.8.x

### DIFF
--- a/apis/chef/src/main/java/org/jclouds/chef/internal/BaseChefService.java
+++ b/apis/chef/src/main/java/org/jclouds/chef/internal/BaseChefService.java
@@ -155,7 +155,7 @@ public class BaseChefService implements ChefService {
    String buildBootstrapConfiguration(BootstrapConfig bootstrapConfig) {
       checkNotNull(bootstrapConfig, "bootstrapConfig must not be null");
 
-      Map<String, Object> configMap = Maps.newHashMap();
+      Map<String, Object> configMap = Maps.newLinkedHashMap();
       configMap.put("run_list", bootstrapConfig.getRunList());
 
       if (bootstrapConfig.getEnvironment().isPresent()) {

--- a/apis/chef/src/main/java/org/jclouds/ohai/functions/NestSlashKeys.java
+++ b/apis/chef/src/main/java/org/jclouds/ohai/functions/NestSlashKeys.java
@@ -94,7 +94,7 @@ public class NestSlashKeys implements Function<Multimap<String, Supplier<JsonBal
    @VisibleForTesting
    void mergeAsPeer(String key, JsonBall value, Map<String, JsonBall> insertionContext) {
       Map<String, JsonBall> immutableValueContext = json.fromJson(insertionContext.get(key).toString(), mapLiteral);
-      Map<String, JsonBall> valueContext = Maps.newHashMap(immutableValueContext);
+      Map<String, JsonBall> valueContext = Maps.newLinkedHashMap(immutableValueContext);
       Map<String, JsonBall> toPut = json.<Map<String, JsonBall>> fromJson(value.toString(), mapLiteral);
       Set<String> uniques = Sets.difference(toPut.keySet(), valueContext.keySet());
       for (String k : uniques) {
@@ -135,7 +135,7 @@ public class NestSlashKeys implements Function<Multimap<String, Supplier<JsonBal
 
       checkArgument(rootValue.matches("^\\{.*\\}$"), "value must be a hash: %s", rootValue);
       Map<String, JsonBall> immutableInsertionContext = json.fromJson(rootValue, mapLiteral);
-      Map<String, JsonBall> insertionContext = Maps.newHashMap(immutableInsertionContext);
+      Map<String, JsonBall> insertionContext = Maps.newLinkedHashMap(immutableInsertionContext);
       if (keyParts.size() == 1) {
          if (!insertionContext.containsKey(keyParts.get(0))) {
             insertionContext.put(keyParts.get(0), toInsert);

--- a/apis/chef/src/test/java/org/jclouds/chef/internal/BaseChefServiceTest.java
+++ b/apis/chef/src/test/java/org/jclouds/chef/internal/BaseChefServiceTest.java
@@ -84,7 +84,7 @@ public class BaseChefServiceTest {
       BootstrapConfig bootstrapConfig = BootstrapConfig.builder().runList(runlist)
             .attributes(new JsonBall("{\"tomcat6\":{\"ssl_port\":8433}}")).build();
       String config = chefService.buildBootstrapConfiguration(bootstrapConfig);
-      assertEquals(config, "{\"tomcat6\":{\"ssl_port\":8433},\"run_list\":[\"recipe[apache2]\",\"role[webserver]\"]}");
+      assertEquals(config, "{\"run_list\":[\"recipe[apache2]\",\"role[webserver]\"],\"tomcat6\":{\"ssl_port\":8433}}");
    }
 
    public void testBuildBootstrapConfigurationWithRunlistAndAttributesAndEnvironment() {
@@ -93,7 +93,7 @@ public class BaseChefServiceTest {
             .attributes(new JsonBall("{\"tomcat6\":{\"ssl_port\":8433}}")).environment("env").build();
       String config = chefService.buildBootstrapConfiguration(bootstrapConfig);
       assertEquals(config,
-            "{\"tomcat6\":{\"ssl_port\":8433},\"environment\":\"env\",\"run_list\":[\"recipe[apache2]\",\"role[webserver]\"]}");
+            "{\"run_list\":[\"recipe[apache2]\",\"role[webserver]\"],\"environment\":\"env\",\"tomcat6\":{\"ssl_port\":8433}}");
    }
 
 }

--- a/apis/chef/src/test/java/org/jclouds/ohai/config/OhaiModuleTest.java
+++ b/apis/chef/src/test/java/org/jclouds/ohai/config/OhaiModuleTest.java
@@ -133,7 +133,7 @@ public class OhaiModuleTest {
       assertEquals(
             json.toJson(ohai.ohai.get(), new TypeLiteral<Map<String, JsonBall>>() {
             }.getType()),
-            "{\"ohai_time\":1279992919,\"platform\":\"macosx\",\"platform_version\":\"10.3.0\",\"current_user\":\"user\",\"test\":{\"prop2\":\"test2\",\"prop1\":\"test1\"},\"jvm\":{\"system\":{\"user.name\":\"user\",\"os.version\":\"10.3.0\",\"os.name\":\"Mac OS X\"}}}");
+            "{\"ohai_time\":1279992919,\"platform\":\"macosx\",\"platform_version\":\"10.3.0\",\"current_user\":\"user\",\"test\":{\"prop1\":\"test1\",\"prop2\":\"test2\"},\"jvm\":{\"system\":{\"user.name\":\"user\",\"os.version\":\"10.3.0\",\"os.name\":\"Mac OS X\"}}}");
    }
 
    static class Ohai {

--- a/apis/chef/src/test/java/org/jclouds/ohai/functions/NestSlashKeysTest.java
+++ b/apis/chef/src/test/java/org/jclouds/ohai/functions/NestSlashKeysTest.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -39,7 +39,7 @@ import com.google.inject.Injector;
 /**
  * Tests behavior of {@code NestSlashKeys}
  */
-@Test(groups = { "unit" }, sequential = true)
+@Test(groups = "unit", testName = "NestSlashKeysTest")
 public class NestSlashKeysTest {
 
    private NestSlashKeys converter;
@@ -60,56 +60,56 @@ public class NestSlashKeysTest {
    @Test
    public void testBase() {
       assertEquals(
-            json.toJson(converter.apply(ImmutableMultimap.<String, Supplier<JsonBall>> of("java",
+            json.toJson(converter.apply(ImmutableListMultimap.<String, Supplier<JsonBall>> of("java",
                   Suppliers.ofInstance(new JsonBall("java"))))), "{\"java\":\"java\"}");
    }
 
    @Test(expectedExceptions = IllegalArgumentException.class)
    public void testIllegal() {
-      json.toJson(converter.apply(ImmutableMultimap.<String, Supplier<JsonBall>> of("java",
+      json.toJson(converter.apply(ImmutableListMultimap.<String, Supplier<JsonBall>> of("java",
             Suppliers.ofInstance(new JsonBall("java")), "java/system", Suppliers.ofInstance(new JsonBall("system")))));
    }
 
    @Test
    public void testOne() {
       assertEquals(
-            json.toJson(converter.apply(ImmutableMultimap.<String, Supplier<JsonBall>> of("java",
+            json.toJson(converter.apply(ImmutableListMultimap.<String, Supplier<JsonBall>> of("java",
                   Suppliers.ofInstance(new JsonBall("{\"time\":\"time\"}")), "java/system",
                   Suppliers.ofInstance(new JsonBall("system"))))),
-            "{\"java\":{\"system\":\"system\",\"time\":\"time\"}}");
+            "{\"java\":{\"time\":\"time\",\"system\":\"system\"}}");
    }
 
    @Test
    public void testOneDuplicate() {
       assertEquals(
-            json.toJson(converter.apply(ImmutableMultimap.<String, Supplier<JsonBall>> of("java",
+            json.toJson(converter.apply(ImmutableListMultimap.<String, Supplier<JsonBall>> of("java",
                   Suppliers.ofInstance(new JsonBall("{\"time\":\"time\"}")), "java",
                   Suppliers.ofInstance(new JsonBall("{\"system\":\"system\"}"))))),
-            "{\"java\":{\"system\":\"system\",\"time\":\"time\"}}");
+            "{\"java\":{\"time\":\"time\",\"system\":\"system\"}}");
    }
 
    @Test
    public void testMerge() {
       assertEquals(
-            json.toJson(converter.apply(ImmutableMultimap.<String, Supplier<JsonBall>> of("java",
+            json.toJson(converter.apply(ImmutableListMultimap.<String, Supplier<JsonBall>> of("java",
                   Suppliers.ofInstance(new JsonBall("{\"time\":{\"1\":\"hello\"}}")), "java/time",
                   Suppliers.ofInstance(new JsonBall("{\"2\":\"goodbye\"}"))))),
-            "{\"java\":{\"time\":{\"2\":\"goodbye\",\"1\":\"hello\"}}}");
+            "{\"java\":{\"time\":{\"1\":\"hello\",\"2\":\"goodbye\"}}}");
    }
 
    @Test
    public void testMergeNestedTwice() {
       assertEquals(
-            json.toJson(converter.apply(ImmutableMultimap.<String, Supplier<JsonBall>> of("java",
+            json.toJson(converter.apply(ImmutableListMultimap.<String, Supplier<JsonBall>> of("java",
                   Suppliers.ofInstance(new JsonBall("{\"time\":{\"1\":\"hello\"}}")), "java",
                   Suppliers.ofInstance(new JsonBall("{\"time\":{\"2\":\"goodbye\"}}"))))),
-            "{\"java\":{\"time\":{\"2\":\"goodbye\",\"1\":\"hello\"}}}");
+            "{\"java\":{\"time\":{\"1\":\"hello\",\"2\":\"goodbye\"}}}");
    }
 
    @Test
    public void testReplaceList() {
       assertEquals(
-            json.toJson(converter.apply(ImmutableMultimap.<String, Supplier<JsonBall>> of("java",
+            json.toJson(converter.apply(ImmutableListMultimap.<String, Supplier<JsonBall>> of("java",
                   Suppliers.ofInstance(new JsonBall("{\"time\":{\"1\":[\"hello\"]}}")), "java/time",
                   Suppliers.ofInstance(new JsonBall("{\"1\":[\"goodbye\"]}"))))),
             "{\"java\":{\"time\":{\"1\":[\"goodbye\"]}}}");

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/Tag.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/Tag.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import org.jclouds.javax.annotation.Nullable;

--- a/apis/openstack-cinder/src/main/java/org/jclouds/openstack/cinder/v1/CinderApi.java
+++ b/apis/openstack-cinder/src/main/java/org/jclouds/openstack/cinder/v1/CinderApi.java
@@ -19,12 +19,9 @@ package org.jclouds.openstack.cinder.v1;
 import java.io.Closeable;
 import java.util.Set;
 
+import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.location.Zone;
 import org.jclouds.location.functions.ZoneToEndpoint;
-import org.jclouds.openstack.cinder.v1.domain.Snapshot;
-import org.jclouds.openstack.cinder.v1.domain.Volume;
-import org.jclouds.openstack.cinder.v1.domain.VolumeType;
-import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.openstack.cinder.v1.extensions.AvailabilityZoneApi;
 import org.jclouds.openstack.cinder.v1.features.QuotaApi;
 import org.jclouds.openstack.cinder.v1.features.SnapshotApi;
@@ -55,7 +52,7 @@ public interface CinderApi extends Closeable {
    @Provides
    @Zone
    Set<String> getConfiguredZones();
-   
+
    /**
     * Provides synchronous access to Extension features.
     */
@@ -76,7 +73,7 @@ public interface CinderApi extends Closeable {
    @Delegate
    VolumeTypeApi getVolumeTypeApiForZone(
          @EndpointParam(parser = ZoneToEndpoint.class) @Nullable String zone);
-   
+
    /**
     * Provides synchronous access to Snapshot features.
     */


### PR DESCRIPTION
In attempting to backport the `AutoService` changes to the **1.8.x** branch today, I consistently ran into test failures because of this ordering issue. Apparently, commit [cd4ce6](https://github.com/jclouds/jclouds/commit/cd4ce6b1923b37c30a98f3ff5c54947c68ecf292) had not been backported. :cry: cc @nacx 