### PR TITLE
fix usermetadata check on OS X

### DIFF
--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/integration/FilesystemBlobIntegrationTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/integration/FilesystemBlobIntegrationTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.filesystem.integration;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Properties;
 
 import org.jclouds.blobstore.domain.Blob;
@@ -75,4 +76,14 @@ public class FilesystemBlobIntegrationTest extends BaseBlobIntegrationTest {
    public void testCreateBlobWithExpiry() throws InterruptedException {
       super.testCreateBlobWithExpiry();
    }
+
+   /* Java on OS X does not support extended attributes, which the filesystem backend
+    * uses to implement user metadata */
+   @Override
+   protected void checkUserMetadata(Map<String, String> userMetadata1, Map<String, String> userMetadata2) {
+      if (!org.jclouds.utils.TestUtils.isMacOSX()) {
+         super.checkUserMetadata(userMetadata1, userMetadata2);
+      }
+   }
+
 }

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
@@ -555,6 +555,10 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
       testPut(payload, new ByteSourcePayload(byteSource), length, new PutOptions().multipart(true));
    }
 
+   protected void checkUserMetadata(Map<String, String> userMetadata1, Map<String, String> userMetadata2) {
+      assertThat(userMetadata1).isEqualTo(userMetadata2);
+   }
+
    private void testPut(Payload payload, Payload expectedPayload, long length, PutOptions options)
          throws IOException, InterruptedException {
       BlobStore blobStore = view.getBlobStore();
@@ -581,10 +585,10 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
          }
          validateMetadata(blob.getMetadata(), container, blob.getMetadata().getName());
          checkContentMetadata(blob);
-         assertThat(blob.getMetadata().getUserMetadata()).isEqualTo(userMetadata);
-
          PageSet<? extends StorageMetadata> set = blobStore.list(container);
          assertThat(set).hasSize(1);
+
+         checkUserMetadata(blob.getMetadata().getUserMetadata(), userMetadata);
       } finally {
          returnContainer(container);
       }


### PR DESCRIPTION
Java on OS X does not support extended attributes, which the
filesystem blobstore uses to implement user metadata. This disable
the relevant test on OS X