### PR TITLE
JCLOUDS-660: Improve container ACL support

### DIFF
--- a/apis/atmos/src/main/java/org/jclouds/atmos/AtmosClient.java
+++ b/apis/atmos/src/main/java/org/jclouds/atmos/AtmosClient.java
@@ -175,4 +175,12 @@ public interface AtmosClient extends Closeable {
    @Fallback(FalseOnNotFoundOr404.class)
    boolean isPublic(@PathParam("path") String path);
 
+   @Named("SetObjectMetadata")
+   @POST
+   @Path("/{path}")
+   @QueryParams(keys = "acl")
+   @Produces(MediaType.APPLICATION_OCTET_STREAM)
+   @Fallback(ThrowKeyNotFoundOn404.class)
+   @Consumes(MediaType.WILDCARD)
+   void setGroupAcl(@PathParam("path") String path, PutOptions options);
 }

--- a/apis/atmos/src/main/java/org/jclouds/atmos/blobstore/AtmosBlobStore.java
+++ b/apis/atmos/src/main/java/org/jclouds/atmos/blobstore/AtmosBlobStore.java
@@ -36,6 +36,7 @@ import org.jclouds.atmos.util.AtmosUtils;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobMetadata;
+import org.jclouds.blobstore.domain.ContainerAccess;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.functions.BlobToHttpGetOptions;
@@ -116,6 +117,26 @@ public class AtmosBlobStore extends BaseBlobStore {
    @Override
    public boolean createContainerInLocation(Location location, String container) {
       return sync.createDirectory(container) != null;
+   }
+
+   @Override
+   public ContainerAccess getContainerAccess(String container) {
+      if (sync.isPublic(container)) {
+         return ContainerAccess.PUBLIC_READ;
+      } else {
+         return ContainerAccess.PRIVATE;
+      }
+   }
+
+   @Override
+   public void setContainerAccess(String container, ContainerAccess access) {
+      org.jclouds.atmos.options.PutOptions options = new org.jclouds.atmos.options.PutOptions();
+      if (access == ContainerAccess.PUBLIC_READ) {
+         options.publicRead();
+      } else {
+         options.publicNone();
+      }
+      sync.setGroupAcl(container, options);
    }
 
    /**

--- a/apis/atmos/src/main/java/org/jclouds/atmos/filters/SignRequest.java
+++ b/apis/atmos/src/main/java/org/jclouds/atmos/filters/SignRequest.java
@@ -177,7 +177,12 @@ public class SignRequest implements HttpRequestFilter {
    @VisibleForTesting
    void appendCanonicalizedResource(HttpRequest request, StringBuilder toSign) {
       // Path portion of the HTTP request URI, in lowercase.
-      toSign.append(request.getEndpoint().getRawPath().toLowerCase()).append("\n");
+      toSign.append(request.getEndpoint().getRawPath().toLowerCase());
+      String query = request.getEndpoint().getRawQuery();
+      if (query != null) {
+         toSign.append("?").append(query);
+      }
+      toSign.append("\n");
    }
 
 }

--- a/apis/atmos/src/main/java/org/jclouds/atmos/options/PutOptions.java
+++ b/apis/atmos/src/main/java/org/jclouds/atmos/options/PutOptions.java
@@ -47,6 +47,12 @@ public class PutOptions extends BaseHttpRequestOptions {
       return this;
    }
 
+   public PutOptions publicNone() {
+      this.replaceHeader("x-emc-useracl", "root=FULL_CONTROL");
+      this.replaceHeader("x-emc-groupacl", "other=NONE");
+      return this;
+   }
+
    public static class Builder {
 
       /**
@@ -55,6 +61,11 @@ public class PutOptions extends BaseHttpRequestOptions {
       public static PutOptions publicRead() {
          PutOptions options = new PutOptions();
          return options.publicRead();
+      }
+
+      public static PutOptions publicNone() {
+         PutOptions options = new PutOptions();
+         return options.publicNone();
       }
    }
 }

--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/integration/FilesystemContainerIntegrationTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/integration/FilesystemContainerIntegrationTest.java
@@ -36,6 +36,7 @@ import org.jclouds.filesystem.reference.FilesystemConstants;
 import org.jclouds.filesystem.utils.TestUtils;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.testng.SkipException;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -165,5 +166,10 @@ public class FilesystemContainerIntegrationTest extends BaseContainerIntegration
    public Object[][] ignoreOnWindows() {
       return TestUtils.isWindowsOs() ? TestUtils.NO_INVOCATIONS
             : TestUtils.SINGLE_NO_ARG_INVOCATION;
+   }
+
+   @Override
+   public void testSetContainerAccess() throws Exception {
+      throw new SkipException("Intentionally not implemented for the transient provider");
    }
 }

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/reference/SwiftHeaders.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/reference/SwiftHeaders.java
@@ -49,6 +49,7 @@ public final class SwiftHeaders {
    public static final String CONTAINER_READ = "X-Container-Read";
    public static final String CONTAINER_WRITE = "X-Container-Write";
    public static final String CONTAINER_ACL_ANYBODY_READ = ".r:*,.rlistings";
+   public static final String CONTAINER_ACL_PRIVATE = "";
    
    // CORS
    public static final String CONTAINER_ACCESS_CONTROL_ALLOW_ORIGIN = CONTAINER_METADATA_PREFIX + "Access-Control-Allow-Origin";

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/AccessControlList.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/AccessControlList.java
@@ -19,6 +19,7 @@ package org.jclouds.s3.domain;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -105,10 +106,10 @@ public class AccessControlList {
     * @param permission
     */
    public AccessControlList revokePermission(Grantee grantee, String permission) {
-      Collection<Grant> grantsForGrantee = findGrantsForGrantee(grantee.getIdentifier());
-      for (Grant grant : grantsForGrantee) {
-         if (grant.getPermission().equals(permission)) {
-            grants.remove(grant);
+      for (Iterator<Grant> it = grants.iterator(); it.hasNext();) {
+         Grant grant = it.next();
+         if (grant.getGrantee().equals(grantee) && grant.getPermission().equals(permission)) {
+            it.remove();
          }
       }
       return this;

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/blobstore/SwiftBlobStore.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/blobstore/SwiftBlobStore.java
@@ -31,6 +31,7 @@ import javax.inject.Singleton;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobMetadata;
+import org.jclouds.blobstore.domain.ContainerAccess;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.domain.internal.PageSetImpl;
@@ -313,5 +314,15 @@ public class SwiftBlobStore extends BaseBlobStore {
       if (options.isPublicRead())
          throw new UnsupportedOperationException("publicRead");
       return createContainerInLocation(location, container);
+   }
+
+   @Override
+   public ContainerAccess getContainerAccess(String container) {
+      throw new UnsupportedOperationException("not implemented");
+   }
+
+   @Override
+   public void setContainerAccess(String container, ContainerAccess access) {
+      throw new UnsupportedOperationException("not implemented");
    }
 }

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/blobstore/integration/SwiftContainerIntegrationLiveTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/blobstore/integration/SwiftContainerIntegrationLiveTest.java
@@ -101,4 +101,9 @@ public class SwiftContainerIntegrationLiveTest extends BaseContainerIntegrationT
       // use new Swift provider instead
       throw new SkipException("Intentionally not implemented for the legacy Swift provider");
    }
+
+   @Override
+   public void testSetContainerAccess() throws Exception {
+      throw new SkipException("Intentionally not implemented for the legacy Swift provider");
+   }
 }

--- a/blobstore/src/main/java/org/jclouds/blobstore/BlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/BlobStore.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobBuilder;
 import org.jclouds.blobstore.domain.BlobMetadata;
+import org.jclouds.blobstore.domain.ContainerAccess;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.options.CreateContainerOptions;
@@ -90,6 +91,10 @@ public interface BlobStore {
     * @see #createContainerInLocation(Location,String)
     */
    boolean createContainerInLocation(@Nullable Location location, String container, CreateContainerOptions options);
+
+   ContainerAccess getContainerAccess(String container);
+
+   void setContainerAccess(String container, ContainerAccess access);
 
    /**
     * Lists all resources in a container non-recursive.

--- a/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
@@ -47,6 +47,7 @@ import org.jclouds.blobstore.LocalStorageStrategy;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobBuilder;
 import org.jclouds.blobstore.domain.BlobMetadata;
+import org.jclouds.blobstore.domain.ContainerAccess;
 import org.jclouds.blobstore.domain.MutableBlobMetadata;
 import org.jclouds.blobstore.domain.MutableStorageMetadata;
 import org.jclouds.blobstore.domain.PageSet;
@@ -373,6 +374,16 @@ public final class LocalBlobStore implements BlobStore {
    @Override
    public boolean createContainerInLocation(Location location, String name) {
       return storageStrategy.createContainerInLocation(name, location);
+   }
+
+   @Override
+   public ContainerAccess getContainerAccess(String container) {
+      throw new UnsupportedOperationException("not implemented");
+   }
+
+   @Override
+   public void setContainerAccess(String container, ContainerAccess access) {
+      throw new UnsupportedOperationException("not implemented");
    }
 
    private Blob loadBlob(final String container, final String key) {

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/ContainerAccess.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/ContainerAccess.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jclouds.blobstore.domain;
+
+public enum ContainerAccess {
+   /** Only allow bucket owner to read and write objects. */
+   PRIVATE,
+   /** Allow all users to read objects but only allow owner to write objects. */
+   PUBLIC_READ;
+}

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/TransientContainerIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/TransientContainerIntegrationTest.java
@@ -32,6 +32,7 @@ import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.integration.internal.BaseContainerIntegrationTest;
 import org.jclouds.domain.Location;
 import org.testng.annotations.Test;
+import org.testng.SkipException;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -79,5 +80,10 @@ public class TransientContainerIntegrationTest extends BaseContainerIntegrationT
 
       created = blobStore.createContainerInLocation(location, container);
       assertFalse(created);
+   }
+
+   @Override
+   public void testSetContainerAccess() throws Exception {
+      throw new SkipException("Intentionally not implemented for the transient provider");
    }
 }

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
@@ -37,8 +37,10 @@ import java.util.concurrent.TimeoutException;
 
 import javax.ws.rs.core.MediaType;
 
