### PR TITLE
Update AutoValue to version 1.0

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -212,7 +212,7 @@
     <assertj-guava.version>1.3.0</assertj-guava.version>
     <auto-factory.version>0.1-beta1</auto-factory.version>
     <auto-service.version>1.0-rc2</auto-service.version>
-    <auto-value.version>1.0-rc2</auto-value.version>
+    <auto-value.version>1.0</auto-value.version>
     <http.proxyHost />
     <http.proxyPort />
     <jclouds.wire.httpstream.url>http://archive.apache.org/dist/commons/logging/binaries/commons-logging-1.1.1-bin.tar.gz</jclouds.wire.httpstream.url>


### PR DESCRIPTION
AutoValue was [updated](https://github.com/google/auto/commit/c36dbb535c905fb2cdbfa2755f25241d90dbd9c4) to version 1.0 recently!  This PR is pretty self-explainatory :smile: 

**NOTE:** Downstream repositories broke when making this change initially. I submitted [PR 122](https://github.com/jclouds/jclouds-labs/pull/122) in `jclouds-labs` and [PR 123](https://github.com/jclouds/jclouds-labs-google/pull/123) in `jclouds-labs-google` to split out the dependencies into `auto-service` and `auto-value`.  They will need to be committed _prior_ to merging this PR!