### PR TITLE
Fixed VolumeAttachment in HPCloud Compute

### DIFF
--- a/apis/chef/pom.xml
+++ b/apis/chef/pom.xml
@@ -75,9 +75,8 @@
     </dependency>
     <!--  for ohai -->
     <dependency>
-        <groupId>com.google.inject.extensions</groupId>
-        <artifactId>guice-multibindings</artifactId>
-        <version>3.0</version>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-multibindings</artifactId>
     </dependency>
     <!--  for transient chef provider -->
     <dependency>

--- a/apis/openstack-keystone/pom.xml
+++ b/apis/openstack-keystone/pom.xml
@@ -51,6 +51,11 @@
       <artifactId>jclouds-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- for the extension namespaces -->
+    <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-multibindings</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-core</artifactId>

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/Aliases.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/Aliases.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.keystone.v2_0.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(value = { ElementType.TYPE, ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD })
+@Qualifier
+public @interface Aliases {
+
+}

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneHttpApiModule.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneHttpApiModule.java
@@ -49,11 +49,11 @@ import com.google.common.base.Suppliers;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
 import com.google.inject.AbstractModule;
+import com.google.inject.Binder;
 import com.google.inject.Provides;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.multibindings.MapBinder;
 
 /**
  * Configures the Keystone API.
@@ -91,17 +91,16 @@ public class KeystoneHttpApiModule extends HttpApiModule<KeystoneApi> {
       }
    }
 
+   // Allow providers to cleanly contribute their own aliases
+   public static MapBinder<URI, URI> aliasBinder(Binder binder) {
+      return MapBinder.newMapBinder(binder, URI.class, URI.class, Aliases.class).permitDuplicates();
+   }
+
    @Override
    protected void configure() {
       bind(ImplicitOptionalConverter.class).to(PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensionsSet.class);
       super.configure();
-   }
-
-   @Provides
-   @Singleton
-   public Multimap<URI, URI> aliases() {
-       return ImmutableMultimap.<URI, URI>builder()
-          .build();
+      aliasBinder(binder());
    }
 
    @Provides

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/functions/PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensionsSetTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/functions/PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensionsSetTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.jclouds.date.internal.SimpleDateFormatDateService;
+import org.jclouds.openstack.keystone.v2_0.config.Aliases;
 import org.jclouds.openstack.v2_0.ServiceType;
 import org.jclouds.openstack.v2_0.domain.Extension;
 import org.jclouds.reflect.Invocation;
@@ -44,6 +45,7 @@ import com.google.common.collect.Multimap;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Provides;
+import com.google.inject.multibindings.MapBinder;
 
 @Test(groups = "unit", testName = "PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensionsSetTest")
 public class PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensionsSetTest {
@@ -138,6 +140,13 @@ public class PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensio
                new AbstractModule() {
                   @Override
                   protected void configure() {
+                     MapBinder<URI, URI> aliasBindings = MapBinder.newMapBinder(binder(),
+                           URI.class, URI.class, Aliases.class).permitDuplicates();
+                     for (URI key : aliases.keySet()) {
+                        for (URI value : aliases.get(key)) {
+                           aliasBindings.addBinding(key).toInstance(value);
+                        }
+                     }
                   }
 
                   @Provides
@@ -145,10 +154,6 @@ public class PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensio
                      return extensionsForRegion;
                   }
 
-                  @Provides
-                  Multimap<URI, URI> getAliases() {
-                     return aliases;
-                  }
                }).getInstance(PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensionsSet.class);
 
       return fn;

--- a/apis/openstack-nova/pom.xml
+++ b/apis/openstack-nova/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>openstack-keystone</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- for the extension namespaces -->
+    <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-multibindings</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-compute</artifactId>

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/config/NovaHttpApiModule.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/config/NovaHttpApiModule.java
@@ -16,6 +16,8 @@
  */
 package org.jclouds.openstack.nova.v2_0.config;
 
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneHttpApiModule.aliasBinder;
+
 import java.net.URI;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -39,9 +41,8 @@ import org.jclouds.rest.functions.ImplicitOptionalConverter;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
 import com.google.inject.Provides;