+import org.jclouds.blobstore.BlobStore;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobMetadata;
+import org.jclouds.blobstore.domain.ContainerAccess;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.options.ListContainerOptions;
@@ -472,6 +474,23 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
          }
       } finally {
          returnContainer(containerName);
+      }
+   }
+
+   @Test(groups = { "integration", "live" })
+   public void testSetContainerAccess() throws Exception {
+      BlobStore blobStore = view.getBlobStore();
+      String containerName = getContainerName();
+      try {
+         assertThat(blobStore.getContainerAccess(containerName)).isEqualTo(ContainerAccess.PRIVATE);
+
+         blobStore.setContainerAccess(containerName, ContainerAccess.PUBLIC_READ);
+         assertThat(blobStore.getContainerAccess(containerName)).isEqualTo(ContainerAccess.PUBLIC_READ);
+
+         blobStore.setContainerAccess(containerName, ContainerAccess.PRIVATE);
+         assertThat(blobStore.getContainerAccess(containerName)).isEqualTo(ContainerAccess.PRIVATE);
+      } finally {
+         recycleContainerAndAddToPool(containerName);
       }
    }
 

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/AzureBlobStore.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/AzureBlobStore.java
@@ -42,6 +42,7 @@ import org.jclouds.azureblob.options.ListBlobsOptions;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobMetadata;
+import org.jclouds.blobstore.domain.ContainerAccess;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.domain.internal.PageSetImpl;
@@ -281,5 +282,24 @@ public class AzureBlobStore extends BaseBlobStore {
       if (options.isPublicRead())
          createContainerOptions.withPublicAccess(PublicAccess.CONTAINER);
       return sync.createContainer(container, createContainerOptions);
+   }
+
+   public ContainerAccess getContainerAccess(String container) {
+      PublicAccess access = sync.getPublicAccessForContainer(container);
+      if (access == PublicAccess.BLOB) {
+         return ContainerAccess.PUBLIC_READ;
+      } else {
+         return ContainerAccess.PRIVATE;
+      }
+   }
+
+   public void setContainerAccess(String container, ContainerAccess access) {
+      PublicAccess publicAccess;
+      if (access == ContainerAccess.PUBLIC_READ) {
+         publicAccess = PublicAccess.BLOB;
+      } else {
+         publicAccess = PublicAccess.PRIVATE;
+      }
+      sync.setPublicAccessForContainer(container, publicAccess);
    }
 }


### PR DESCRIPTION
Implement setting and getting container ACL for public read and private access.  Tested against Atmos Online, AWS-S3, Microsoft Azure, and Rackspace CloudFiles.