### PR TITLE
Volume attachment fix for cloudservers-uk

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/config/NovaHttpApiModule.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/config/NovaHttpApiModule.java
@@ -62,40 +62,44 @@ public class NovaHttpApiModule extends HttpApiModule<NovaApi> {
    @Provides
    @Singleton
    public Multimap<URI, URI> aliases() {
-       return ImmutableMultimap.<URI, URI>builder()
-          .put(URI.create(ExtensionNamespaces.SECURITY_GROUPS),
-               URI.create("http://docs.openstack.org/compute/ext/securitygroups/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.FLOATING_IPS),
-               URI.create("http://docs.openstack.org/compute/ext/floating_ips/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.KEYPAIRS),
-               URI.create("http://docs.openstack.org/compute/ext/keypairs/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.SIMPLE_TENANT_USAGE),
-               URI.create("http://docs.openstack.org/compute/ext/os-simple-tenant-usage/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.HOSTS),
-               URI.create("http://docs.openstack.org/compute/ext/hosts/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.VOLUMES),
-               URI.create("http://docs.openstack.org/compute/ext/volumes/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.VIRTUAL_INTERFACES),
-               URI.create("http://docs.openstack.org/compute/ext/virtual_interfaces/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.CREATESERVEREXT),
-               URI.create("http://docs.openstack.org/compute/ext/createserverext/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.ADMIN_ACTIONS),
-               URI.create("http://docs.openstack.org/compute/ext/admin-actions/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.AGGREGATES),
-               URI.create("http://docs.openstack.org/compute/ext/aggregates/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.FLAVOR_EXTRA_SPECS),
-               URI.create("http://docs.openstack.org/compute/ext/flavor_extra_specs/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.QUOTAS),
-               URI.create("http://docs.openstack.org/compute/ext/quotas-sets/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.VOLUME_TYPES),
-               URI.create("http://docs.openstack.org/compute/ext/volume_types/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.AVAILABILITY_ZONE),
-               URI.create("http://docs.openstack.org/compute/ext/availabilityzone/api/v1.1"))
-          .put(URI.create(ExtensionNamespaces.VOLUME_ATTACHMENTS),
-               URI.create("http://docs.openstack.org/compute/ext/os-volume-attachment-update/api/v2"))
-          .put(URI.create(ExtensionNamespaces.ATTACH_INTERFACES),
-               URI.create("http://docs.openstack.org/compute/ext/interfaces/api/v1.1"))
-          .build();
+      return customAliases(ImmutableMultimap.<URI, URI>builder()
+            .put(URI.create(ExtensionNamespaces.SECURITY_GROUPS),
+                  URI.create("http://docs.openstack.org/compute/ext/securitygroups/api/v1.1"))
+            .put(URI.create(ExtensionNamespaces.FLOATING_IPS),
+                  URI.create("http://docs.openstack.org/compute/ext/floating_ips/api/v1.1"))
+            .put(URI.create(ExtensionNamespaces.KEYPAIRS),
+                  URI.create("http://docs.openstack.org/compute/ext/keypairs/api/v1.1"))
+            .put(URI.create(ExtensionNamespaces.SIMPLE_TENANT_USAGE),
+                  URI.create("http://docs.openstack.org/compute/ext/os-simple-tenant-usage/api/v1.1"))
+            .put(URI.create(ExtensionNamespaces.HOSTS),
+                  URI.create("http://docs.openstack.org/compute/ext/hosts/api/v1.1"))
+            .put(URI.create(ExtensionNamespaces.VOLUMES),
+                  URI.create("http://docs.openstack.org/compute/ext/volumes/api/v1.1"))
+            .put(URI.create(ExtensionNamespaces.VIRTUAL_INTERFACES),
+                  URI.create("http://docs.openstack.org/compute/ext/virtual_interfaces/api/v1.1"))
+            .put(URI.create(ExtensionNamespaces.CREATESERVEREXT),
+                  URI.create("http://docs.openstack.org/compute/ext/createserverext/api/v1.1"))
+            .put(URI.create(ExtensionNamespaces.ADMIN_ACTIONS),
+                  URI.create("http://docs.openstack.org/compute/ext/admin-actions/api/v1.1"))
+            .put(URI.create(ExtensionNamespaces.AGGREGATES),
+                  URI.create("http://docs.openstack.org/compute/ext/aggregates/api/v1.1"))
+            .put(URI.create(ExtensionNamespaces.FLAVOR_EXTRA_SPECS),
+                  URI.create("http://docs.openstack.org/compute/ext/flavor_extra_specs/api/v1.1"))
+            .put(URI.create(ExtensionNamespaces.QUOTAS),
+                  URI.create("http://docs.openstack.org/compute/ext/quotas-sets/api/v1.1"))
+            .put(URI.create(ExtensionNamespaces.VOLUME_TYPES),
+                  URI.create("http://docs.openstack.org/compute/ext/volume_types/api/v1.1"))
+            .put(URI.create(ExtensionNamespaces.AVAILABILITY_ZONE),
+                  URI.create("http://docs.openstack.org/compute/ext/availabilityzone/api/v1.1"))
+            .put(URI.create(ExtensionNamespaces.VOLUME_ATTACHMENTS),
+                  URI.create("http://docs.openstack.org/compute/ext/os-volume-attachment-update/api/v2"))
+            .put(URI.create(ExtensionNamespaces.ATTACH_INTERFACES),
+                  URI.create("http://docs.openstack.org/compute/ext/interfaces/api/v1.1"))
+            .build());
+   }
+
+   protected Multimap<URI, URI> customAliases(Multimap<URI, URI> aliases) {
+      return aliases;
    }
 
    @Provides

--- a/providers/rackspace-cloudservers-uk/pom.xml
+++ b/providers/rackspace-cloudservers-uk/pom.xml
@@ -110,6 +110,12 @@
       <artifactId>auto-service</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.provider</groupId>
+      <artifactId>rackspace-cloudblockstorage-uk</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/providers/rackspace-cloudservers-uk/src/main/java/org/jclouds/rackspace/cloudservers/uk/CloudServersUKProviderMetadata.java
+++ b/providers/rackspace-cloudservers-uk/src/main/java/org/jclouds/rackspace/cloudservers/uk/CloudServersUKProviderMetadata.java
@@ -27,7 +27,6 @@ import java.util.Properties;
 
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
 import org.jclouds.openstack.nova.v2_0.NovaApiMetadata;
-import org.jclouds.openstack.nova.v2_0.config.NovaHttpApiModule;
 import org.jclouds.openstack.nova.v2_0.config.NovaParserModule;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
@@ -35,6 +34,7 @@ import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticati
 import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationModule;
 import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes;
 import org.jclouds.rackspace.cloudservers.uk.config.CloudServersUKComputeServiceContextModule;
+import org.jclouds.rackspace.cloudservers.uk.config.CloudServersUKHttpApiModule;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableSet;
@@ -89,7 +89,7 @@ public class CloudServersUKProviderMetadata extends BaseProviderMetadata {
                                               .add(CloudIdentityAuthenticationModule.class)
                                               .add(RegionModule.class)
                                               .add(NovaParserModule.class)
-                                              .add(NovaHttpApiModule.class)
+                                              .add(CloudServersUKHttpApiModule.class)
                                               .add(CloudServersUKComputeServiceContextModule.class).build())
                   .build())
          .homepage(URI.create("http://www.rackspace.co.uk/opencloud"))

--- a/providers/rackspace-cloudservers-uk/src/main/java/org/jclouds/rackspace/cloudservers/uk/config/CloudServersUKHttpApiModule.java
+++ b/providers/rackspace-cloudservers-uk/src/main/java/org/jclouds/rackspace/cloudservers/uk/config/CloudServersUKHttpApiModule.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jclouds.rackspace.cloudservers.us.config;
+package org.jclouds.rackspace.cloudservers.uk.config;
 
 import java.net.URI;
 
@@ -28,7 +28,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 
 @ConfiguresHttpApi
-public class CloudServersUSHttpApiModule extends NovaHttpApiModule {
+public class CloudServersUKHttpApiModule extends NovaHttpApiModule {
 
    @Override
    public Multimap<URI, URI> customAliases(Multimap<URI, URI> aliases) {

--- a/providers/rackspace-cloudservers-uk/src/test/java/org/jclouds/rackspace/cloudservers/uk/compute/extensions/CloudServersUKVolumeAttachmentExtensionLiveTest.java
+++ b/providers/rackspace-cloudservers-uk/src/test/java/org/jclouds/rackspace/cloudservers/uk/compute/extensions/CloudServersUKVolumeAttachmentExtensionLiveTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudservers.uk.compute.extensions;
+
+import java.util.Properties;
+
+import org.jclouds.openstack.nova.v2_0.extensions.VolumeAttachmentApiLiveTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "live", singleThreaded = true, testName = "CloudServersUKVolumeAttachmentExtensionLiveTest")
+public class CloudServersUKVolumeAttachmentExtensionLiveTest extends VolumeAttachmentApiLiveTest {
+
+   public CloudServersUKVolumeAttachmentExtensionLiveTest() {
+      provider = "rackspace-cloudservers-uk";
+      // Specifying a device currently does not work for rackspace and causes issues
+      deviceId = "";
+   }
+
+   @Override
+   protected Properties setupProperties() {
+      Properties props = super.setupProperties();
+      volumeProvider = "rackspace-cloudblockstorage-uk";
+      volumeSizeGB = 80;
+      singleRegion = "LON";
+      return props;
+   }
+
+}


### PR DESCRIPTION
Also uses @nacx better approach to making NovaHttpApi aliases overrideable.