+import com.google.inject.multibindings.MapBinder;
 
 /**
  * Configures the Nova connection.
@@ -57,45 +58,44 @@ public class NovaHttpApiModule extends HttpApiModule<NovaApi> {
    protected void configure() {
       bind(ImplicitOptionalConverter.class).to(PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensionsSet.class);
       super.configure();
+      bindDefaultAliases();
    }
 
-   @Provides
-   @Singleton
-   public Multimap<URI, URI> aliases() {
-       return ImmutableMultimap.<URI, URI>builder()
-          .put(URI.create(ExtensionNamespaces.SECURITY_GROUPS),
-               URI.create("http://docs.openstack.org/compute/ext/securitygroups/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.FLOATING_IPS),
-               URI.create("http://docs.openstack.org/compute/ext/floating_ips/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.KEYPAIRS),
-               URI.create("http://docs.openstack.org/compute/ext/keypairs/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.SIMPLE_TENANT_USAGE),
-               URI.create("http://docs.openstack.org/compute/ext/os-simple-tenant-usage/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.HOSTS),
-               URI.create("http://docs.openstack.org/compute/ext/hosts/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.VOLUMES),
-               URI.create("http://docs.openstack.org/compute/ext/volumes/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.VIRTUAL_INTERFACES),
-               URI.create("http://docs.openstack.org/compute/ext/virtual_interfaces/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.CREATESERVEREXT),
-               URI.create("http://docs.openstack.org/compute/ext/createserverext/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.ADMIN_ACTIONS),
-               URI.create("http://docs.openstack.org/compute/ext/admin-actions/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.AGGREGATES),
-               URI.create("http://docs.openstack.org/compute/ext/aggregates/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.FLAVOR_EXTRA_SPECS),
-               URI.create("http://docs.openstack.org/compute/ext/flavor_extra_specs/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.QUOTAS),
-               URI.create("http://docs.openstack.org/compute/ext/quotas-sets/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.VOLUME_TYPES),
-               URI.create("http://docs.openstack.org/compute/ext/volume_types/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.AVAILABILITY_ZONE),
-               URI.create("http://docs.openstack.org/compute/ext/availabilityzone/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.VOLUME_ATTACHMENTS),
-               URI.create("http://docs.openstack.org/compute/ext/os-volume-attachment-update/api/v2"))
-          .put(URI.create(ExtensionNamespaces.ATTACH_INTERFACES),
-               URI.create("http://docs.openstack.org/compute/ext/interfaces/api/v1.1"))
-          .build();
+   // Intentionally private so subclasses use the Guice multibindings to contribute their aliases
+   private void bindDefaultAliases() {
+      MapBinder<URI, URI> aliases = aliasBinder(binder());
+      aliases.addBinding(URI.create(ExtensionNamespaces.SECURITY_GROUPS)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/securitygroups/api/v1.1"));
+      aliases.addBinding(URI.create(ExtensionNamespaces.FLOATING_IPS)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/floating_ips/api/v1.1"));
+      aliases.addBinding(URI.create(ExtensionNamespaces.KEYPAIRS)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/keypairs/api/v1.1"));
+      aliases.addBinding(URI.create(ExtensionNamespaces.SIMPLE_TENANT_USAGE)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/os-simple-tenant-usage/api/v1.1"));
+      aliases.addBinding(URI.create(ExtensionNamespaces.HOSTS)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/hosts/api/v1.1"));
+      aliases.addBinding(URI.create(ExtensionNamespaces.VOLUMES)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/volumes/api/v1.1"));
+      aliases.addBinding(URI.create(ExtensionNamespaces.VIRTUAL_INTERFACES)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/virtual_interfaces/api/v1.1"));
+      aliases.addBinding(URI.create(ExtensionNamespaces.CREATESERVEREXT)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/createserverext/api/v1.1"));
+      aliases.addBinding(URI.create(ExtensionNamespaces.ADMIN_ACTIONS)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/admin-actions/api/v1.1"));
+      aliases.addBinding(URI.create(ExtensionNamespaces.AGGREGATES)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/aggregates/api/v1.1"));
+      aliases.addBinding(URI.create(ExtensionNamespaces.FLAVOR_EXTRA_SPECS)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/flavor_extra_specs/api/v1.1"));
+      aliases.addBinding(URI.create(ExtensionNamespaces.QUOTAS)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/quotas-sets/api/v1.1"));
+      aliases.addBinding(URI.create(ExtensionNamespaces.VOLUME_TYPES)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/volume_types/api/v1.1"));
+      aliases.addBinding(URI.create(ExtensionNamespaces.AVAILABILITY_ZONE)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/availabilityzone/api/v1.1"));
+      aliases.addBinding(URI.create(ExtensionNamespaces.VOLUME_ATTACHMENTS)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/os-volume-attachment-update/api/v2"));
+      aliases.addBinding(URI.create(ExtensionNamespaces.ATTACH_INTERFACES)).toInstance(
+            URI.create("http://docs.openstack.org/compute/ext/interfaces/api/v1.1"));
    }
 
    @Provides
@@ -104,7 +104,7 @@ public class NovaHttpApiModule extends HttpApiModule<NovaApi> {
       return CacheBuilder.newBuilder().expireAfterWrite(23, TimeUnit.HOURS)
             .build(new CacheLoader<String, Set<? extends Extension>>() {
                @Override
-               public Set<? extends Extension> load(String key) throws Exception {
+               public Set<? extends Extension> load(final String key) throws Exception {
                   return novaApi.get().getExtensionApi(key).list();
                }
             });

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/extensions/VolumeAttachmentApiLiveTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/extensions/VolumeAttachmentApiLiveTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.jclouds.ContextBuilder;
 import org.jclouds.openstack.cinder.v1.CinderApi;
+import org.jclouds.openstack.cinder.v1.CinderApiMetadata;
 import org.jclouds.openstack.cinder.v1.domain.Volume;
 import org.jclouds.openstack.cinder.v1.features.VolumeApi;
 import org.jclouds.openstack.cinder.v1.options.CreateVolumeOptions;
@@ -49,6 +50,7 @@ public class VolumeAttachmentApiLiveTest extends BaseNovaApiLiveTest {
    private Server server;
 
    protected String volumeProvider;
+   protected String volumeProviderVersion;
    protected int volumeSizeGB;
    protected String deviceId = "/dev/wtf";
 
@@ -56,6 +58,8 @@ public class VolumeAttachmentApiLiveTest extends BaseNovaApiLiveTest {
    protected Properties setupProperties() {
       Properties props = super.setupProperties();
       volumeProvider = setIfTestSystemPropertyPresent(props, provider + ".volume-provider", "openstack-cinder");
+      volumeProviderVersion = setIfTestSystemPropertyPresent(props, provider + ".volume-provider-version",
+          new CinderApiMetadata().getVersion());
       volumeSizeGB = Integer.parseInt(setIfTestSystemPropertyPresent(props, provider + ".volume-size-gb", "1"));
       singleRegion = setIfTestSystemPropertyPresent(props, provider + ".region", "RegionOne");
       return props;
@@ -71,6 +75,7 @@ public class VolumeAttachmentApiLiveTest extends BaseNovaApiLiveTest {
       if ("openstack-cinder".equals(volumeProvider)) {
          cinderApi = ContextBuilder.newBuilder(volumeProvider)
                .endpoint(endpoint)
+               .apiVersion(volumeProviderVersion)
                .credentials(identity, credential)
                .buildApi(CinderApi.class);
       }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,12 +55,10 @@
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-assistedinject</artifactId>
-      <version>3.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>3.0</version>
     </dependency>
     <dependency>
       <groupId>org.99soft.guice</groupId>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -206,6 +206,7 @@
     <maven.site.url.base>gitsite:git@github.com/jclouds/jclouds-maven-site.git</maven.site.url.base>
     <clojure.version>1.3.0</clojure.version>
     <guava.version>16.0.1</guava.version>
+    <guice.version>3.0</guice.version>
     <okhttp.version>2.2.0</okhttp.version>
     <surefire.version>2.17</surefire.version>
     <assertj-core.version>1.7.0</assertj-core.version>
@@ -245,6 +246,21 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-assistedinject</artifactId>
+        <version>${guice.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
+        <version>${guice.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-multibindings</artifactId>
+        <version>${guice.version}</version>
       </dependency>
       <dependency>
         <groupId>org.easymock</groupId>

--- a/providers/hpcloud-compute/pom.xml
+++ b/providers/hpcloud-compute/pom.xml
@@ -55,6 +55,11 @@
       <artifactId>openstack-nova</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- for the extension namespaces -->
+    <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-multibindings</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-core</artifactId>
@@ -92,6 +97,12 @@
     <dependency>
       <groupId>org.apache.jclouds.driver</groupId>
       <artifactId>jclouds-sshj</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-cinder</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/providers/hpcloud-compute/src/main/java/org/jclouds/hpcloud/compute/HPCloudComputeProviderMetadata.java
+++ b/providers/hpcloud-compute/src/main/java/org/jclouds/hpcloud/compute/HPCloudComputeProviderMetadata.java
@@ -26,13 +26,13 @@ import static org.jclouds.openstack.nova.v2_0.config.NovaProperties.AUTO_GENERAT
 import java.net.URI;
 import java.util.Properties;
 
+import org.jclouds.hpcloud.compute.config.HPCloudComputeHttpApiModule;
 import org.jclouds.hpcloud.compute.config.HPCloudComputeServiceContextModule;
 import org.jclouds.openstack.keystone.v2_0.config.AuthenticationApiModule;
 import org.jclouds.openstack.keystone.v2_0.config.CredentialTypes;
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule;
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
 import org.jclouds.openstack.nova.v2_0.NovaApiMetadata;
-import org.jclouds.openstack.nova.v2_0.config.NovaHttpApiModule;
 import org.jclouds.openstack.nova.v2_0.config.NovaParserModule;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
@@ -95,7 +95,7 @@ public class HPCloudComputeProviderMetadata extends BaseProviderMetadata {
                                               .add(KeystoneAuthenticationModule.class)
                                               .add(RegionModule.class)
                                               .add(NovaParserModule.class)
-                                              .add(NovaHttpApiModule.class)
+                                              .add(HPCloudComputeHttpApiModule.class)
                                               .add(HPCloudComputeServiceContextModule.class).build())
                   .build())
          .homepage(URI.create("http://hpcloud.com"))

--- a/providers/hpcloud-compute/src/main/java/org/jclouds/hpcloud/compute/config/HPCloudComputeHttpApiModule.java
+++ b/providers/hpcloud-compute/src/main/java/org/jclouds/hpcloud/compute/config/HPCloudComputeHttpApiModule.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jclouds.rackspace.cloudservers.us.config;
+package org.jclouds.hpcloud.compute.config;
 
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneHttpApiModule.aliasBinder;
 
@@ -26,12 +26,8 @@ import org.jclouds.rest.ConfiguresHttpApi;
 
 import com.google.inject.multibindings.MapBinder;
 
-/**
- * Configures the Rackspace connection.
- *
- */
 @ConfiguresHttpApi
