### PR TITLE
disable directory blob tests in OS X

### DIFF
--- a/apis/filesystem/src/main/java/org/jclouds/filesystem/predicates/validators/internal/FilesystemBlobKeyValidatorImpl.java
+++ b/apis/filesystem/src/main/java/org/jclouds/filesystem/predicates/validators/internal/FilesystemBlobKeyValidatorImpl.java
@@ -41,11 +41,6 @@ public class FilesystemBlobKeyValidatorImpl extends FilesystemBlobKeyValidator {
         if (name.startsWith(File.separator))
             throw new IllegalArgumentException(String.format(
                     "Blob key '%s' cannot start with character %s", name, File.separator));
-
-        //blobkey cannot end with / (or \ in Windows) character
-        if (name.endsWith(File.separator))
-            throw new IllegalArgumentException(String.format(
-                    "Blob key '%s' cannot end with character %s", name, File.separator));
     }
 
 }

--- a/apis/filesystem/src/main/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImpl.java
+++ b/apis/filesystem/src/main/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImpl.java
@@ -43,6 +43,7 @@ import org.jclouds.blobstore.LocalStorageStrategy;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobBuilder;
 import org.jclouds.blobstore.options.ListContainerOptions;
+import org.jclouds.blobstore.reference.BlobStoreConstants;
 import org.jclouds.domain.Location;
 import org.jclouds.filesystem.predicates.validators.FilesystemBlobKeyValidator;
 import org.jclouds.filesystem.predicates.validators.FilesystemContainerNameValidator;
@@ -67,6 +68,13 @@ import com.google.common.io.ByteSource;
 import com.google.common.io.Files;
 import com.google.common.primitives.Longs;
 
+/**
+ * FilesystemStorageStrategyImpl implements a blob store that stores objects
+ * on the file system. Content metadata and user attributes are stored in
+ * extended attributes if the file system supports them. Directory blobs
+ * (blobs that end with a /) cannot have content, but otherwise appear in
+ * LIST like normal blobs.
+ */
 public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
 
    private static final String XATTR_CONTENT_DISPOSITION = "user.content-disposition";
@@ -76,6 +84,8 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
    private static final String XATTR_CONTENT_TYPE = "user.content-type";
    private static final String XATTR_EXPIRES = "user.expires";
    private static final String XATTR_USER_METADATA_PREFIX = "user.user-metadata.";
+   private static final byte[] DIRECTORY_MD5 =
+           Hashing.md5().hashBytes(new byte[0]).asBytes();
 
    private static final String BACK_SLASH = "\\";
 
