### PR TITLE
Fix InitScriptConfigurationForTasks.initScriptPattern on Windows hosts

### DIFF
--- a/compute/src/main/java/org/jclouds/compute/callables/InitScriptConfigurationForTasks.java
+++ b/compute/src/main/java/org/jclouds/compute/callables/InitScriptConfigurationForTasks.java
@@ -16,9 +16,9 @@
  */
 package org.jclouds.compute.callables;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.io.File;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.inject.Named;
@@ -47,7 +47,20 @@ public class InitScriptConfigurationForTasks {
    public InitScriptConfigurationForTasks initScriptPattern(
             @Named(PROPERTY_INIT_SCRIPT_PATTERN) String initScriptPattern) {
       this.initScriptPattern = checkNotNull(initScriptPattern, "initScriptPattern ex. /tmp/init-%s");
-      this.basedir = new File(initScriptPattern).getParent();
+      checkArgument(this.initScriptPattern.startsWith("/"), "initScriptPattern must be a UNIX-style path starting at the root (/)");
+
+      int lastSlash = initScriptPattern.lastIndexOf('/');
+      if (lastSlash == -1) {
+         // no slash? impossible if the checkArgument above had worked properly!
+         throw new IllegalArgumentException("initScriptPattern must be a UNIX-style path starting at the root (/)");
+      } else if (lastSlash == 0) {
+         // the only slash is at the beginning, so this is a filename but no subdirectories - e.g. "/foo"
+         this.basedir = "/";
+      } else {
+         // multiple path components - e.g. "/foo/bar"
+         this.basedir = initScriptPattern.substring(0, lastSlash);
+         // result: "/foo/bar" becomes "/foo"
+      }
       return this;
    }
 

--- a/compute/src/test/java/org/jclouds/compute/callables/InitScriptConfigurationForTasksTest.java
+++ b/compute/src/test/java/org/jclouds/compute/callables/InitScriptConfigurationForTasksTest.java
@@ -16,10 +16,7 @@
  */
 package org.jclouds.compute.callables;
 
-import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
-
-import java.io.File;
 
 import org.testng.annotations.Test;
 
@@ -40,7 +37,7 @@ public class InitScriptConfigurationForTasksTest {
    public void testPatternUpdatesBasedir() {
       InitScriptConfigurationForTasks config = InitScriptConfigurationForTasks.create();
       config.initScriptPattern("/var/foo-init-%s");
-      assertEquals(config.getBasedir(), format("%svar", File.separator));
+      assertEquals(config.getBasedir(), "/var");
       assertEquals(config.getInitScriptPattern(), "/var/foo-init-%s");
    }
 
@@ -55,7 +52,7 @@ public class InitScriptConfigurationForTasksTest {
 
       }).getInstance(InitScriptConfigurationForTasks.class);
       config.initScriptPattern("/var/foo-init-%s");
-      assertEquals(config.getBasedir(), format("%svar", File.separator));
+      assertEquals(config.getBasedir(), "/var");
       assertEquals(config.getInitScriptPattern(), "/var/foo-init-%s");
    }
 
@@ -76,4 +73,19 @@ public class InitScriptConfigurationForTasksTest {
       assertEquals(config.getAnonymousTaskSuffixSupplier().get(), "1");
    }
 
+   @Test
+   public void testInitScriptPattern() throws Exception {
+      InitScriptConfigurationForTasks config = InitScriptConfigurationForTasks.create();
+      config.initScriptPattern("/var/tmp/jclouds-%s");
+      assertEquals(config.getBasedir(), "/var/tmp");
+      assertEquals(config.getInitScriptPattern(), "/var/tmp/jclouds-%s");
+   }
+
+   @Test
+   public void testInitScriptPatternAtRoot() throws Exception {
+      InitScriptConfigurationForTasks config = InitScriptConfigurationForTasks.create();
+      config.initScriptPattern("/jclouds-%s");
+      assertEquals(config.getBasedir(), "/");
+      assertEquals(config.getInitScriptPattern(), "/jclouds-%s");
+   }
 }


### PR DESCRIPTION
This method has incorrect results when run on Windows. It is expected to
generate folder names compatible with Unix-like target machines, but by
using File.getParent it will actually be influenced by the host machine
OS type. This results in baseDir being set to a style that will not work
on Unix-like targets.