### PR TITLE
Add Rackspace CDN service type

### DIFF
--- a/apis/rackspace-cloudidentity/src/main/java/org/jclouds/rackspace/cloudidentity/v2_0/ServiceType.java
+++ b/apis/rackspace-cloudidentity/src/main/java/org/jclouds/rackspace/cloudidentity/v2_0/ServiceType.java
@@ -66,6 +66,11 @@ public final class ServiceType {
     */
    public static final String BIG_DATA = "rax:bigdata";
 
+   /**
+    * CDN
+    */
+   public static final String CDN = "rax:cdn";
+
    private ServiceType() {
       throw new AssertionError("intentionally unimplemented");
    }


### PR DESCRIPTION
This PR adds the Early Access Rackspace CDN service `rax:cdn` to the known service types that can be returned in the Cloud Identity Service Catalog.  For additional info on the CDN service, please refer to the [docs](http://docs.rackspace.com/cdn/api/v1.0/cdn-devguide/content/Overview.html).