### PR TITLE
Deprecate Nova API for volumes in favour of Cinder API for volumes

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/extensions/VolumeApi.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/extensions/VolumeApi.java
@@ -48,7 +48,11 @@ import com.google.common.collect.FluentIterable;
 
 /**
  * Provides access to the OpenStack Compute (Nova) Volume extension API.
+ *
+ * @deprecated Please use {@link org.jclouds.openstack.cinder.v1.features.VolumeApi} or
+ *             {@link org.jclouds.openstack.cinder.v1.features.VolumeApi} instead. To be removed in jclouds 2.0.
  */
+@Deprecated
 @Beta
 @Extension(of = ServiceType.COMPUTE, namespace = ExtensionNamespaces.VOLUMES)
 @RequestFilters(AuthenticateRequest.class)
@@ -57,8 +61,11 @@ public interface VolumeApi {
    /**
     * Returns a summary list of snapshots.
     *
+    * @deprecated Please use {@link org.jclouds.openstack.cinder.v1.features.VolumeApi#list()} instead.
+    *             To be removed in jclouds 2.0.
     * @return the list of snapshots
     */
+   @Deprecated
    @Named("volume:list")
    @GET
    @Path("/os-volumes")
@@ -69,8 +76,11 @@ public interface VolumeApi {
    /**
     * Returns a detailed list of volumes.
     *
+    * @deprecated Please use {@link org.jclouds.openstack.cinder.v1.features.VolumeApi#listInDetail()} instead.
+    *             To be removed in jclouds 2.0.
     * @return the list of volumes.
     */
+   @Deprecated
    @Named("volume:list")
    @GET
    @Path("/os-volumes/detail")
@@ -81,8 +91,11 @@ public interface VolumeApi {
    /**
     * Return data about the given volume.
     *
+    * @deprecated Please use {@link org.jclouds.openstack.cinder.v1.features.VolumeApi#get(String)} instead.
+    *             To be removed in jclouds 2.0.
     * @return details of a specific snapshot.
     */
+   @Deprecated
    @Named("volume:get")
    @GET
    @Path("/os-volumes/{id}")
@@ -94,8 +107,11 @@ public interface VolumeApi {
    /**
     * Creates a new Snapshot
     *
+    * @deprecated Please use {@link org.jclouds.openstack.cinder.v1.features.VolumeApi#create(int, CreateVolumeOptions)} instead.
+    *             To be removed in jclouds 2.0.
     * @return the new Snapshot
     */
+   @Deprecated
    @Named("volume:create")
    @POST
    @Path("/os-volumes")
@@ -107,8 +123,11 @@ public interface VolumeApi {
    /**
     * Delete a snapshot.
     *
+    * @deprecated Please use {@link org.jclouds.openstack.cinder.v1.features.VolumeApi#delete(String)} instead.
+    *             To be removed in jclouds 2.0.
     * @return true if successful
     */
+   @Deprecated
    @Named("volume:delete")
    @DELETE
    @Path("/os-volumes/{volumeId}")
@@ -120,8 +139,11 @@ public interface VolumeApi {
    /**
     * Returns a summary list of snapshots.
     *
+    * @deprecated Please use {@link org.jclouds.openstack.cinder.v1.features.SnapshotApi#list()} instead.
+    *             To be removed in jclouds 2.0.
     * @return the list of snapshots
     */
+   @Deprecated
    @Named("volume:listSnapshots")
    @GET
    @Path("/os-snapshots")
@@ -132,8 +154,11 @@ public interface VolumeApi {
    /**
     * Returns a summary list of snapshots.
     *
+    * @deprecated Please use {@link org.jclouds.openstack.cinder.v1.features.SnapshotApi#listInDetail()} instead.
+    *             To be removed in jclouds 2.0.
     * @return the list of snapshots
     */
+   @Deprecated
    @Named("volume:listSnapshots")
    @GET
    @Path("/os-snapshots/detail")
@@ -144,8 +169,11 @@ public interface VolumeApi {
    /**
     * Return data about the given snapshot.
     *
+    * @deprecated Please use {@link org.jclouds.openstack.cinder.v1.features.SnapshotApi#get(String)} instead.
+    *             To be removed in jclouds 2.0.
     * @return details of a specific snapshot.
     */
+   @Deprecated
    @Named("volume:getSnapshot")
    @GET
    @Path("/os-snapshots/{id}")
@@ -157,6 +185,8 @@ public interface VolumeApi {
    /**
     * Creates a new Snapshot.
     *
+    * @deprecated Please use {@link org.jclouds.openstack.cinder.v1.features.SnapshotApi#create(String, CreateVolumeSnapshotOptions)} instead.
+    *             To be removed in jclouds 2.0.
     * @return the new Snapshot
     */
    @Named("volume:createSnapshot")
@@ -170,6 +200,8 @@ public interface VolumeApi {
    /**
     * Delete a snapshot.
     *
+    * @deprecated Please use {@link org.jclouds.openstack.cinder.v1.features.SnapshotApi#delete(String)} instead.
+    *             To be removed in jclouds 2.0.
     * @return true if successful
     */
    @Named("volume:deleteSnapshot")

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/extensions/VolumeAttachmentApi.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/extensions/VolumeAttachmentApi.java
@@ -40,25 +40,14 @@ import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.SelectJson;
 import org.jclouds.rest.annotations.WrapWith;
 
-import com.google.common.annotations.Beta;
 import com.google.common.collect.FluentIterable;
 
 /**
  * Provides access to the OpenStack Compute (Nova) Volume Attachments Extension API.
  *
- * This API strictly handles attaching Volumes to Servers. To create and manage Volumes you need to use one of the
- * following APIs:
- *
- * 1. The Cinder API
- *    If your OpenStack deployment is Folsom or later and it supports the Cinder block storage service, use this API.
- *    @see org.jclouds.openstack.cinder.v1.features.VolumeApi
- *
- * 2. The nova-volume API
- *    If your OpenStack deployment is Essex or earlier and it supports the nova-volume extension, use this API.
- *    @see org.jclouds.openstack.nova.v2_0.extensions.VolumeApi
- *
+ * This API strictly handles attaching Volumes to Servers. To create and manage Volumes you need to use the Cinder API.
+ * @see org.jclouds.openstack.cinder.v1.features.VolumeApi
  */
-@Beta
 @Extension(of = ServiceType.COMPUTE, namespace = ExtensionNamespaces.VOLUME_ATTACHMENTS)
 @RequestFilters(AuthenticateRequest.class)
 @Consumes(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Helps reduce user confusion over which API to use too.