### PR TITLE
Update okhttp to version 2.2.0

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -206,7 +206,7 @@
     <maven.site.url.base>gitsite:git@github.com/jclouds/jclouds-maven-site.git</maven.site.url.base>
     <clojure.version>1.3.0</clojure.version>
     <guava.version>16.0.1</guava.version>
-    <okhttp.version>2.1.0</okhttp.version>
+    <okhttp.version>2.2.0</okhttp.version>
     <surefire.version>2.17</surefire.version>
     <assertj-core.version>1.7.0</assertj-core.version>
     <assertj-guava.version>1.3.0</assertj-guava.version>


### PR DESCRIPTION
This PR updates the `okhttp` dependency to version **2.2.0**.

There are quite a number of [fixes](https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-220) in this release. For APIs that require this dependency, the new [interceptors](https://github.com/square/okhttp/wiki/Interceptors) could prove to be a very useful feature.