### PR TITLE
JCLOUDS-794: Use bogus URL for generic S3 endpoint

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/S3ApiMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/S3ApiMetadata.java
@@ -94,7 +94,7 @@ public class S3ApiMetadata extends BaseHttpApiMetadata {
          .name("Amazon Simple Storage Service (S3) API")
          .identityName("Access Key ID")
          .credentialName("Secret Access Key")
-         .defaultEndpoint("https://s3.amazonaws.com")
+         .defaultEndpoint("http://localhost")
          .documentation(URI.create("http://docs.amazonwebservices.com/AmazonS3/latest/API"))
          .version("2006-03-01")
          .defaultProperties(S3ApiMetadata.defaultProperties())

--- a/apis/s3/src/test/java/org/jclouds/s3/PathBasedS3ClientExpectTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/PathBasedS3ClientExpectTest.java
@@ -43,7 +43,7 @@ public class PathBasedS3ClientExpectTest extends BaseS3ClientExpectTest {
    public void testBucketExistsReturnsTrueOn200AndFalseOn404() {
       
       HttpRequest bucketFooExists = HttpRequest.builder().method("HEAD")
-                                               .endpoint("https://s3.amazonaws.com/foo")
+                                               .endpoint("http://localhost/foo")
                                                .addHeader("Date", CONSTANT_DATE)
                                                .addHeader("Authorization", "AWS identity:lLD0mzo2bZPIWhxlFDZoT09MKUQ=")
                                                .build();
@@ -60,7 +60,7 @@ public class PathBasedS3ClientExpectTest extends BaseS3ClientExpectTest {
    public void testPutBucketReturnsTrueOn200() {
       
       HttpRequest bucketFooExists = HttpRequest.builder().method("PUT")
-                                               .endpoint("https://s3.amazonaws.com/foo")
+                                               .endpoint("http://localhost/foo")
                                                .addHeader("Date", CONSTANT_DATE)
                                                .addHeader("Authorization", "AWS identity:GeP4OqEL/eM+gQt+4Vtcm02gebc=")
                                                .build();
@@ -75,7 +75,7 @@ public class PathBasedS3ClientExpectTest extends BaseS3ClientExpectTest {
    public void testPutObjectReturnsETagOn200() {
       
       HttpRequest bucketFooExists = HttpRequest.builder().method("PUT")
-                                               .endpoint("https://s3.amazonaws.com/bucket/object")
+                                               .endpoint("http://localhost/bucket/object")
                                                .addHeader("Expect", "100-continue")
                                                .addHeader("Date", CONSTANT_DATE)
                                                .addHeader("Authorization", "AWS identity:6gC0m7SYFDPwkUqY5EHV/6i9DfM=")

--- a/apis/s3/src/test/java/org/jclouds/s3/S3ClientExpectTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/S3ClientExpectTest.java
@@ -32,7 +32,7 @@ public class S3ClientExpectTest extends BaseS3ClientExpectTest {
    public void testBucketExistsReturnsTrueOn200AndFalseOn404() {
       
       HttpRequest bucketFooExists = HttpRequest.builder().method("HEAD").endpoint(
-               URI.create("https://s3.amazonaws.com/foo")).headers(
+               URI.create("http://localhost/foo")).headers(
                ImmutableMultimap.<String, String> builder()
                   .put("Date", CONSTANT_DATE)
                   .put("Authorization", "AWS identity:lLD0mzo2bZPIWhxlFDZoT09MKUQ=")

--- a/apis/s3/src/test/java/org/jclouds/s3/binders/BindAsHostPrefixIfConfiguredNoPathTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/binders/BindAsHostPrefixIfConfiguredNoPathTest.java
@@ -40,7 +40,7 @@ public class BindAsHostPrefixIfConfiguredNoPathTest extends BaseS3ClientTest<S3C
 
       Invokable<?, ?> method = method(S3Client.class, "deleteObject", String.class, String.class);
       GeneratedHttpRequest request = processor.createRequest(method, ImmutableList.<Object> of("testbucket.example.com", "test.jpg"));
-      assertRequestLineEquals(request, "DELETE https://s3.amazonaws.com/testbucket.example.com/test.jpg HTTP/1.1");
+      assertRequestLineEquals(request, "DELETE http://localhost/testbucket.example.com/test.jpg HTTP/1.1");
    }
 
 

--- a/apis/s3/src/test/java/org/jclouds/s3/blobstore/S3BlobSignerExpectTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/blobstore/S3BlobSignerExpectTest.java
@@ -41,7 +41,7 @@ public class S3BlobSignerExpectTest extends BaseBlobSignerExpectTest {
    @Override
    protected HttpRequest getBlob() {
       return HttpRequest.builder().method("GET")
-                        .endpoint("https://s3.amazonaws.com/container/name")
+                        .endpoint("http://localhost/container/name")
                         .addHeader("Date", "Thu, 05 Jun 2008 16:38:19 GMT")
                         .addHeader("Authorization", "AWS identity:0uvBv1wEskuhFHYJF/L6kEV9A7o=").build();
    }
@@ -56,7 +56,7 @@ public class S3BlobSignerExpectTest extends BaseBlobSignerExpectTest {
    @Override
    protected HttpRequest getBlobWithTime() {
       return HttpRequest.builder().method("GET")
-            .endpoint("https://s3.amazonaws.com/container/name")
+            .endpoint("http://locahost/container/name")
             .addHeader("Date", "Thu, 05 Jun 2008 16:38:19 GMT")
             .addHeader("Authorization", "AWS identity:0uvBv1wEskuhFHYJF/L6kEV9A7o=").build();
    }
@@ -64,7 +64,7 @@ public class S3BlobSignerExpectTest extends BaseBlobSignerExpectTest {
    @Override
    protected HttpRequest getBlobWithOptions() {
       return HttpRequest.builder().method("GET")
-            .endpoint("https://s3.amazonaws.com/container/name")
+            .endpoint("http://localhost/container/name")
             .addHeader("Range", "bytes=0-1")
             .addHeader("Date", "Thu, 05 Jun 2008 16:38:19 GMT")
             .addHeader("Authorization", "AWS identity:0uvBv1wEskuhFHYJF/L6kEV9A7o=").build();
@@ -73,7 +73,7 @@ public class S3BlobSignerExpectTest extends BaseBlobSignerExpectTest {
    @Override
    protected HttpRequest putBlob() {
       return HttpRequest.builder().method("PUT")
-            .endpoint("https://s3.amazonaws.com/container/name")
+            .endpoint("http://localhost/container/name")
             .addHeader("Expect", "100-continue")
             .addHeader("Date", "Thu, 05 Jun 2008 16:38:19 GMT")
             .addHeader("Authorization", "AWS identity:zM2oT+71KcoOSxv1SU5L12UXnT8=").build();
@@ -89,7 +89,7 @@ public class S3BlobSignerExpectTest extends BaseBlobSignerExpectTest {
    @Override
    protected HttpRequest putBlobWithTime() {
       return HttpRequest.builder().method("PUT")
-            .endpoint("https://s3.amazonaws.com/container/name")
+            .endpoint("http://localhost/container/name")
             .addHeader("Expect", "100-continue")
             .addHeader("Date", "Thu, 05 Jun 2008 16:38:19 GMT")
             .addHeader("Authorization", "AWS identity:zM2oT+71KcoOSxv1SU5L12UXnT8=").build();
@@ -98,7 +98,7 @@ public class S3BlobSignerExpectTest extends BaseBlobSignerExpectTest {
    @Override
    protected HttpRequest removeBlob() {
       return HttpRequest.builder().method("DELETE")
-            .endpoint("https://s3.amazonaws.com/container/name")
+            .endpoint("http://localhost/container/name")
             .addHeader("Date", "Thu, 05 Jun 2008 16:38:19 GMT")
             .addHeader("Authorization", "AWS identity:4FnyjdX/ULdDMRbVlLNjZfEo9RQ=").build();
    }

--- a/apis/s3/src/test/java/org/jclouds/s3/filters/RequestAuthorizeSignatureTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/filters/RequestAuthorizeSignatureTest.java
@@ -144,7 +144,7 @@ public class RequestAuthorizeSignatureTest extends BaseS3ClientTest<S3Client> {
             method(S3Client.class, "getBucketLocation", String.class),
             ImmutableList.<Object> of(bucketName));
       URI uri = request.getEndpoint();
-      assertEquals(uri.getHost(), "s3.amazonaws.com");
+      assertEquals(uri.getHost(), "localhost");
       assertEquals(uri.getPath(), "/" + bucketName);
    }
 

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3ApiMetadata.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3ApiMetadata.java
@@ -58,6 +58,7 @@ public class AWSS3ApiMetadata extends S3ApiMetadata {
          super(AWSS3Client.class);
          id("aws-s3")
          .name("Amazon-specific S3 API")
+         .defaultEndpoint("https://s3.amazonaws.com")
          .defaultProperties(AWSS3ApiMetadata.defaultProperties())
          .view(typeToken(AWSS3BlobStoreContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>>of(AWSS3HttpApiModule.class, AWSS3BlobStoreContextModule.class));


### PR DESCRIPTION
This prevents users from accidentally connecting to AWS.