@@ -167,7 +177,13 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
    public boolean blobExists(String container, String key) {
       filesystemContainerNameValidator.validate(container);
       filesystemBlobKeyValidator.validate(key);
-      return buildPathAndChecksIfFileExists(container, key);
+      try {
+         return buildPathAndChecksIfBlobExists(container, key);
+      } catch (IOException e) {
+         logger.error(e, "An error occurred while checking key %s in container %s",
+                 container, key);
+         throw Throwables.propagate(e);
+      }
    }
 
    /**
@@ -204,7 +220,14 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
       builder.name(key);
       File file = getFileForBlobKey(container, key);
       Path path = file.toPath();
-      ByteSource byteSource = Files.asByteSource(file);
+      ByteSource byteSource;
+
+      if (getDirectoryBlobSuffix(key) != null) {
+         logger.debug("%s - %s is a directory", container, key);
+         byteSource = ByteSource.empty();
+      } else {
+         byteSource = Files.asByteSource(file);
+      }
       try {
          String contentDisposition = null;
          String contentEncoding = null;
@@ -266,13 +289,57 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
       return blob;
    }
 
+   private void writeCommonMetadataAttr(UserDefinedFileAttributeView view, Blob blob) throws IOException {
+      ContentMetadata metadata = blob.getMetadata().getContentMetadata();
+      writeStringAttributeIfPresent(view, XATTR_CONTENT_DISPOSITION, metadata.getContentDisposition());
+      writeStringAttributeIfPresent(view, XATTR_CONTENT_ENCODING, metadata.getContentEncoding());
+      writeStringAttributeIfPresent(view, XATTR_CONTENT_LANGUAGE, metadata.getContentLanguage());
+      writeStringAttributeIfPresent(view, XATTR_CONTENT_TYPE, metadata.getContentType());
+      Date expires = metadata.getExpires();
+      if (expires != null) {
+         ByteBuffer buf = ByteBuffer.allocate(Longs.BYTES).putLong(expires.getTime());
+         buf.flip();
+         view.write(XATTR_EXPIRES, buf);
+      }
+      for (Map.Entry<String, String> entry : blob.getMetadata().getUserMetadata().entrySet()) {
+         writeStringAttributeIfPresent(view, XATTR_USER_METADATA_PREFIX + entry.getKey(), entry.getValue());
+      }
+   }
+
+   private String putDirectoryBlob(final String containerName, final Blob blob) throws IOException {
+      String blobKey = blob.getMetadata().getName();
+      ContentMetadata metadata = blob.getMetadata().getContentMetadata();
+      Long contentLength = metadata.getContentLength();
+      if (contentLength != null && contentLength != 0) {
+         throw new IllegalArgumentException(
+                 "Directory blob cannot have content: " + blobKey);
+      }
+      File outputFile = getFileForBlobKey(containerName, blobKey);
+      Path outputPath = outputFile.toPath();
+      if (!outputFile.isDirectory() && !outputFile.mkdirs()) {
+         throw new IOException("Unable to mkdir: " + outputPath);
+      }
+
+      UserDefinedFileAttributeView view = getUserDefinedFileAttributeView(outputPath);
+      if (view != null) {
+         view.write(XATTR_CONTENT_MD5, ByteBuffer.wrap(DIRECTORY_MD5));
+         writeCommonMetadataAttr(view, blob);
+      } else {
+         logger.warn("xattr not supported on %s", blobKey);
+      }
+
+      return base16().lowerCase().encode(DIRECTORY_MD5);
+   }
+
    @Override
    public String putBlob(final String containerName, final Blob blob) throws IOException {
       String blobKey = blob.getMetadata().getName();
       Payload payload = blob.getPayload();
-      ContentMetadata metadata = payload.getContentMetadata();
       filesystemContainerNameValidator.validate(containerName);
       filesystemBlobKeyValidator.validate(blobKey);
+      if (getDirectoryBlobSuffix(blobKey) != null) {
+         return putDirectoryBlob(containerName, blob);
+      }
       File outputFile = getFileForBlobKey(containerName, blobKey);
       Path outputPath = outputFile.toPath();
       HashingInputStream his = null;
@@ -292,19 +359,7 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
          if (getFileStore(outputPath).supportsFileAttributeView(UserDefinedFileAttributeView.class)) {
             UserDefinedFileAttributeView view = getFileAttributeView(outputPath, UserDefinedFileAttributeView.class);
             view.write(XATTR_CONTENT_MD5, ByteBuffer.wrap(actualHashCode.asBytes()));
-            writeStringAttributeIfPresent(view, XATTR_CONTENT_DISPOSITION, metadata.getContentDisposition());
-            writeStringAttributeIfPresent(view, XATTR_CONTENT_ENCODING, metadata.getContentEncoding());
-            writeStringAttributeIfPresent(view, XATTR_CONTENT_LANGUAGE, metadata.getContentLanguage());
-            writeStringAttributeIfPresent(view, XATTR_CONTENT_TYPE, metadata.getContentType());
-            Date expires = metadata.getExpires();
-            if (expires != null) {
-               ByteBuffer buf = ByteBuffer.allocate(Longs.BYTES).putLong(expires.getTime());
-               buf.flip();
-               view.write(XATTR_EXPIRES, buf);
-            }
-            for (Map.Entry<String, String> entry : blob.getMetadata().getUserMetadata().entrySet()) {
-               writeStringAttributeIfPresent(view, XATTR_USER_METADATA_PREFIX + entry.getKey(), entry.getValue());
-            }
+            writeCommonMetadataAttr(view, blob);
          }
          return base16().lowerCase().encode(actualHashCode.asBytes());
       } catch (IOException ex) {
@@ -328,7 +383,20 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
       logger.debug("Deleting blob %s", fileName);
       File fileToBeDeleted = new File(fileName);
       if (!fileToBeDeleted.delete()) {
-         logger.debug("Could not delete %s", fileToBeDeleted);
+         if (fileToBeDeleted.isDirectory()) {
+            try {
+               UserDefinedFileAttributeView view = getUserDefinedFileAttributeView(fileToBeDeleted.toPath());
+               if (view != null) {
+                  for (String s : view.list()) {
+                     view.delete(s);
+                  }
+               }
+            } catch (IOException e) {
+               logger.debug("Could not delete attributes from %s", fileToBeDeleted);
+            }
+         } else {
+            logger.debug("Could not delete %s", fileToBeDeleted);
+         }
       }
 
       // now examine if the key of the blob is a complex key (with a directory structure)
@@ -401,11 +469,43 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
 
    // ---------------------------------------------------------- Private methods
 
-   private boolean buildPathAndChecksIfFileExists(String... tokens) {
+   private boolean buildPathAndChecksIfBlobExists(String... tokens) throws IOException {
       String path = buildPathStartingFromBaseDir(tokens);
       File file = new File(path);
       boolean exists = file.exists() && file.isFile();
+      if (!exists && getDirectoryBlobSuffix(tokens[tokens.length - 1]) != null
+              && file.isDirectory()) {
+         UserDefinedFileAttributeView view = getUserDefinedFileAttributeView(file.toPath());
+         exists = view != null && view.list().contains(XATTR_CONTENT_MD5);
+      }
       return exists;
+   }
+
+   private static String getDirectoryBlobSuffix(String key) {
+      for (String suffix : BlobStoreConstants.DIRECTORY_SUFFIXES) {
+         if (key.endsWith(suffix)) {
+            return suffix;
+         }
+      }
+      return null;
+   }
+
+   private static String directoryBlobName(String key) {
+      String suffix = getDirectoryBlobSuffix(key);
+      if (suffix != null) {
+         if (!BlobStoreConstants.DIRECTORY_BLOB_SUFFIX.equals(suffix)) {
+            key = key.substring(0, key.lastIndexOf(suffix));
+         }
+         return key + BlobStoreConstants.DIRECTORY_BLOB_SUFFIX;
+      }
+      return null;
+   }
+
+   private UserDefinedFileAttributeView getUserDefinedFileAttributeView(Path path) throws IOException {
+      if (getFileStore(path).supportsFileAttributeView(UserDefinedFileAttributeView.class)) {
+         return getFileAttributeView(path, UserDefinedFileAttributeView.class);
+      }
+      return null;
    }
 
    /**
@@ -547,7 +647,7 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
          if (child.isFile()) {
             blobNames.add(function.apply(child.getAbsolutePath()));
          } else if (child.isDirectory()) {
-            blobNames.add(function.apply(child.getAbsolutePath()));
+            blobNames.add(function.apply(child.getAbsolutePath()) + File.separator);
             populateBlobKeysInContainer(child, blobNames, function);
          }
       }
@@ -592,5 +692,9 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
       if (value != null) {
          view.write(name, ByteBuffer.wrap(value.getBytes(StandardCharsets.UTF_8)));
       }
+   }
+
+   private static void copyStringAttributeIfPresent(UserDefinedFileAttributeView view, String name, Map<String, String> attrs) throws IOException {
+      writeStringAttributeIfPresent(view, name, attrs.get(name));
    }
 }

--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/FilesystemBlobStoreTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/FilesystemBlobStoreTest.java
@@ -58,6 +58,7 @@ import org.jclouds.util.Closeables2;
 import org.jclouds.util.Strings2;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Sets;
@@ -461,7 +462,7 @@ public class FilesystemBlobStoreTest {
         putBlobAndCheckIt(TestUtils.createRandomBlobKey("putBlob-", ".jpg"));
     }
 
-    @Test
+    @Test(dataProvider = "ignoreOnMacOSX")
     public void testPutDirectoryBlobs() {
         blobStore.createContainerInLocation(null, CONTAINER_NAME);
 
@@ -478,7 +479,7 @@ public class FilesystemBlobStoreTest {
         assertTrue(blobStore.blobExists(CONTAINER_NAME, childKey));
     }
 
-    @Test
+    @Test(dataProvider = "ignoreOnMacOSX")
     public void testGetDirectoryBlob() throws IOException {
         blobStore.createContainerInLocation(null, CONTAINER_NAME);
 
@@ -494,7 +495,7 @@ public class FilesystemBlobStoreTest {
                 blobKey.substring(0, blobKey.length() - 1)));
     }
 
-
+    @Test(dataProvider = "ignoreOnMacOSX")
     public void testListDirectoryBlobs() {
         blobStore.createContainerInLocation(null, CONTAINER_NAME);
         checkForContainerContent(CONTAINER_NAME, null);
@@ -869,4 +870,9 @@ public class FilesystemBlobStoreTest {
         TestUtils.fileExists(TARGET_CONTAINER_NAME + File.separator + blobKey, true);
     }
 
+    @DataProvider
+    public Object[][] ignoreOnMacOSX() {
+        return org.jclouds.utils.TestUtils.isMacOSX() ? TestUtils.NO_INVOCATIONS
+                : TestUtils.SINGLE_NO_ARG_INVOCATION;
+    }
 }

--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/predicates/validators/internal/FilesystemBlobKeyValidatorTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/predicates/validators/internal/FilesystemBlobKeyValidatorTest.java
@@ -51,11 +51,6 @@ public class FilesystemBlobKeyValidatorTest {
             validator.validate(File.separator + "is" + File.separator + "" + "ok");
             fail("Blob key value incorrect, but was not recognized");
         } catch (IllegalArgumentException e) {}
-
-        try {
-            validator.validate("all" + File.separator + "is" + File.separator);
-            fail("Blob key value incorrect, but was not recognized");
-        } catch (IllegalArgumentException e) {}
     }
 
 

--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImplTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImplTest.java
@@ -341,6 +341,64 @@ public class FilesystemStorageStrategyImplTest {
       assertEquals(newBlob.getMetadata().getName(), blobKey, "Created blob name is different");
    }
 
+   public void testWriteDirectoryBlob() throws IOException {
+      String blobKey = TestUtils.createRandomBlobKey("a/b/c/directory-", File.separator);
+      Blob blob = storageStrategy.newBlob(blobKey);
+      storageStrategy.putBlob(CONTAINER_NAME, blob);
+      // verify that the files is equal
+      File blobFullPath = new File(TARGET_CONTAINER_NAME, blobKey);
+      assertTrue(blobFullPath.isDirectory());
+
+      assertTrue(storageStrategy.blobExists(CONTAINER_NAME, blobKey));
+   }
+
+   public void testGetDirectoryBlob() throws IOException {
+      String blobKey = TestUtils.createRandomBlobKey("a/b/c/directory-", File.separator);
+      Blob blob = storageStrategy.newBlob(blobKey);
+      storageStrategy.putBlob(CONTAINER_NAME, blob);
+
+      assertTrue(storageStrategy.blobExists(CONTAINER_NAME, blobKey));
+
+      blob = storageStrategy.getBlob(CONTAINER_NAME, blobKey);
+      assertEquals(blob.getMetadata().getName(), blobKey, "Created blob name is different");
+
+      assertTrue(!storageStrategy.blobExists(CONTAINER_NAME,
+              blobKey.substring(0, blobKey.length() - 1)));
+   }
+
+   public void testListDirectoryBlob() throws IOException {
+      String blobKey = TestUtils.createRandomBlobKey("directory-", File.separator);
+      Blob blob = storageStrategy.newBlob(blobKey);
+      storageStrategy.putBlob(CONTAINER_NAME, blob);
+
+      Iterable<String> keys = storageStrategy.getBlobKeysInsideContainer(CONTAINER_NAME);
+      Iterator<String> iter = keys.iterator();
+      assertTrue(iter.hasNext());
+      assertEquals(iter.next(), blobKey);
+      assertFalse(iter.hasNext());
+   }
+
+   public void testDeleteDirectoryBlob() throws IOException {
+      String blobKey = TestUtils.createRandomBlobKey("a/b/c/directory-", File.separator);
+      Blob blob = storageStrategy.newBlob(blobKey);
+      storageStrategy.putBlob(CONTAINER_NAME, blob);
+      File blobFullPath = new File(TARGET_CONTAINER_NAME, blobKey);
+      assertTrue(blobFullPath.isDirectory());
+
+      storageStrategy.removeBlob(CONTAINER_NAME, blobKey);
+   }
+
+   public void testDeleteIntermediateDirectoryBlob() throws IOException {
+      String parentKey = TestUtils.createRandomBlobKey("a/b/c/directory-", File.separator);
+      String childKey = TestUtils.createRandomBlobKey(parentKey + "directory-", File.separator);
+      storageStrategy.putBlob(CONTAINER_NAME, storageStrategy.newBlob(parentKey));
+      storageStrategy.putBlob(CONTAINER_NAME, storageStrategy.newBlob(childKey));
+
+      storageStrategy.removeBlob(CONTAINER_NAME, parentKey);
+      assertFalse(storageStrategy.blobExists(CONTAINER_NAME, parentKey));
+      assertTrue(storageStrategy.blobExists(CONTAINER_NAME, childKey));
+   }
+
    public void testWritePayloadOnFile() throws IOException {
       String blobKey = TestUtils.createRandomBlobKey("writePayload-", ".img");
       File sourceFile = TestUtils.getImageForBlobPayload();

--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImplTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImplTest.java
@@ -48,6 +48,7 @@ import org.jclouds.util.Throwables2;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.SkipException;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -341,6 +342,7 @@ public class FilesystemStorageStrategyImplTest {
       assertEquals(newBlob.getMetadata().getName(), blobKey, "Created blob name is different");
    }
 
+   @Test(dataProvider = "ignoreOnMacOSX")
    public void testWriteDirectoryBlob() throws IOException {
       String blobKey = TestUtils.createRandomBlobKey("a/b/c/directory-", File.separator);
       Blob blob = storageStrategy.newBlob(blobKey);
@@ -352,11 +354,11 @@ public class FilesystemStorageStrategyImplTest {
       assertTrue(storageStrategy.blobExists(CONTAINER_NAME, blobKey));
    }
 
+   @Test(dataProvider = "ignoreOnMacOSX")
    public void testGetDirectoryBlob() throws IOException {
       String blobKey = TestUtils.createRandomBlobKey("a/b/c/directory-", File.separator);
       Blob blob = storageStrategy.newBlob(blobKey);
       storageStrategy.putBlob(CONTAINER_NAME, blob);
-
       assertTrue(storageStrategy.blobExists(CONTAINER_NAME, blobKey));
 
       blob = storageStrategy.getBlob(CONTAINER_NAME, blobKey);
@@ -388,6 +390,7 @@ public class FilesystemStorageStrategyImplTest {
       storageStrategy.removeBlob(CONTAINER_NAME, blobKey);
    }
 
+   @Test(dataProvider = "ignoreOnMacOSX")
    public void testDeleteIntermediateDirectoryBlob() throws IOException {
       String parentKey = TestUtils.createRandomBlobKey("a/b/c/directory-", File.separator);
       String childKey = TestUtils.createRandomBlobKey(parentKey + "directory-", File.separator);
@@ -396,6 +399,7 @@ public class FilesystemStorageStrategyImplTest {
 
       storageStrategy.removeBlob(CONTAINER_NAME, parentKey);
       assertFalse(storageStrategy.blobExists(CONTAINER_NAME, parentKey));
+
       assertTrue(storageStrategy.blobExists(CONTAINER_NAME, childKey));
    }
 
@@ -629,4 +633,9 @@ public class FilesystemStorageStrategyImplTest {
       return tempAbsolutePath;
    }
 
+   @DataProvider
+   public Object[][] ignoreOnMacOSX() {
+        return org.jclouds.utils.TestUtils.isMacOSX() ? TestUtils.NO_INVOCATIONS
+                : TestUtils.SINGLE_NO_ARG_INVOCATION;
+   }
 }

--- a/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
@@ -28,6 +28,7 @@ import static com.google.common.collect.Sets.newTreeSet;
 import static org.jclouds.blobstore.options.ListContainerOptions.Builder.recursive;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.util.Date;
 import java.util.Set;
@@ -46,7 +47,6 @@ import org.jclouds.blobstore.LocalStorageStrategy;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobBuilder;
 import org.jclouds.blobstore.domain.BlobMetadata;
-import org.jclouds.blobstore.domain.MutableBlobMetadata;
 import org.jclouds.blobstore.domain.MutableStorageMetadata;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
@@ -58,7 +58,6 @@ import org.jclouds.blobstore.options.CreateContainerOptions;
 import org.jclouds.blobstore.options.GetOptions;
 import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.blobstore.options.PutOptions;
-import org.jclouds.blobstore.strategy.IfDirectoryReturnNameStrategy;
 import org.jclouds.blobstore.util.BlobStoreUtils;
 import org.jclouds.blobstore.util.BlobUtils;
 import org.jclouds.collect.Memoized;
@@ -90,7 +89,6 @@ public final class LocalBlobStore implements BlobStore {
    private final BlobUtils blobUtils;
    private final Supplier<Set<? extends Location>> locations;
    private final ContentMetadataCodec contentMetadataCodec;
-   private final IfDirectoryReturnNameStrategy ifDirectoryReturnName;
    private final Blob.Factory blobFactory;
    private final LocalStorageStrategy storageStrategy;
 
@@ -99,14 +97,12 @@ public final class LocalBlobStore implements BlobStore {
          BlobUtils blobUtils,
          @Memoized Supplier<Set<? extends Location>> locations,
          ContentMetadataCodec contentMetadataCodec,
-         IfDirectoryReturnNameStrategy ifDirectoryReturnName,
          Blob.Factory blobFactory, LocalStorageStrategy storageStrategy) {
       this.context = checkNotNull(context, "context");
       this.blobUtils = checkNotNull(blobUtils, "blobUtils");
       this.locations = checkNotNull(locations, "locations");
       this.blobFactory = blobFactory;
       this.contentMetadataCodec = contentMetadataCodec;
-      this.ifDirectoryReturnName = ifDirectoryReturnName;
       this.storageStrategy = storageStrategy;
    }
 
@@ -227,13 +223,7 @@ public final class LocalBlobStore implements BlobStore {
                   checkState(oldBlob != null, "blob " + key + " is not present although it was in the list of "
                         + containerName);
                   checkState(oldBlob.getMetadata() != null, "blob " + containerName + "/" + key + " has no metadata");
-                  MutableBlobMetadata md = BlobStoreUtils.copy(oldBlob.getMetadata());
-                  String directoryName = ifDirectoryReturnName.execute(md);
-                  if (directoryName != null) {
-                     md.setName(directoryName);
-                     md.setType(StorageType.RELATIVE_PATH);
-                  }
-                  return md;
+                  return BlobStoreUtils.copy(oldBlob.getMetadata());
                }
             }));
 
@@ -250,10 +240,13 @@ public final class LocalBlobStore implements BlobStore {
          }
 
          final String prefix = options.getDir();
-         if (prefix != null) {
+         if (prefix != null && !prefix.isEmpty()) {
+            final String dirPrefix = prefix.endsWith(File.separator) ?
+                    prefix :
+                    prefix + File.separator;
             contents = newTreeSet(filter(contents, new Predicate<StorageMetadata>() {
                public boolean apply(StorageMetadata o) {
-                  return o != null && o.getName().startsWith(prefix) && !o.getName().equals(prefix);
+                  return o != null && o.getName().startsWith(dirPrefix) && !o.getName().equals(dirPrefix);
                }
             }));
          }

--- a/blobstore/src/main/java/org/jclouds/blobstore/reference/BlobStoreConstants.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/reference/BlobStoreConstants.java
@@ -54,6 +54,7 @@ public final class BlobStoreConstants {
    public static final String PROPERTY_USER_METADATA_PREFIX = "jclouds.blobstore.metaprefix";
 
    public static final String BLOBSTORE_LOGGER = "jclouds.blobstore";
+   public static final String DIRECTORY_BLOB_SUFFIX = "/";
 
    private BlobStoreConstants() {
       throw new AssertionError("intentionally unimplemented");


### PR DESCRIPTION
On OS X, java doesn't support xattrs, which is required by
directory blobs. Disable those tests on OS X

should fix @jdaggett 's problem with #637 