### PR TITLE
Added support for RunInstances parameter PrivateIpAddress on EC2

### DIFF
--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/AWSEC2TemplateOptions.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/AWSEC2TemplateOptions.java
@@ -85,6 +85,8 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
             eTo.spotPrice(getSpotPrice());
          if (getSpotOptions() != null)
             eTo.spotOptions(getSpotOptions());
+         if (getPrivateIpAddress() != null)
+            eTo.privateIpAddress(getPrivateIpAddress());
       }
    }
 
@@ -97,6 +99,7 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
    private Set<String> groupIds = ImmutableSet.of();
    private String iamInstanceProfileArn;
    private String iamInstanceProfileName;
+   private String privateIpAddress;
 
    @Override
    public boolean equals(Object o) {
@@ -110,13 +113,14 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
                && equal(this.noPlacementGroup, that.noPlacementGroup) && equal(this.subnetId, that.subnetId)
                && equal(this.spotPrice, that.spotPrice) && equal(this.spotOptions, that.spotOptions)
                && equal(this.groupIds, that.groupIds) && equal(this.iamInstanceProfileArn, that.iamInstanceProfileArn)
-               && equal(this.iamInstanceProfileName, that.iamInstanceProfileName);
+               && equal(this.iamInstanceProfileName, that.iamInstanceProfileName)
+               && equal(this.privateIpAddress, that.privateIpAddress);
    }
 
    @Override
    public int hashCode() {
       return Objects.hashCode(super.hashCode(), monitoringEnabled, placementGroup, noPlacementGroup, subnetId,
-               spotPrice, spotOptions, groupIds, iamInstanceProfileArn, iamInstanceProfileName);
+               spotPrice, spotOptions, groupIds, iamInstanceProfileArn, iamInstanceProfileName, privateIpAddress);
    }
 
    @Override
@@ -135,6 +139,7 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
          toString.add("groupIds", groupIds);
       toString.add("iamInstanceProfileArn", iamInstanceProfileArn);
       toString.add("iamInstanceProfileName", iamInstanceProfileName);
+      toString.add("privateIpAddress", privateIpAddress);
       return toString;
    }
 
@@ -192,6 +197,11 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
    @SinceApiVersion("2012-06-01")
    public AWSEC2TemplateOptions iamInstanceProfileName(String name) {
       this.iamInstanceProfileName = checkNotNull(emptyToNull(name), "name must be defined");
+      return this;
+   }
+
+   public AWSEC2TemplateOptions privateIpAddress(String address) {
+      this.privateIpAddress = checkNotNull(emptyToNull(address), "address must be defined");
       return this;
    }
 
