### PR TITLE
Modernize the VolumeAttachmentApiLiveTest

### DIFF
--- a/apis/openstack-nova/pom.xml
+++ b/apis/openstack-nova/pom.xml
@@ -73,6 +73,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-cinder</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-compute</artifactId>
       <version>${project.version}</version>

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/extensions/VolumeAttachmentApiLiveTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/extensions/VolumeAttachmentApiLiveTest.java
@@ -17,7 +17,6 @@
 package org.jclouds.openstack.nova.v2_0.extensions;
 
 import com.google.common.collect.FluentIterable;
-import com.google.common.collect.Iterables;
 import org.jclouds.ContextBuilder;
 import org.jclouds.openstack.cinder.v1.CinderApi;
 import org.jclouds.openstack.cinder.v1.domain.Volume;
@@ -31,6 +30,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 
 import static org.testng.Assert.assertEquals;
@@ -44,9 +44,20 @@ public class VolumeAttachmentApiLiveTest extends BaseNovaApiLiveTest {
    private VolumeApi volumeApi;
    private VolumeAttachmentApi volumeAttachmentApi;
 
-   private String region;
    private Volume volume;
    private Server server;
+
+   protected String volumeProvider;
+   protected int volumeSizeGB;
+
+   @Override
+   protected Properties setupProperties() {
+      Properties props = super.setupProperties();
+      volumeProvider = setIfTestSystemPropertyPresent(props, provider + ".volume-provider", "openstack-cinder");
+      volumeSizeGB = Integer.parseInt(setIfTestSystemPropertyPresent(props, provider + ".volume-size-gb", "1"));
+      singleRegion = setIfTestSystemPropertyPresent(props, provider + ".region", "RegionOne");
+      return props;
+   }
 
    @BeforeClass(groups = {"integration", "live"})
    @Override
@@ -55,61 +66,38 @@ public class VolumeAttachmentApiLiveTest extends BaseNovaApiLiveTest {
 
       CinderApi cinderApi;
 
-      if ("openstack-cinder".equals(getVolumeProvider())) {
-         cinderApi = ContextBuilder.newBuilder(getVolumeProvider())
+      if ("openstack-cinder".equals(volumeProvider)) {
+         cinderApi = ContextBuilder.newBuilder(volumeProvider)
                .endpoint(endpoint)
                .credentials(identity, credential)
                .buildApi(CinderApi.class);
       }
       else {
-         cinderApi = ContextBuilder.newBuilder(getVolumeProvider())
+         cinderApi = ContextBuilder.newBuilder(volumeProvider)
                .credentials(identity, credential)
                .buildApi(CinderApi.class);
       }
 
-      region = Iterables.getFirst(regions, "RegionOne");
-      volumeApi = cinderApi.getVolumeApi(region);
-      volumeAttachmentApi = api.getVolumeAttachmentApi(region).get();
+      volumeApi = cinderApi.getVolumeApi(singleRegion);
+      volumeAttachmentApi = api.getVolumeAttachmentApi(singleRegion).get();
 
       CreateVolumeOptions options = CreateVolumeOptions.Builder
             .name("jclouds-test-volume")
             .description("description of test volume");
 
-      volume = volumeApi.create(getVolumeSizeGB(), options);
+      volume = volumeApi.create(volumeSizeGB, options);
       VolumePredicates.awaitAvailable(volumeApi).apply(volume);
 
-      server = createServerInRegion(region);
+      server = createServerInRegion(singleRegion);
    }
 
    @AfterClass(groups = {"integration", "live"})
    @Override
    public void tearDown() {
       volumeApi.delete(volume.getId());
-      api.getServerApi(region).delete(server.getId());
+      api.getServerApi(singleRegion).delete(server.getId());
 
       super.tearDown();
-   }
-
-   public String getVolumeProvider() {
-      String volumeProviderKey = "test." + provider + ".volume-provider";
-
-      if (System.getProperties().containsKey(volumeProviderKey)) {
-         return System.getProperty(volumeProviderKey);
-      }
-      else {
-         return "openstack-cinder";
-      }
-   }
-
-   public int getVolumeSizeGB() {
-      String volumeSizeKey = "test." + provider + ".volume-size-gb";
-
-      if (System.getProperties().containsKey(volumeSizeKey)) {
-         return Integer.parseInt(System.getProperty(volumeSizeKey));
-      }
-      else {
-         return 1;
-      }
    }
 
    @Test

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/features/ServerApiLiveTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/features/ServerApiLiveTest.java
@@ -117,7 +117,7 @@ public class ServerApiLiveTest extends BaseNovaApiLiveTest {
                   // This network UUID must match an existing network.
                   ImmutableSet.of(Network.builder().networkUuid("bc4cfa2b-2b27-4671-8e8f-73009623def0").fixedIp("192.168.55.56").build())
             );
-            ServerCreated server = serverApi.create(hostName, imageIdForRegion(regionId), "1", options);
+            ServerCreated server = serverApi.create(hostName, imageId(regionId), "1", options);
             serverId = server.getId();
 
             awaitActive(serverApi).apply(server.getId());
@@ -239,7 +239,7 @@ public class ServerApiLiveTest extends BaseNovaApiLiveTest {
          options = options.availabilityZone(availabilityZoneId);
       }
 
-      ServerCreated server = serverApi.create(hostName, imageIdForRegion(regionId), flavorRefForRegion(regionId), options);
+      ServerCreated server = serverApi.create(hostName, imageId(regionId), flavorId(regionId), options);
 
       awaitActive(serverApi).apply(server.getId());
 

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/internal/BaseNovaApiLiveTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/internal/BaseNovaApiLiveTest.java
@@ -91,7 +91,7 @@ public class BaseNovaApiLiveTest extends BaseApiLiveTest<NovaApi> {
 
    protected Server createServerInRegion(String regionId, CreateServerOptions options) {
       ServerApi serverApi = api.getServerApi(regionId);
-      ServerCreated server = serverApi.create(hostName, imageIdForRegion(regionId), flavorRefForRegion(regionId), options);
+      ServerCreated server = serverApi.create(hostName, imageId(regionId), flavorId(regionId), options);
       blockUntilServerInState(server.getId(), serverApi, Status.ACTIVE);
       return serverApi.get(server.getId());
    }
@@ -114,21 +114,35 @@ public class BaseNovaApiLiveTest extends BaseApiLiveTest<NovaApi> {
       }
    }
 
-   protected String imageIdForRegion(String regionId) {
-      ImageApi imageApi = api.getImageApi(regionId);
+   protected String imageId(String regionId) {
+      String imageIdKey = "test." + provider + ".image-id";
 
-      // Get the first image from the list as it tends to be "lighter" and faster to start
-      return Iterables.get(imageApi.list().concat(), 0).getId();
+      if (System.getProperties().containsKey(imageIdKey)) {
+         return System.getProperty(imageIdKey);
+      }
+      else {
+         ImageApi imageApi = api.getImageApi(regionId);
+
+         // Get the first image from the list as it tends to be "lighter" and faster to start
+         return Iterables.get(imageApi.list().concat(), 0).getId();
+      }
    }
 
-   protected String flavorRefForRegion(String regionId) {
-      FlavorApi flavorApi = api.getFlavorApi(regionId);
-      return DEFAULT_FLAVOR_ORDERING.min(flavorApi.listInDetail().concat().filter(new Predicate<Flavor>() {
-         @Override
-         public boolean apply(Flavor in) {
-            return in.getDisk() >= 10 && in.getRam() >= 4 && in.getVcpus() >= 2;
-         }
-      })).getId();
+   protected String flavorId(String regionId) {
+      String imageIdKey = "test." + provider + ".flavor-id";
+
+      if (System.getProperties().containsKey(imageIdKey)) {
+         return System.getProperty(imageIdKey);
+      }
+      else {
+         FlavorApi flavorApi = api.getFlavorApi(regionId);
+         return DEFAULT_FLAVOR_ORDERING.min(flavorApi.listInDetail().concat().filter(new Predicate<Flavor>() {
+            @Override
+            public boolean apply(Flavor in) {
+               return in.getDisk() >= 10 && in.getRam() >= 4 && in.getVcpus() >= 2;
+            }
+         })).getId();
+      }
    }
 
    static final Ordering<Flavor> DEFAULT_FLAVOR_ORDERING = new Ordering<Flavor>() {

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/internal/BaseNovaApiLiveTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/internal/BaseNovaApiLiveTest.java
@@ -54,16 +54,15 @@ public class BaseNovaApiLiveTest extends BaseApiLiveTest<NovaApi> {
    }
 
    protected Set<String> regions;
+   protected String singleRegion;
 
    @BeforeClass(groups = { "integration", "live" })
    @Override
    public void setup() {
       super.setup();
 
-      String testRegion = System.getProperty("test." + provider + ".region");
-
-      if (testRegion != null) {
-         regions = ImmutableSet.of(testRegion);
+      if (singleRegion != null) {
+         regions = ImmutableSet.of(singleRegion);
       } else {
          regions = api.getConfiguredRegions();
       }
@@ -82,6 +81,7 @@ public class BaseNovaApiLiveTest extends BaseApiLiveTest<NovaApi> {
       Properties props = super.setupProperties();
       setIfTestSystemPropertyPresent(props, KeystoneProperties.CREDENTIAL_TYPE);
       setIfTestSystemPropertyPresent(props, NovaProperties.AUTO_ALLOCATE_FLOATING_IPS);
+      singleRegion = setIfTestSystemPropertyPresent(props, provider + ".region");
       return props;
    }
 

--- a/core/src/test/java/org/jclouds/apis/BaseApiLiveTest.java
+++ b/core/src/test/java/org/jclouds/apis/BaseApiLiveTest.java
@@ -73,6 +73,17 @@ public abstract class BaseApiLiveTest<A extends Closeable> {
       return null;
    }
 
+   protected String setIfTestSystemPropertyPresent(Properties overrides, String key, String defaultValue) {
+      String val = setIfTestSystemPropertyPresent(overrides, key);
+
+      if (val == null) {
+         val = defaultValue;
+         overrides.setProperty(key, val);
+      }
+
+      return val;
+   }
+
    /**
     * This helps live testing against specific regions only.
     * @param regions A list of regions, usually from getConfiguredRegions()


### PR DESCRIPTION
To run the test on OpenStack (DevStack)

    mvn clean test -Plive -Dtest.openstack-nova.endpoint=http://$DEVSTACK_HOST:5000/v2.0/ -Dtest.openstack-nova.identity=demo:demo -Dtest.openstack-nova.credential=devstack -Dtest.openstack-nova.image-id=$IMAGE_ID -Dtest.openstack-nova.flavor-id=1 -Dtest=VolumeAttachmentApiLiveTest

To run the test on Rackspace

    mvn clean test -Plive -Dtest.openstack-nova.endpoint=https://identity.api.rackspacecloud.com/v2.0/ -Dtest.openstack-nova.identity=$RACKSPACE_USERNAME -Dtest.openstack-nova.credential=$RACKSPACE_PASSWORD -Dtest.openstack-nova.image-id=$IMAGE_ID -Dtest.openstack-nova.flavor-id=$FLAVOR_ID -Dtest.openstack-nova.region=IAD -Dtest.openstack-nova.volume-size-gb=100 -Dtest=VolumeAttachmentApiLiveTest

As expected, due to [this change](https://github.com/jclouds/jclouds/commit/2db654fbe3e32c3799cf2cb8999cd422878d3928#diff-5d6a573e2a00f18e2381f2e66c8469c7L62), this test currently fails on Rackspace with the error

    java.lang.IllegalStateException: Optional.get() cannot be called on an absent value
        at com.google.common.base.Absent.get(Absent.java:47)
        at org.jclouds.openstack.nova.v2_0.extensions.VolumeAttachmentApiLiveTest.setup(VolumeAttachmentApiLiveTest.java:72)

@zack-shoylev to provide the fix in a subsequent PR