-public class CloudServersUSHttpApiModule extends NovaHttpApiModule {
+public class HPCloudComputeHttpApiModule extends NovaHttpApiModule {
 
    @Override
    protected void configure() {

--- a/providers/hpcloud-compute/src/test/java/org/jclouds/hpcloud/compute/extensions/HPCloudComputeVolumeAttachmentExtensionLiveTest.java
+++ b/providers/hpcloud-compute/src/test/java/org/jclouds/hpcloud/compute/extensions/HPCloudComputeVolumeAttachmentExtensionLiveTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.hpcloud.compute.extensions;
+
+import java.util.Properties;
+
+import org.jclouds.hpcloud.compute.HPCloudComputeProviderMetadata;
+import org.jclouds.openstack.keystone.v2_0.config.CredentialTypes;
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties;
+import org.jclouds.openstack.nova.v2_0.extensions.VolumeAttachmentApiLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", testName = "HPCloudComputeVolumeAttachmentExtensionLiveTest", singleThreaded = true)
+public class HPCloudComputeVolumeAttachmentExtensionLiveTest extends VolumeAttachmentApiLiveTest {
+
+   public HPCloudComputeVolumeAttachmentExtensionLiveTest() {
+      HPCloudComputeProviderMetadata metadata = new HPCloudComputeProviderMetadata();
+      provider = metadata.getId();
+      System.setProperty("test." + provider + ".endpoint", metadata.getEndpoint());
+      System.setProperty(KeystoneProperties.CREDENTIAL_TYPE, CredentialTypes.API_ACCESS_KEY_CREDENTIALS);
+   }
+
+   @Override
+   protected Properties setupProperties() {
+      Properties props = super.setupProperties();
+      volumeProviderVersion = setIfTestSystemPropertyPresent(props, provider + ".volume-provider-version", "1.0");
+      singleRegion = setIfTestSystemPropertyPresent(props, provider + ".region", "region-a.geo-1");
+      return props;
+   }
+
+}

--- a/providers/rackspace-cloudservers-uk/pom.xml
+++ b/providers/rackspace-cloudservers-uk/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>openstack-nova</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- for the extension namespaces -->
+    <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-multibindings</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-core</artifactId>
@@ -109,6 +114,12 @@
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.provider</groupId>
+      <artifactId>rackspace-cloudblockstorage-uk</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/providers/rackspace-cloudservers-uk/src/main/java/org/jclouds/rackspace/cloudservers/uk/CloudServersUKProviderMetadata.java
+++ b/providers/rackspace-cloudservers-uk/src/main/java/org/jclouds/rackspace/cloudservers/uk/CloudServersUKProviderMetadata.java
@@ -27,7 +27,6 @@ import java.util.Properties;
 
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
 import org.jclouds.openstack.nova.v2_0.NovaApiMetadata;
-import org.jclouds.openstack.nova.v2_0.config.NovaHttpApiModule;
 import org.jclouds.openstack.nova.v2_0.config.NovaParserModule;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
@@ -35,6 +34,7 @@ import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticati
 import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationModule;
 import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes;
 import org.jclouds.rackspace.cloudservers.uk.config.CloudServersUKComputeServiceContextModule;
+import org.jclouds.rackspace.cloudservers.uk.config.CloudServersUKHttpApiModule;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableSet;
@@ -89,7 +89,7 @@ public class CloudServersUKProviderMetadata extends BaseProviderMetadata {
                                               .add(CloudIdentityAuthenticationModule.class)
                                               .add(RegionModule.class)
                                               .add(NovaParserModule.class)
-                                              .add(NovaHttpApiModule.class)
+                                              .add(CloudServersUKHttpApiModule.class)
                                               .add(CloudServersUKComputeServiceContextModule.class).build())
                   .build())
          .homepage(URI.create("http://www.rackspace.co.uk/opencloud"))

--- a/providers/rackspace-cloudservers-uk/src/main/java/org/jclouds/rackspace/cloudservers/uk/config/CloudServersUKHttpApiModule.java
+++ b/providers/rackspace-cloudservers-uk/src/main/java/org/jclouds/rackspace/cloudservers/uk/config/CloudServersUKHttpApiModule.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jclouds.rackspace.cloudservers.us.config;
+package org.jclouds.rackspace.cloudservers.uk.config;
 
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneHttpApiModule.aliasBinder;
 
@@ -28,17 +28,16 @@ import com.google.inject.multibindings.MapBinder;
 
 /**
  * Configures the Rackspace connection.
- *
  */
 @ConfiguresHttpApi
-public class CloudServersUSHttpApiModule extends NovaHttpApiModule {
+public class CloudServersUKHttpApiModule extends NovaHttpApiModule {
 
-   @Override
-   protected void configure() {
-      super.configure();
-      MapBinder<URI, URI> aliases = aliasBinder(binder());
-      aliases.addBinding(URI.create(ExtensionNamespaces.VOLUME_ATTACHMENTS)).toInstance(
+    @Override
+    protected void configure() {
+        super.configure();
+        MapBinder<URI, URI> aliases = aliasBinder(binder());
+        aliases.addBinding(URI.create(ExtensionNamespaces.VOLUME_ATTACHMENTS)).toInstance(
             URI.create("http://docs.openstack.org/compute/ext/volumes/api/v1.1"));
-   }
+    }
 
 }

--- a/providers/rackspace-cloudservers-uk/src/test/java/org/jclouds/rackspace/cloudservers/uk/compute/extensions/CloudServersUKVolumeAttachmentExtensionLiveTest.java
+++ b/providers/rackspace-cloudservers-uk/src/test/java/org/jclouds/rackspace/cloudservers/uk/compute/extensions/CloudServersUKVolumeAttachmentExtensionLiveTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudservers.uk.compute.extensions;
+
+import java.util.Properties;
+
+import org.jclouds.openstack.nova.v2_0.extensions.VolumeAttachmentApiLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", singleThreaded = true, testName = "CloudServersUKVolumeAttachmentExtensionLiveTest")
+public class CloudServersUKVolumeAttachmentExtensionLiveTest extends VolumeAttachmentApiLiveTest {
+
+   public CloudServersUKVolumeAttachmentExtensionLiveTest() {
+      provider = "rackspace-cloudservers-uk";
+      // Specifying a device currently does not work for rackspace and causes issues
+      deviceId = "";
+   }
+
+   @Override
+   protected Properties setupProperties() {
+      Properties props = super.setupProperties();
+      volumeProvider = "rackspace-cloudblockstorage-uk";
+      volumeSizeGB = 80;
+      singleRegion = "LON";
+      return props;
+   }
+
+}

--- a/providers/rackspace-cloudservers-us/pom.xml
+++ b/providers/rackspace-cloudservers-us/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>openstack-nova</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- for the extension namespaces -->
+    <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-multibindings</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-core</artifactId>


### PR DESCRIPTION
Fixes the volume extension namespace in the HPCloud Compute provider.
This PR also adds a custom method to make it easier to override the default OpenStack namespaces without having to copy/paste the entire Guice module, and allows to configure the Cinder version in the tests (which could be different than the provider's compute version, for example).

/cc @zack-shoylev @ccustine @everett-toews

While fixing this I've noticed that the RAX UK provider was not updated with the volume attachment fixes. Should that be done?