@@ -440,6 +450,11 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
       public static AWSEC2TemplateOptions iamInstanceProfileName(String name) {
          AWSEC2TemplateOptions options = new AWSEC2TemplateOptions();
          return options.iamInstanceProfileName(name);
+      }
+
+      public static AWSEC2TemplateOptions privateIpAddress(String address) {
+         AWSEC2TemplateOptions options = new AWSEC2TemplateOptions();
+         return options.privateIpAddress(address);
       }
 
       /**
@@ -787,5 +802,9 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
    @SinceApiVersion("2012-06-01")
    public String getIAMInstanceProfileName() {
       return iamInstanceProfileName;
+   }
+
+   public String getPrivateIpAddress() {
+      return privateIpAddress;
    }
 }

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/strategy/CreateKeyPairPlacementAndSecurityGroupsAsNeededAndReturnRunOptions.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/strategy/CreateKeyPairPlacementAndSecurityGroupsAsNeededAndReturnRunOptions.java
@@ -92,6 +92,8 @@ public class CreateKeyPairPlacementAndSecurityGroupsAsNeededAndReturnRunOptions 
          instanceOptions.withIAMInstanceProfileArn(awsTemplateOptions.getIAMInstanceProfileArn());
       if (awsTemplateOptions.getIAMInstanceProfileName() != null)
          instanceOptions.withIAMInstanceProfileName(awsTemplateOptions.getIAMInstanceProfileName());
+      if (awsTemplateOptions.getPrivateIpAddress() != null)
+         instanceOptions.withPrivateIpAddress(awsTemplateOptions.getPrivateIpAddress());
 
       return instanceOptions;
    }

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/options/AWSRunInstancesOptions.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/options/AWSRunInstancesOptions.java
@@ -114,6 +114,16 @@ public class AWSRunInstancesOptions extends RunInstancesOptions {
       return this;
    }
 
+   /**
+    * The primary IP address for VPC instance. You must specify a value from the IP address range of the subnet.
+    *
+    * @see org.jclouds.aws.ec2.domain.AWSRunningInstance#getPrivateIpAddress()
+    */
+   public AWSRunInstancesOptions withPrivateIpAddress(String address) {
+      formParameters.put("PrivateIpAddress", checkNotNull(address, "address"));
+      return this;
+   }
+
    public static class Builder extends RunInstancesOptions.Builder {
 
       /**
@@ -218,6 +228,14 @@ public class AWSRunInstancesOptions extends RunInstancesOptions {
       public static AWSRunInstancesOptions withBlockDeviceMappings(Set<? extends BlockDeviceMapping> mappings) {
          AWSRunInstancesOptions options = new AWSRunInstancesOptions();
          return options.withBlockDeviceMappings(mappings);
+      }
+
+      /**
+       * @see AWSRunInstancesOptions#withPrivateIpAddress(String)
+       */
+      public static AWSRunInstancesOptions withPrivateIpAdress(String address) {
+         AWSRunInstancesOptions options = new AWSRunInstancesOptions();
+         return options.withPrivateIpAddress(address);
       }
 
    }

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/options/AWSEC2TemplateOptionsTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/options/AWSEC2TemplateOptionsTest.java
@@ -25,6 +25,7 @@ import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.inboundP
 import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.installPrivateKey;
 import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.keyPair;
 import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.noKeyPair;
+import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.privateIpAddress;
 import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.securityGroupIds;
 import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.securityGroups;
 import static org.testng.Assert.assertEquals;
@@ -412,5 +413,16 @@ public class AWSEC2TemplateOptionsTest {
    @Test(expectedExceptions = NullPointerException.class)
    public void testIAMInstanceProfileNameNPE() {
       iamInstanceProfileName(null);
+   }
+
+   @Test
+   public void testPrivateIpAddressStatic() {
+      AWSEC2TemplateOptions options = privateIpAddress("10.0.0.1");
+      assertEquals(options.getPrivateIpAddress(), "10.0.0.1");
+   }
+
+   @Test(expectedExceptions = NullPointerException.class)
+   public void testPrivateIpAddressNPE() {
+      privateIpAddress(null);
    }
 }

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/options/AWSRunInstancesOptionsTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/options/AWSRunInstancesOptionsTest.java
@@ -23,6 +23,7 @@ import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withIAM
 import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withIAMInstanceProfileName;
 import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withKernelId;
 import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withKeyName;
+import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withPrivateIpAdress;
 import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withRamdisk;
 import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withSecurityGroup;
 import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withSecurityGroupId;
@@ -369,6 +370,17 @@ public class AWSRunInstancesOptionsTest {
    @Test(expectedExceptions = NullPointerException.class)
    public void testWithBlockDeviceMappingNPE() {
       withBlockDeviceMappings(null);
+   }
+
+   @Test
+   public void testWithPrivateIpAddressStatic() {
+      AWSRunInstancesOptions options = withPrivateIpAdress("10.0.0.1");
+      assertEquals(options.buildFormParameters().get("PrivateIpAddress"), ImmutableList.of("10.0.0.1"));
+   }
+
+   @Test(expectedExceptions = NullPointerException.class)
+   public void testWithPrivateIpAddressStaticNPE() {
+      withPrivateIpAdress(null);
    }
 
 }


### PR DESCRIPTION
According to [docs](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html):

> PrivateIpAddress
>
> [EC2-VPC] The primary IP address. You must specify a value from the IP address range of the subnet.
> Only one private IP address can be designated as primary. Therefore, you can't specify this parameter if PrivateIpAddresses.n.Primary is set to true and PrivateIpAddresses.n.PrivateIpAddress is set to an IP address.
>
> Default: We select an IP address from the IP address range of the subnet.
> Type: String
> Required: No