### PR TITLE
Ensures files generated on Windows while building are not checked.

### DIFF
--- a/resources/checkstyle.xml
+++ b/resources/checkstyle.xml
@@ -91,5 +91,6 @@
     <module name="RegexpMultiline">
         <property name="format" value="\r\n"/>
         <property name="message" value="Do not use Windows line endings"/>
+        <property name="fileExtensions" value="java,xml,json"/>
     </module>
 </module>


### PR DESCRIPTION
For example:

```
[INFO] --- maven-checkstyle-plugin:2.15:check (default) @ jclouds-resources ---
[WARNING] target\maven-archiver\pom.properties[1] (regexp) RegexpMultiline: Do not use Windows line endings
[WARNING] target\maven-archiver\pom.properties[2] (regexp) RegexpMultiline: Do not use Windows line endings
[WARNING] target\maven-archiver\pom.properties[3] (regexp) RegexpMultiline: Do not use Windows line endings
[WARNING] target\maven-archiver\pom.properties[4] (regexp) RegexpMultiline: Do not use Windows line endings
[WARNING] target\maven-archiver\pom.properties[5] (regexp) RegexpMultiline: Do not use Windows line endings
[INFO] ------------------------------------------------------------------------
```