### PR TITLE
Fixes AWS EC2 virtualization types of hardware profiles

### DIFF
--- a/apis/ec2/src/main/java/org/jclouds/ec2/compute/domain/EC2HardwareBuilder.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/compute/domain/EC2HardwareBuilder.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import org.jclouds.compute.domain.Hardware;
 import org.jclouds.compute.domain.HardwareBuilder;
 import org.jclouds.compute.domain.Image;
-import org.jclouds.compute.domain.OsFamily;
 import org.jclouds.compute.domain.Processor;
 import org.jclouds.compute.domain.Volume;
 import org.jclouds.compute.domain.VolumeBuilder;
@@ -39,22 +38,33 @@ import org.jclouds.ec2.domain.InstanceType;
 import org.jclouds.ec2.domain.RootDeviceType;
 import org.jclouds.ec2.domain.VirtualizationType;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 
 /**
  * 
  * @see <a href=
  *      "http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/index.html?instance-types.html"
  *      />
+ * 
+ * and <a href=
+ *      "http://aws.amazon.com/amazon-linux-ami/instance-type-matrix/"
+ *      />.
+ *      
+ * Also note Windows only supports HVM, as per
+ *     <a href=
+ *     "http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html"
+ *     />.
+ *     On Windows you may have to constrain hardware appropriately.
  */
 public class EC2HardwareBuilder extends HardwareBuilder {
    private Predicate<Image> rootDeviceType = any();
-   private Predicate<Image> virtualizationType = Predicates.or(new IsWindows(), new RequiresVirtualizationType(
-         VirtualizationType.PARAVIRTUAL));
+   private Predicate<Image> virtualizationType = null; 
    private Predicate<Image> imageIds = any();
    private Predicate<Image> is64Bit = any();
 
@@ -85,20 +95,6 @@ public class EC2HardwareBuilder extends HardwareBuilder {
       @Override
       public String toString() {
          return "requiresRootDeviceType(" + type + ")";
-      }
-
-   }
-
-   public static class IsWindows implements Predicate<Image> {
-
-      @Override
-      public boolean apply(Image image) {
-         return image.getOperatingSystem() != null && OsFamily.WINDOWS == image.getOperatingSystem().getFamily();
-      }
-
-      @Override
-      public String toString() {
-         return "isWindows()";
       }
 
    }
@@ -136,6 +132,20 @@ public class EC2HardwareBuilder extends HardwareBuilder {
 
    public EC2HardwareBuilder virtualizationType(VirtualizationType virtualizationType) {
       this.virtualizationType = new RequiresVirtualizationType(virtualizationType);
+      return this;
+   }
+
+   public EC2HardwareBuilder virtualizationTypes(VirtualizationType ...virtualizationTypes) {
+      Preconditions.checkArgument(virtualizationTypes.length > 0, "At least one virtualization type is required.");
+      if (virtualizationTypes.length == 1) {
+         this.virtualizationType = new RequiresVirtualizationType(virtualizationTypes[0]);
+      } else {
+         List<RequiresVirtualizationType> supportedVirtualizationTypes = Lists.newArrayList();
+         for (VirtualizationType virtualizationType : virtualizationTypes) {
+            supportedVirtualizationTypes.add(new RequiresVirtualizationType(virtualizationType));
+         }
+         this.virtualizationType = Predicates.or(supportedVirtualizationTypes);
+      }
       return this;
    }
 
@@ -203,11 +213,104 @@ public class EC2HardwareBuilder extends HardwareBuilder {
       return EC2HardwareBuilder.class.cast(super.userMetadata(userMetadata));
    }
 
+   private EC2HardwareBuilder t2() {
+      virtualizationTypes(VirtualizationType.HVM);
+      return this;
+   }
+   
+   private EC2HardwareBuilder m3() {
+      virtualizationTypes(VirtualizationType.HVM, VirtualizationType.PARAVIRTUAL);
+      return this;
+   }
+   
+   private EC2HardwareBuilder c3() {
+      virtualizationTypes(VirtualizationType.HVM, VirtualizationType.PARAVIRTUAL);
+      return this;
+   }
+   
+   private EC2HardwareBuilder c4() {
+      virtualizationTypes(VirtualizationType.HVM, VirtualizationType.PARAVIRTUAL);
+      return this;
+   }
+   
+   // TODO include D2 (dense) types?
+   @SuppressWarnings("unused")
+   private EC2HardwareBuilder d2() {
+      virtualizationTypes(VirtualizationType.HVM);
+      return this;
+   }
+   
+   private EC2HardwareBuilder r3() {
+      virtualizationTypes(VirtualizationType.HVM);
+      return this;
+   }
+   
+   private EC2HardwareBuilder g2() {
+      virtualizationTypes(VirtualizationType.HVM);
+      return this;
+   }
+   
+   private EC2HardwareBuilder i2() {
+      virtualizationTypes(VirtualizationType.HVM);
+      return this;
+   }
+   
+   private EC2HardwareBuilder hs1() {
+      virtualizationTypes(VirtualizationType.HVM, VirtualizationType.PARAVIRTUAL);
+      return this;
+   }
+
+   // TODO below this line are previous generation, discouraged
+   // http://aws.amazon.com/ec2/previous-generation/
+   private EC2HardwareBuilder m1() {
+      virtualizationTypes(VirtualizationType.PARAVIRTUAL);
+      return this;
+   }
+   
+   private EC2HardwareBuilder c1() {
+      virtualizationTypes(VirtualizationType.PARAVIRTUAL);
+      return this;
+   }
+   
+   private EC2HardwareBuilder cc2() {
+      virtualizationTypes(VirtualizationType.HVM);
+      return this;
+   }
+   
+   private EC2HardwareBuilder m2() {
+      virtualizationTypes(VirtualizationType.PARAVIRTUAL);
+      return this;
+   }
+   
+   // cr1 never included in jclouds, so skipped here
+   
+   private EC2HardwareBuilder hi1() {
+      virtualizationTypes(VirtualizationType.HVM, VirtualizationType.PARAVIRTUAL);
+      return this;
+   }
+   
+   private EC2HardwareBuilder t1() {
+      virtualizationTypes(VirtualizationType.PARAVIRTUAL);
+      return this;
+   }
+   
+   private EC2HardwareBuilder cg1() {
+      virtualizationTypes(VirtualizationType.HVM);
+      return this;
+   }
+   
+   private EC2HardwareBuilder cc1() {
+      // often no longer available - not adding capacity (use cc2)
+      virtualizationTypes(VirtualizationType.HVM);
+      return this;
+   }
+   
+
    /**
     * @see InstanceType#M1_SMALL
     */
    public static EC2HardwareBuilder m1_small() {
-      return new EC2HardwareBuilder(InstanceType.M1_SMALL)
+      return new EC2HardwareBuilder(InstanceType.M1_SMALL).m1()
             .ram(1740)
             .processors(ImmutableList.of(new Processor(1.0, 1.0)))
             .volumes(ImmutableList.<Volume> of(
@@ -219,7 +322,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#M1_MEDIUM
     */
    public static EC2HardwareBuilder m1_medium() {
-      return new EC2HardwareBuilder(InstanceType.M1_MEDIUM)
+      return new EC2HardwareBuilder(InstanceType.M1_MEDIUM).m1()
             .ram(3750)
             .processors(ImmutableList.of(new Processor(1.0, 2.0)))
             .volumes(ImmutableList.<Volume> of(
@@ -233,7 +336,8 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#T1_MICRO
     */
    public static EC2HardwareBuilder t1_micro() {
-      return new EC2HardwareBuilder(InstanceType.T1_MICRO).ram(630)
+      return new EC2HardwareBuilder(InstanceType.T1_MICRO).t1()
+            .ram(630)
             .processors(ImmutableList.of(new Processor(1.0, 1.0))).rootDeviceType(RootDeviceType.EBS);
    }
 
@@ -241,7 +345,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#T2_MICRO
     */
    public static EC2HardwareBuilder t2_micro() {
-      return new EC2HardwareBuilder(InstanceType.T2_MICRO)
+      return new EC2HardwareBuilder(InstanceType.T2_MICRO).t2()
             .ram(1024)
             .processors(ImmutableList.of(new Processor(1.0, 0.1))).rootDeviceType(RootDeviceType.EBS);
    }
@@ -250,7 +354,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#T2_SMALL
     */
    public static EC2HardwareBuilder t2_small() {
-      return new EC2HardwareBuilder(InstanceType.T2_SMALL)
+      return new EC2HardwareBuilder(InstanceType.T2_SMALL).t2()
             .ram(2048)
             .processors(ImmutableList.of(new Processor(1.0, 0.2))).rootDeviceType(RootDeviceType.EBS);
    }
@@ -259,7 +363,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#T2_MEDIUM
     */
    public static EC2HardwareBuilder t2_medium() {
-      return new EC2HardwareBuilder(InstanceType.T2_MEDIUM)
+      return new EC2HardwareBuilder(InstanceType.T2_MEDIUM).t2()
             .ram(4096)
             .processors(ImmutableList.of(new Processor(1.0, 0.4))).rootDeviceType(RootDeviceType.EBS);
    }
@@ -268,7 +372,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#M1_LARGE
     */
    public static EC2HardwareBuilder m1_large() {
-      return new EC2HardwareBuilder(InstanceType.M1_LARGE)
+      return new EC2HardwareBuilder(InstanceType.M1_LARGE).m1()
             .ram(7680)
             .processors(ImmutableList.of(new Processor(2.0, 2.0)))
             .volumes(ImmutableList.<Volume> of(
@@ -282,7 +386,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#M1_XLARGE
     */
    public static EC2HardwareBuilder m1_xlarge() {
-      return new EC2HardwareBuilder(InstanceType.M1_XLARGE)
+      return new EC2HardwareBuilder(InstanceType.M1_XLARGE).m1()
             .ram(15360)
             .processors(ImmutableList.of(new Processor(4.0, 2.0)))
             .volumes(ImmutableList.<Volume> of(
@@ -298,7 +402,8 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#M2_XLARGE
     */
    public static EC2HardwareBuilder m2_xlarge() {
-      return new EC2HardwareBuilder(InstanceType.M2_XLARGE).ram(17510)
+      return new EC2HardwareBuilder(InstanceType.M2_XLARGE).m2()
+            .ram(17510)
             .processors(ImmutableList.of(new Processor(2.0, 3.25)))
             .volumes(ImmutableList.<Volume> of(
                   new VolumeBuilder().type(LOCAL).size(420.0f).device("/dev/sda1").bootDevice(true).durable(false).build()))
@@ -309,7 +414,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#M2_2XLARGE
     */
    public static EC2HardwareBuilder m2_2xlarge() {
-      return new EC2HardwareBuilder(InstanceType.M2_2XLARGE)
+      return new EC2HardwareBuilder(InstanceType.M2_2XLARGE).m2()
             .ram(35020)
             .processors(ImmutableList.of(new Processor(4.0, 3.25)))
             .volumes(ImmutableList.<Volume> of(
@@ -322,7 +427,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#M2_4XLARGE
     */
    public static EC2HardwareBuilder m2_4xlarge() {
-      return new EC2HardwareBuilder(InstanceType.M2_4XLARGE)
+      return new EC2HardwareBuilder(InstanceType.M2_4XLARGE).m2()
             .ram(70041)
             .processors(ImmutableList.of(new Processor(8.0, 3.25)))
             .volumes(ImmutableList.<Volume> of(
@@ -336,7 +441,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#M3_MEDIUM
     */
    public static EC2HardwareBuilder m3_medium() {
-      return new EC2HardwareBuilder(InstanceType.M3_MEDIUM)
+      return new EC2HardwareBuilder(InstanceType.M3_MEDIUM).m3()
             .ram(3840)
             .processors(ImmutableList.of(new Processor(1.0, 3.0)))
             .volumes(ImmutableList.<Volume> of(
@@ -348,7 +453,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#M3_LARGE
     */
    public static EC2HardwareBuilder m3_large() {
-      return new EC2HardwareBuilder(InstanceType.M3_LARGE)
+      return new EC2HardwareBuilder(InstanceType.M3_LARGE).m3()
             .ram(7680)
             .processors(ImmutableList.of(new Processor(2.0, 3.25)))
             .volumes(ImmutableList.<Volume> of(
@@ -360,7 +465,8 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#M3_XLARGE
     */
    public static EC2HardwareBuilder m3_xlarge() {
-      return new EC2HardwareBuilder(InstanceType.M3_XLARGE).ram(15360)
+      return new EC2HardwareBuilder(InstanceType.M3_XLARGE).m3()
+              .ram(15360)
               .processors(ImmutableList.of(new Processor(4.0, 3.25)))
               .is64Bit(true)
               .volumes(ImmutableList.<Volume> of(
@@ -373,7 +479,8 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#M3_2XLARGE
     */
    public static EC2HardwareBuilder m3_2xlarge() {
-      return new EC2HardwareBuilder(InstanceType.M3_2XLARGE).ram(30720)
+      return new EC2HardwareBuilder(InstanceType.M3_2XLARGE).m3()
+              .ram(30720)
               .processors(ImmutableList.of(new Processor(8.0, 3.25)))
               .is64Bit(true)
               .volumes(ImmutableList.<Volume> of(
@@ -386,7 +493,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#C1_MEDIUM
     */
    public static EC2HardwareBuilder c1_medium() {
-      return new EC2HardwareBuilder(InstanceType.C1_MEDIUM)
+      return new EC2HardwareBuilder(InstanceType.C1_MEDIUM).c1()
             .ram(1740)
             .processors(ImmutableList.of(new Processor(2.0, 2.5)))
             .volumes(ImmutableList.<Volume> of(
@@ -398,7 +505,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#C1_XLARGE
     */
    public static EC2HardwareBuilder c1_xlarge() {
-      return new EC2HardwareBuilder(InstanceType.C1_XLARGE)
+      return new EC2HardwareBuilder(InstanceType.C1_XLARGE).c1()
             .ram(7168)
             .processors(ImmutableList.of(new Processor(8.0, 2.5)))
             .volumes(ImmutableList.<Volume> of(
@@ -414,7 +521,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#C3_LARGE
     */
    public static EC2HardwareBuilder c3_large() {
-      return new EC2HardwareBuilder(InstanceType.C3_LARGE)
+      return new EC2HardwareBuilder(InstanceType.C3_LARGE).c3()
               .ram(3750)
               .processors(ImmutableList.of(new Processor(2.0, 3.5)))
               .volumes(ImmutableList.<Volume> of(
@@ -428,7 +535,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#C3_XLARGE
     */
    public static EC2HardwareBuilder c3_xlarge() {
-      return new EC2HardwareBuilder(InstanceType.C3_XLARGE)
+      return new EC2HardwareBuilder(InstanceType.C3_XLARGE).c3()
               .ram(7168)
               .processors(ImmutableList.of(new Processor(4.0, 3.5)))
               .volumes(ImmutableList.<Volume> of(
@@ -442,7 +549,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#C3_2XLARGE
     */
    public static EC2HardwareBuilder c3_2xlarge() {
-      return new EC2HardwareBuilder(InstanceType.C3_2XLARGE)
+      return new EC2HardwareBuilder(InstanceType.C3_2XLARGE).c3()
               .ram(15360)
               .processors(ImmutableList.of(new Processor(8.0, 3.5)))
               .volumes(ImmutableList.<Volume> of(
@@ -456,7 +563,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#C3_4XLARGE
     */
    public static EC2HardwareBuilder c3_4xlarge() {
-      return new EC2HardwareBuilder(InstanceType.C3_4XLARGE)
+      return new EC2HardwareBuilder(InstanceType.C3_4XLARGE).c3()
               .ram(30720)
               .processors(ImmutableList.of(new Processor(16.0, 3.4375)))
               .volumes(ImmutableList.<Volume> of(
@@ -470,7 +577,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#C3_8XLARGE
     */
    public static EC2HardwareBuilder c3_8xlarge() {
-      return new EC2HardwareBuilder(InstanceType.C3_8XLARGE)
+      return new EC2HardwareBuilder(InstanceType.C3_8XLARGE).c3()
               .ram(61440)
               .processors(ImmutableList.of(new Processor(32.0, 3.375)))
               .volumes(ImmutableList.<Volume> of(
@@ -484,7 +591,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#C4_LARGE
     */
    public static EC2HardwareBuilder c4_large() {
-      return new EC2HardwareBuilder(InstanceType.C4_LARGE)
+      return new EC2HardwareBuilder(InstanceType.C4_LARGE).c4()
          .ram(3840)
          .processors(ImmutableList.of(new Processor(2.0, 3.5)))
          .rootDeviceType(RootDeviceType.EBS);
@@ -494,7 +601,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#C4_XLARGE
     */
    public static EC2HardwareBuilder c4_xlarge() {
-      return new EC2HardwareBuilder(InstanceType.C4_XLARGE)
+      return new EC2HardwareBuilder(InstanceType.C4_XLARGE).c4()
          .ram(7680)
          .processors(ImmutableList.of(new Processor(4.0, 3.5)))
          .rootDeviceType(RootDeviceType.EBS);
@@ -504,7 +611,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#C4_2XLARGE
     */
    public static EC2HardwareBuilder c4_2xlarge() {
-      return new EC2HardwareBuilder(InstanceType.C4_2XLARGE)
+      return new EC2HardwareBuilder(InstanceType.C4_2XLARGE).c4()
          .ram(15360)
          .processors(ImmutableList.of(new Processor(8.0, 3.5)))
          .rootDeviceType(RootDeviceType.EBS);
@@ -514,7 +621,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#C4_4XLARGE
     */
    public static EC2HardwareBuilder c4_4xlarge() {
-      return new EC2HardwareBuilder(InstanceType.C4_4XLARGE)
+      return new EC2HardwareBuilder(InstanceType.C4_4XLARGE).c4()
          .ram(30720)
          .processors(ImmutableList.of(new Processor(16.0, 3.5)))
          .rootDeviceType(RootDeviceType.EBS);
@@ -524,14 +631,14 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#C4_8XLARGE
     */
    public static EC2HardwareBuilder c4_8xlarge() {
-      return new EC2HardwareBuilder(InstanceType.C4_8XLARGE)
+      return new EC2HardwareBuilder(InstanceType.C4_8XLARGE).c4()
          .ram(61440)
          .processors(ImmutableList.of(new Processor(36.0, 3.5)))
          .rootDeviceType(RootDeviceType.EBS);
    }
 
    public static EC2HardwareBuilder cg1_4xlarge() {
-      return new EC2HardwareBuilder(InstanceType.CG1_4XLARGE)
+      return new EC2HardwareBuilder(InstanceType.CG1_4XLARGE).cg1()
             .ram(22 * 1024)
             .processors(ImmutableList.of(new Processor(4.0, 4.0), new Processor(4.0, 4.0)))
             .volumes(ImmutableList.<Volume> of(
@@ -542,7 +649,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
    }
 
    public static EC2HardwareBuilder cc1_4xlarge() {
-      return new EC2HardwareBuilder(InstanceType.CC1_4XLARGE)
+      return new EC2HardwareBuilder(InstanceType.CC1_4XLARGE).cc1()
             .ram(23 * 1024)
             .processors(ImmutableList.of(new Processor(4.0, 4.0), new Processor(4.0, 4.0)))
             .volumes(ImmutableList.<Volume> of(
@@ -553,7 +660,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
    }
 
    public static EC2HardwareBuilder cc2_8xlarge() {
-      return new EC2HardwareBuilder(InstanceType.CC2_8XLARGE)
+      return new EC2HardwareBuilder(InstanceType.CC2_8XLARGE).cc2()
             .ram(60 * 1024 + 512)
             .processors(ImmutableList.of(new Processor(8.0, 5.5), new Processor(8.0, 5.5)))
             .volumes(ImmutableList.<Volume> of(
@@ -569,7 +676,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#G2_2XLARGE
     */
    public static EC2HardwareBuilder g2_2xlarge() {
-      return new EC2HardwareBuilder(InstanceType.G2_2XLARGE)
+      return new EC2HardwareBuilder(InstanceType.G2_2XLARGE).g2()
 	    .ram(15 * 1024)
             .processors(ImmutableList.of(new Processor(8.0, 3.25)))
             .volumes(ImmutableList.<Volume> of(
@@ -582,7 +689,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#I2_XLARGE
     */
    public static EC2HardwareBuilder i2_xlarge() {
-      return new EC2HardwareBuilder(InstanceType.I2_XLARGE)
+      return new EC2HardwareBuilder(InstanceType.I2_XLARGE).i2()
               .ram(30 * 1024 + 512)
               .processors(ImmutableList.of(new Processor(4.0, 3.5)))
               .volumes(ImmutableList.<Volume> of(
@@ -595,7 +702,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#I2_2XLARGE
     */
    public static EC2HardwareBuilder i2_2xlarge() {
-      return new EC2HardwareBuilder(InstanceType.I2_2XLARGE)
+      return new EC2HardwareBuilder(InstanceType.I2_2XLARGE).i2()
               .ram(61 * 1024)
               .processors(ImmutableList.of(new Processor(8.0, 3.375)))
               .volumes(ImmutableList.<Volume> of(
@@ -609,7 +716,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#I2_4XLARGE
     */
    public static EC2HardwareBuilder i2_4xlarge() {
-      return new EC2HardwareBuilder(InstanceType.I2_4XLARGE)
+      return new EC2HardwareBuilder(InstanceType.I2_4XLARGE).i2()
               .ram(122 * 1024)
               .processors(ImmutableList.of(new Processor(16.0, 3.3125)))
               .volumes(ImmutableList.<Volume> of(
@@ -625,7 +732,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#I2_8XLARGE
     */
    public static EC2HardwareBuilder i2_8xlarge() {
-      return new EC2HardwareBuilder(InstanceType.I2_8XLARGE)
+      return new EC2HardwareBuilder(InstanceType.I2_8XLARGE).i2()
               .ram(244 * 1024)
               .processors(ImmutableList.of(new Processor(32.0, 3.25)))
               .volumes(ImmutableList.<Volume> of(
@@ -642,7 +749,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
    }
 
    public static EC2HardwareBuilder hi1_4xlarge() {
-      return new EC2HardwareBuilder(InstanceType.HI1_4XLARGE)
+      return new EC2HardwareBuilder(InstanceType.HI1_4XLARGE).hi1()
             .ram(60 * 1024 + 512)
             .processors(ImmutableList.of(new Processor(16.0, 2.1875)))
             .volumes(ImmutableList.<Volume> of(
@@ -659,7 +766,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
             'q', 'r', 's', 't', 'u', 'v', 'w', 'x')) {
          all24Volumes.add(new VolumeBuilder().type(LOCAL).size(twoTB).device("/dev/sd" + letter).bootDevice(false).durable(false).build());
       }
-      return new EC2HardwareBuilder(InstanceType.HS1_8XLARGE)
+      return new EC2HardwareBuilder(InstanceType.HS1_8XLARGE).hs1()
             .ram(117 * 1024)
             .processors(ImmutableList.of(new Processor(16.0, 2.1875)))
             .volumes(all24Volumes.build())
@@ -670,7 +777,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#R3_LARGE
     */
    public static EC2HardwareBuilder r3_large() {
-      return new EC2HardwareBuilder(InstanceType.R3_LARGE)
+      return new EC2HardwareBuilder(InstanceType.R3_LARGE).r3()
             .ram(15616)
             .processors(ImmutableList.of(new Processor(2.0, 2.5)))
             .volumes(ImmutableList.<Volume> of(
@@ -682,7 +789,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#R3_XLARGE
     */
    public static EC2HardwareBuilder r3_xlarge() {
-      return new EC2HardwareBuilder(InstanceType.R3_XLARGE)
+      return new EC2HardwareBuilder(InstanceType.R3_XLARGE).r3()
             .ram(31232)
             .processors(ImmutableList.of(new Processor(4.0, 2.5)))
             .volumes(ImmutableList.<Volume> of(
@@ -694,7 +801,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#R3_2XLARGE
     */
    public static EC2HardwareBuilder r3_2xlarge() {
-      return new EC2HardwareBuilder(InstanceType.R3_2XLARGE)
+      return new EC2HardwareBuilder(InstanceType.R3_2XLARGE).r3()
             .ram(62464)
             .processors(ImmutableList.of(new Processor(8.0, 2.5)))
             .volumes(ImmutableList.<Volume> of(
@@ -706,7 +813,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#R3_4XLARGE
     */
    public static EC2HardwareBuilder r3_4xlarge() {
-      return new EC2HardwareBuilder(InstanceType.R3_4XLARGE)
+      return new EC2HardwareBuilder(InstanceType.R3_4XLARGE).r3()
             .ram(124928)
             .processors(ImmutableList.of(new Processor(16.0, 2.5)))
             .volumes(ImmutableList.<Volume> of(
@@ -718,7 +825,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
     * @see InstanceType#R3_8XLARGE
     */
    public static EC2HardwareBuilder r3_8xlarge() {
-      return new EC2HardwareBuilder(InstanceType.R3_8XLARGE)
+      return new EC2HardwareBuilder(InstanceType.R3_8XLARGE).r3()
             .ram(249856)
             .processors(ImmutableList.of(new Processor(32.0, 2.5)))
             .volumes(ImmutableList.<Volume> of(
@@ -730,6 +837,7 @@ public class EC2HardwareBuilder extends HardwareBuilder {
    @SuppressWarnings("unchecked")
    @Override
    public Hardware build() {
+      Preconditions.checkNotNull(virtualizationType, "virtualizationType");
       boolean reset = false;
       if (this.supportsImage == null)
          reset = true;

--- a/apis/ec2/src/main/java/org/jclouds/ec2/compute/domain/EC2HardwareBuilder.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/compute/domain/EC2HardwareBuilder.java
@@ -136,13 +136,15 @@ public class EC2HardwareBuilder extends HardwareBuilder {
    }
 
    public EC2HardwareBuilder virtualizationTypes(VirtualizationType ...virtualizationTypes) {
+      Preconditions.checkNotNull(virtualizationTypes, "virtualizationTypes");
       Preconditions.checkArgument(virtualizationTypes.length > 0, "At least one virtualization type is required.");
       if (virtualizationTypes.length == 1) {
          this.virtualizationType = new RequiresVirtualizationType(virtualizationTypes[0]);
       } else {
          List<RequiresVirtualizationType> supportedVirtualizationTypes = Lists.newArrayList();
          for (VirtualizationType virtualizationType : virtualizationTypes) {
-            supportedVirtualizationTypes.add(new RequiresVirtualizationType(virtualizationType));
+            supportedVirtualizationTypes.add(new RequiresVirtualizationType(
+                  Preconditions.checkNotNull(virtualizationType, "virtualizationType")));
          }
          this.virtualizationType = Predicates.or(supportedVirtualizationTypes);
       }
@@ -215,6 +217,15 @@ public class EC2HardwareBuilder extends HardwareBuilder {
 
    private EC2HardwareBuilder t2() {
       virtualizationTypes(VirtualizationType.HVM);
+      
+      // TODO T2 is not deprecated, but it requires that you are using a VPC
+      // until we have a way for hardware instances to be filtered based on network
+      // we do NOT want T2 selected automatically.
+      // You get: org.jclouds.aws.AWSResponseException: request POST https://ec2.eu-west-1.amazonaws.com/ HTTP/1.1 failed with code 400, error: AWSError{requestId='2300b99e-ddc0-42ab-b1ed-9d628a161be4', requestToken='null', code='VPCResourceNotSpecified', message='The specified instance type can only be used in a VPC. A subnet ID or network interface ID is required to carry out the request.', context='{Response=, Errors=}'}
+      // A user can explicitly request a t2.micro if they are also setting up a VPC,
+      // but the small default will now be m3.medium which supports VPC and "classic".
+      deprecated();
+      
       return this;
    }
    
@@ -264,21 +275,25 @@ public class EC2HardwareBuilder extends HardwareBuilder {
    // http://aws.amazon.com/ec2/previous-generation/
    private EC2HardwareBuilder m1() {
       virtualizationTypes(VirtualizationType.PARAVIRTUAL);
+      deprecated();
       return this;
    }
    
    private EC2HardwareBuilder c1() {
       virtualizationTypes(VirtualizationType.PARAVIRTUAL);
+      deprecated();
       return this;
    }
    
    private EC2HardwareBuilder cc2() {
       virtualizationTypes(VirtualizationType.HVM);
+      deprecated();
       return this;
    }
    
    private EC2HardwareBuilder m2() {
       virtualizationTypes(VirtualizationType.PARAVIRTUAL);
+      deprecated();
       return this;
    }
    
@@ -286,22 +301,26 @@ public class EC2HardwareBuilder extends HardwareBuilder {
    
    private EC2HardwareBuilder hi1() {
       virtualizationTypes(VirtualizationType.HVM, VirtualizationType.PARAVIRTUAL);
+      deprecated();
       return this;
    }
    
    private EC2HardwareBuilder t1() {
       virtualizationTypes(VirtualizationType.PARAVIRTUAL);
+      deprecated();
       return this;
    }
    
    private EC2HardwareBuilder cg1() {
       virtualizationTypes(VirtualizationType.HVM);
+      deprecated();
       return this;
    }
    
    private EC2HardwareBuilder cc1() {
       // often no longer available - not adding capacity (use cc2)
       virtualizationTypes(VirtualizationType.HVM);
+      deprecated();
       return this;
    }
    

--- a/apis/ec2/src/main/java/org/jclouds/ec2/compute/functions/ImagesToRegionAndIdMap.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/compute/functions/ImagesToRegionAndIdMap.java
@@ -27,6 +27,7 @@ import org.jclouds.compute.domain.Image;
 import org.jclouds.ec2.compute.domain.RegionAndName;
 
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 
 @Singleton
 public class ImagesToRegionAndIdMap implements Function<Iterable<? extends Image>, Map<RegionAndName, ? extends Image>> {
@@ -43,7 +44,9 @@ public class ImagesToRegionAndIdMap implements Function<Iterable<? extends Image
          public RegionAndName apply(Image from) {
             checkState(from.getLocation() != null,
                      "in ec2, image locations cannot be null; typically, they are Region-scoped");
-            return new RegionAndName(from.getLocation().getId(), from.getProviderId());
+            String[] segments = from.getId().split("/");
+            Preconditions.checkArgument(segments.length == 2, "Wrong form for AWS image ID: " + from);
+            return new RegionAndName(segments[0], segments[1]);
          }
 
       });

--- a/compute/src/main/java/org/jclouds/compute/domain/Hardware.java
+++ b/compute/src/main/java/org/jclouds/compute/domain/Hardware.java
@@ -55,4 +55,9 @@ public interface Hardware extends ComputeMetadata {
     */
    @Nullable
    String getHypervisor();
+   
+   /**
+    * True if usage of the hardware profile is now discouraged.
+    */
+   boolean isDeprecated();
 }

--- a/compute/src/main/java/org/jclouds/compute/domain/HardwareBuilder.java
+++ b/compute/src/main/java/org/jclouds/compute/domain/HardwareBuilder.java
@@ -38,6 +38,7 @@ public class HardwareBuilder extends ComputeMetadataBuilder {
    protected List<Volume> volumes = Lists.newArrayList();
    protected Predicate<Image> supportsImage = any();
    protected String hypervisor;
+   protected boolean deprecated = false;
 
    public HardwareBuilder() {
       super(ComputeType.HARDWARE);
@@ -78,6 +79,15 @@ public class HardwareBuilder extends ComputeMetadataBuilder {
       return this;
    }
 
+   public HardwareBuilder deprecated(boolean deprecated) {
+      this.deprecated = deprecated;
+      return this;
+   }
+   
+   public HardwareBuilder deprecated() {
+       return deprecated(true);
+   }
+   
    public HardwareBuilder is64Bit(boolean is64Bit) {
       supportsImage(is64Bit ? ImagePredicates.is64Bit() : not(ImagePredicates.is64Bit()));
       return this;
@@ -126,7 +136,7 @@ public class HardwareBuilder extends ComputeMetadataBuilder {
    @Override
    public Hardware build() {
       return new HardwareImpl(providerId, name, id, location, uri, userMetadata, tags, processors, ram, volumes,
-               supportsImage, hypervisor);
+               supportsImage, hypervisor, deprecated);
    }
 
    @SuppressWarnings("unchecked")

--- a/compute/src/main/java/org/jclouds/compute/domain/internal/HardwareImpl.java
+++ b/compute/src/main/java/org/jclouds/compute/domain/internal/HardwareImpl.java
@@ -46,16 +46,18 @@ public class HardwareImpl extends ComputeMetadataImpl implements Hardware {
    private final List<Volume> volumes;
    private final Predicate<Image> supportsImage;
    private final String hypervisor;
+   private final boolean deprecated;
 
    public HardwareImpl(String providerId, String name, String id, @Nullable Location location, URI uri,
          Map<String, String> userMetadata, Set<String> tags, Iterable<? extends Processor> processors, int ram,
-         Iterable<? extends Volume> volumes, Predicate<Image> supportsImage, @Nullable String hypervisor) {
+         Iterable<? extends Volume> volumes, Predicate<Image> supportsImage, @Nullable String hypervisor, boolean deprecated) {
       super(ComputeType.HARDWARE, providerId, name, id, location, uri, userMetadata, tags);
       this.processors = ImmutableList.copyOf(checkNotNull(processors, "processors"));
       this.ram = ram;
       this.volumes = ImmutableList.copyOf(checkNotNull(volumes, "volumes"));
       this.supportsImage = supportsImage;
       this.hypervisor = hypervisor;
+      this.deprecated = deprecated;
    }
 
    /**
@@ -91,6 +93,14 @@ public class HardwareImpl extends ComputeMetadataImpl implements Hardware {
       return hypervisor;
    }
 
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public boolean isDeprecated() {
+      return deprecated;
+   }
+   
    /**
     * {@inheritDoc}
     */

--- a/compute/src/main/java/org/jclouds/compute/domain/internal/TemplateBuilderImpl.java
+++ b/compute/src/main/java/org/jclouds/compute/domain/internal/TemplateBuilderImpl.java
@@ -483,6 +483,12 @@ public class TemplateBuilderImpl implements TemplateBuilder {
          return Doubles.compare(getCoresAndSpeed(left), getCoresAndSpeed(right));
       }
    };
+   static final Ordering<Hardware> NOT_DEPRECATED_ORDERING = new Ordering<Hardware>() {
+      public int compare(Hardware left, Hardware right) {
+         // we take max so deprecated items come first
+         return ComparisonChain.start().compareTrueFirst(left.isDeprecated(), right.isDeprecated()).result();
+      }
+   };
    static final Ordering<Image> DEFAULT_IMAGE_ORDERING = new Ordering<Image>() {
       public int compare(Image left, Image right) {
          /* This currently, and for some time, has *preferred* images whose fields are null,
@@ -819,6 +825,7 @@ public class TemplateBuilderImpl implements TemplateBuilder {
          hardwareOrdering = hardwareOrdering.reverse();
       if (fastest)
          hardwareOrdering = Ordering.compound(ImmutableList.of(BY_CORES_ORDERING, hardwareOrdering));
+      hardwareOrdering = Ordering.compound(ImmutableList.of(NOT_DEPRECATED_ORDERING, hardwareOrdering));
       return hardwareOrdering;
    }
 

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/AWSEC2ComputeServiceApiMockTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/AWSEC2ComputeServiceApiMockTest.java
@@ -32,6 +32,20 @@ import com.squareup.okhttp.mockwebserver.MockResponse;
 @Test(groups = "unit", testName = "AWSEC2ComputeServiceMockTest", singleThreaded = true)
 public class AWSEC2ComputeServiceApiMockTest extends BaseAWSEC2ApiMockTest {
 
+   protected String getDefaultSmallestInstanceType() {
+      // NOT t2.xxx because that requires a VPC
+      return "m3.medium";
+   }
+     
+   protected String getDefaultParavirtualInstanceType() {
+      // smallest non-deprecated instance type supporting paravirtual
+       return "m3.medium";
+   }
+
+   protected String getDefaultImageId() {
+       return "be3adfd7";
+   }
+   
    public void launchVPCSpotInstanceSubnetId() throws Exception {
       enqueueRegions(DEFAULT_REGION);
       enqueueXml(DEFAULT_REGION, "/availabilityZones.xml");
@@ -56,7 +70,7 @@ public class AWSEC2ComputeServiceApiMockTest extends BaseAWSEC2ApiMockTest {
       assertPosted(DEFAULT_REGION, "Action=DescribeAvailabilityZones");
       assertPosted(DEFAULT_REGION, "Action=DescribeImages&Filter.1.Name=owner-id&Filter.1.Value.1=137112412989&Filter.1.Value.2=801119661308&Filter.1.Value.3=063491364108&Filter.1.Value.4=099720109477&Filter.1.Value.5=411009282317&Filter.2.Name=state&Filter.2.Value.1=available&Filter.3.Name=image-type&Filter.3.Value.1=machine");
       assertPosted(DEFAULT_REGION, "Action=DescribeImages&Filter.1.Name=virtualization-type&Filter.1.Value.1=hvm&Filter.2.Name=architecture&Filter.2.Value.1=x86_64&Filter.3.Name=owner-id&Filter.3.Value.1=137112412989&Filter.3.Value.2=099720109477&Filter.4.Name=hypervisor&Filter.4.Value.1=xen&Filter.5.Name=state&Filter.5.Value.1=available&Filter.6.Name=image-type&Filter.6.Value.1=machine&Filter.7.Name=root-device-type&Filter.7.Value.1=ebs");
-      assertPosted(DEFAULT_REGION, "Action=RequestSpotInstances&SpotPrice=1.0&InstanceCount=1&LaunchSpecification.ImageId=ami-be3adfd7&LaunchSpecification.Placement.AvailabilityZone=us-east-1a&LaunchSpecification.InstanceType=m1.small&LaunchSpecification.SubnetId=subnet-xyz&LaunchSpecification.KeyName=Demo&LaunchSpecification.UserData=I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZ3JhZGU6IG5vbmUK");
+      assertPosted(DEFAULT_REGION, "Action=RequestSpotInstances&SpotPrice=1.0&InstanceCount=1&LaunchSpecification.ImageId=ami-" + getDefaultImageId() + "&LaunchSpecification.Placement.AvailabilityZone=us-east-1a&LaunchSpecification.InstanceType=" + getDefaultSmallestInstanceType() + "&LaunchSpecification.SubnetId=subnet-xyz&LaunchSpecification.KeyName=Demo&LaunchSpecification.UserData=I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZ3JhZGU6IG5vbmUK");
       assertPosted(DEFAULT_REGION, "Action=DescribeSpotInstanceRequests&SpotInstanceRequestId.1=sir-228e6406");
       assertPosted(DEFAULT_REGION, "Action=DescribeImages&ImageId.1=ami-595a0a1c");
       assertPosted(DEFAULT_REGION, "Action=CreateTags&Tag.1.Key=Name&Tag.1.Value=test-228e6406&ResourceId.1=sir-228e6406");
@@ -98,7 +112,7 @@ public class AWSEC2ComputeServiceApiMockTest extends BaseAWSEC2ApiMockTest {
       assertPosted(DEFAULT_REGION, "Action=DescribeSecurityGroups&GroupName.1=jclouds%23test");
       assertPosted(DEFAULT_REGION, "Action=DescribeSecurityGroups&GroupName.1=jclouds%23test");
       assertPosted(DEFAULT_REGION, "Action=AuthorizeSecurityGroupIngress&GroupId=sg-3c6ef654&IpPermissions.0.IpProtocol=tcp&IpPermissions.0.FromPort=22&IpPermissions.0.ToPort=22&IpPermissions.0.IpRanges.0.CidrIp=0.0.0.0/0&IpPermissions.1.IpProtocol=tcp&IpPermissions.1.FromPort=0&IpPermissions.1.ToPort=65535&IpPermissions.1.Groups.0.UserId=993194456877&IpPermissions.1.Groups.0.GroupId=sg-3c6ef654&IpPermissions.2.IpProtocol=udp&IpPermissions.2.FromPort=0&IpPermissions.2.ToPort=65535&IpPermissions.2.Groups.0.UserId=993194456877&IpPermissions.2.Groups.0.GroupId=sg-3c6ef654");
-      assertPosted(DEFAULT_REGION, "Action=RequestSpotInstances&SpotPrice=1.0&InstanceCount=1&LaunchSpecification.ImageId=ami-be3adfd7&LaunchSpecification.Placement.AvailabilityZone=us-east-1a&LaunchSpecification.SecurityGroup.1=jclouds%23test&LaunchSpecification.InstanceType=m1.small&LaunchSpecification.UserData=I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZ3JhZGU6IG5vbmUK&LaunchSpecification.IamInstanceProfile.Arn=arn%3Aaws%3Aiam%3A%3A123456789012%3Ainstance-profile/application_abc/component_xyz/Webserver");
+      assertPosted(DEFAULT_REGION, "Action=RequestSpotInstances&SpotPrice=1.0&InstanceCount=1&LaunchSpecification.ImageId=ami-" + getDefaultImageId() + "&LaunchSpecification.Placement.AvailabilityZone=us-east-1a&LaunchSpecification.SecurityGroup.1=jclouds%23test&LaunchSpecification.InstanceType=" + getDefaultSmallestInstanceType() + "&LaunchSpecification.UserData=I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZ3JhZGU6IG5vbmUK&LaunchSpecification.IamInstanceProfile.Arn=arn%3Aaws%3Aiam%3A%3A123456789012%3Ainstance-profile/application_abc/component_xyz/Webserver");
       assertPosted(DEFAULT_REGION, "Action=DescribeSpotInstanceRequests&SpotInstanceRequestId.1=sir-228e6406");
       assertPosted(DEFAULT_REGION, "Action=DescribeImages&ImageId.1=ami-595a0a1c");
       assertPosted(DEFAULT_REGION, "Action=CreateTags&Tag.1.Key=Name&Tag.1.Value=test-228e6406&ResourceId.1=sir-228e6406");
@@ -138,7 +152,7 @@ public class AWSEC2ComputeServiceApiMockTest extends BaseAWSEC2ApiMockTest {
       assertPosted(DEFAULT_REGION, "Action=DescribeSecurityGroups&GroupName.1=jclouds%23test");
       assertPosted(DEFAULT_REGION, "Action=DescribeSecurityGroups&GroupName.1=jclouds%23test");
       assertPosted(DEFAULT_REGION, "Action=AuthorizeSecurityGroupIngress&GroupId=sg-3c6ef654&IpPermissions.0.IpProtocol=tcp&IpPermissions.0.FromPort=22&IpPermissions.0.ToPort=22&IpPermissions.0.IpRanges.0.CidrIp=0.0.0.0/0&IpPermissions.1.IpProtocol=tcp&IpPermissions.1.FromPort=0&IpPermissions.1.ToPort=65535&IpPermissions.1.Groups.0.UserId=993194456877&IpPermissions.1.Groups.0.GroupId=sg-3c6ef654&IpPermissions.2.IpProtocol=udp&IpPermissions.2.FromPort=0&IpPermissions.2.ToPort=65535&IpPermissions.2.Groups.0.UserId=993194456877&IpPermissions.2.Groups.0.GroupId=sg-3c6ef654");
-      assertPosted(DEFAULT_REGION, "Action=RequestSpotInstances&SpotPrice=1.0&InstanceCount=1&LaunchSpecification.ImageId=ami-be3adfd7&LaunchSpecification.Placement.AvailabilityZone=us-east-1a&LaunchSpecification.SecurityGroup.1=jclouds%23test&LaunchSpecification.InstanceType=m1.small&LaunchSpecification.UserData=I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZ3JhZGU6IG5vbmUK&LaunchSpecification.IamInstanceProfile.Name=Webserver");
+      assertPosted(DEFAULT_REGION, "Action=RequestSpotInstances&SpotPrice=1.0&InstanceCount=1&LaunchSpecification.ImageId=ami-" + getDefaultImageId() + "&LaunchSpecification.Placement.AvailabilityZone=us-east-1a&LaunchSpecification.SecurityGroup.1=jclouds%23test&LaunchSpecification.InstanceType=" + getDefaultSmallestInstanceType() + "&LaunchSpecification.UserData=I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZ3JhZGU6IG5vbmUK&LaunchSpecification.IamInstanceProfile.Name=Webserver");
       assertPosted(DEFAULT_REGION, "Action=DescribeSpotInstanceRequests&SpotInstanceRequestId.1=sir-228e6406");
       assertPosted(DEFAULT_REGION, "Action=DescribeImages&ImageId.1=ami-595a0a1c");
       assertPosted(DEFAULT_REGION, "Action=CreateTags&Tag.1.Key=Name&Tag.1.Value=test-228e6406&ResourceId.1=sir-228e6406");
@@ -174,7 +188,7 @@ public class AWSEC2ComputeServiceApiMockTest extends BaseAWSEC2ApiMockTest {
       assertPosted(DEFAULT_REGION, "Action=DescribeSecurityGroups&GroupName.1=jclouds%23test");
       assertPosted(DEFAULT_REGION, "Action=DescribeSecurityGroups&GroupName.1=jclouds%23test");
       assertPosted(DEFAULT_REGION, "Action=AuthorizeSecurityGroupIngress&GroupId=sg-3c6ef654&IpPermissions.0.IpProtocol=tcp&IpPermissions.0.FromPort=22&IpPermissions.0.ToPort=22&IpPermissions.0.IpRanges.0.CidrIp=0.0.0.0/0&IpPermissions.1.IpProtocol=tcp&IpPermissions.1.FromPort=0&IpPermissions.1.ToPort=65535&IpPermissions.1.Groups.0.UserId=993194456877&IpPermissions.1.Groups.0.GroupId=sg-3c6ef654&IpPermissions.2.IpProtocol=udp&IpPermissions.2.FromPort=0&IpPermissions.2.ToPort=65535&IpPermissions.2.Groups.0.UserId=993194456877&IpPermissions.2.Groups.0.GroupId=sg-3c6ef654");
-      assertPosted(DEFAULT_REGION, "Action=RunInstances&ImageId=ami-8ce4b5c9&MinCount=1&MaxCount=1&InstanceType=t1.micro&SecurityGroup.1=jclouds%23test&UserData=I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZ3JhZGU6IG5vbmUK&IamInstanceProfile.Arn=arn%3Aaws%3Aiam%3A%3A123456789012%3Ainstance-profile/application_abc/component_xyz/Webserver");
+      assertPosted(DEFAULT_REGION, "Action=RunInstances&ImageId=ami-8ce4b5c9&MinCount=1&MaxCount=1&InstanceType=" + getDefaultParavirtualInstanceType() + "&SecurityGroup.1=jclouds%23test&UserData=I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZ3JhZGU6IG5vbmUK&IamInstanceProfile.Arn=arn%3Aaws%3Aiam%3A%3A123456789012%3Ainstance-profile/application_abc/component_xyz/Webserver");
       assertPosted(DEFAULT_REGION, "Action=DescribeInstances&InstanceId.1=i-2baa5550");
       assertPosted(DEFAULT_REGION, "Action=DescribeImages&ImageId.1=ami-aecd60c7");
       assertPosted(DEFAULT_REGION, "Action=CreateTags&Tag.1.Key=Name&Tag.1.Value=test-2baa5550&ResourceId.1=i-2baa5550");
@@ -210,7 +224,7 @@ public class AWSEC2ComputeServiceApiMockTest extends BaseAWSEC2ApiMockTest {
       assertPosted(DEFAULT_REGION, "Action=DescribeSecurityGroups&GroupName.1=jclouds%23test");
       assertPosted(DEFAULT_REGION, "Action=DescribeSecurityGroups&GroupName.1=jclouds%23test");
       assertPosted(DEFAULT_REGION, "Action=AuthorizeSecurityGroupIngress&GroupId=sg-3c6ef654&IpPermissions.0.IpProtocol=tcp&IpPermissions.0.FromPort=22&IpPermissions.0.ToPort=22&IpPermissions.0.IpRanges.0.CidrIp=0.0.0.0/0&IpPermissions.1.IpProtocol=tcp&IpPermissions.1.FromPort=0&IpPermissions.1.ToPort=65535&IpPermissions.1.Groups.0.UserId=993194456877&IpPermissions.1.Groups.0.GroupId=sg-3c6ef654&IpPermissions.2.IpProtocol=udp&IpPermissions.2.FromPort=0&IpPermissions.2.ToPort=65535&IpPermissions.2.Groups.0.UserId=993194456877&IpPermissions.2.Groups.0.GroupId=sg-3c6ef654");
-      assertPosted(DEFAULT_REGION, "Action=RunInstances&ImageId=ami-8ce4b5c9&MinCount=1&MaxCount=1&InstanceType=t1.micro&SecurityGroup.1=jclouds%23test&UserData=I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZ3JhZGU6IG5vbmUK&IamInstanceProfile.Name=Webserver");
+      assertPosted(DEFAULT_REGION, "Action=RunInstances&ImageId=ami-8ce4b5c9&MinCount=1&MaxCount=1&InstanceType=" + getDefaultParavirtualInstanceType() + "&SecurityGroup.1=jclouds%23test&UserData=I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZ3JhZGU6IG5vbmUK&IamInstanceProfile.Name=Webserver");
       assertPosted(DEFAULT_REGION, "Action=DescribeInstances&InstanceId.1=i-2baa5550");
       assertPosted(DEFAULT_REGION, "Action=DescribeImages&ImageId.1=ami-aecd60c7");
       assertPosted(DEFAULT_REGION, "Action=CreateTags&Tag.1.Key=Name&Tag.1.Value=test-2baa5550&ResourceId.1=i-2baa5550");

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/AWSEC2TemplateBuilderLiveTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/AWSEC2TemplateBuilderLiveTest.java
@@ -93,7 +93,7 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
    }
 
    @Test
-   public void testUbuntuInstanceStoreGoesM1SmallNegativeLookaroundDoesntMatchTestImages() {
+   public void testUbuntuInstanceStoreGoesM3MediumNegativeLookaroundDoesntMatchTestImages() {
 
       Template template = view.getComputeService().templateBuilder()
             .imageMatches(EC2ImagePredicates.rootDeviceType(RootDeviceType.INSTANCE_STORE))
@@ -114,12 +114,12 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
       assertEquals(template.getImage().getUserMetadata().get("rootDeviceType"), "instance-store");
       assertEquals(template.getLocation().getId(), "us-east-1");
       assertEquals(getCores(template.getHardware()), 1.0d);
-      assertEquals(template.getHardware().getId(), InstanceType.M1_SMALL);
+      assertEquals(template.getHardware().getId(), InstanceType.M3_MEDIUM);  // smallest non-deprecated supporting PV
       assertEquals(template.getImage().getOperatingSystem().getArch(), "paravirtual");
    }
 
    @Test
-   public void testTemplateBuilderCanUseImageIdAndhardwareIdAndAZ() {
+   public void testTemplateBuilderCanUseImageIdAndHardwareIdAndAZ() {
 
       Template template = view.getComputeService().templateBuilder().imageId("us-east-1/ami-ccb35ea5")
             .hardwareId(InstanceType.M2_2XLARGE).locationId("us-east-1a").build();
@@ -141,15 +141,15 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
    public void testDefaultTemplateBuilder() throws IOException {
       Template defaultTemplate = view.getComputeService().templateBuilder().build();
       assert defaultTemplate.getImage().getProviderId().startsWith("ami-") : defaultTemplate;
-      assertTrue(defaultTemplate.getImage().getOperatingSystem().getVersion().contains("pv-201"),
-              "Default template version should include 'pv-201' but is "
+      assertTrue(defaultTemplate.getImage().getOperatingSystem().getVersion().contains("201"),
+              "Default template version should include '201' but is "
                       + defaultTemplate.getImage().getOperatingSystem().getVersion());
       assertEquals(defaultTemplate.getImage().getOperatingSystem().is64Bit(), true);
       assertEquals(defaultTemplate.getImage().getOperatingSystem().getFamily(), AMZN_LINUX);
       assertEquals(defaultTemplate.getImage().getUserMetadata().get("rootDeviceType"), "ebs");
       assertEquals(defaultTemplate.getLocation().getId(), "us-east-1");
       assertEquals(getCores(defaultTemplate.getHardware()), 1.0d);
-      assertEquals(defaultTemplate.getImage().getOperatingSystem().getArch(), "paravirtual");
+      assertEquals(defaultTemplate.getImage().getOperatingSystem().getArch(), "hvm");
    }
 
    @Test
@@ -158,7 +158,7 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
       Template defaultTemplate = view.getComputeService().templateBuilder().osFamily(AMZN_LINUX)
             .imageMatches(EC2ImagePredicates.rootDeviceType(RootDeviceType.INSTANCE_STORE)).build();
       assert defaultTemplate.getImage().getProviderId().startsWith("ami-") : defaultTemplate;
-      assertEquals(defaultTemplate.getImage().getOperatingSystem().getVersion(), "pv-2014.09.2");
+      assertEquals(defaultTemplate.getImage().getOperatingSystem().getVersion(), "pv-2015.03.rc-1");
       assertEquals(defaultTemplate.getImage().getOperatingSystem().is64Bit(), true);
       assertEquals(defaultTemplate.getImage().getOperatingSystem().getFamily(), AMZN_LINUX);
       assertEquals(defaultTemplate.getImage().getUserMetadata().get("rootDeviceType"), "instance-store");
@@ -172,13 +172,13 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
       Template fastestTemplate = view.getComputeService().templateBuilder().fastest().osFamily(AMZN_LINUX).build();
       assert fastestTemplate.getImage().getProviderId().startsWith("ami-") : fastestTemplate;
       assertEquals(fastestTemplate.getHardware().getProviderId(), InstanceType.C4_8XLARGE);
-      assertEquals(fastestTemplate.getImage().getOperatingSystem().getVersion(), "vpc-nat-pv-2014.09.1");
+      assertEquals(fastestTemplate.getImage().getOperatingSystem().getVersion(), "2011.09.2");
       assertEquals(fastestTemplate.getImage().getOperatingSystem().is64Bit(), true);
       assertEquals(fastestTemplate.getImage().getOperatingSystem().getFamily(), AMZN_LINUX);
       assertEquals(fastestTemplate.getImage().getUserMetadata().get("rootDeviceType"), "ebs");
       assertEquals(fastestTemplate.getLocation().getId(), "us-east-1");
       assertEquals(getCores(fastestTemplate.getHardware()), 36.0d);
-      assertEquals(fastestTemplate.getImage().getOperatingSystem().getArch(), "paravirtual");
+      assertEquals(fastestTemplate.getImage().getOperatingSystem().getArch(), "hvm");
    }
 
    @Test
@@ -219,7 +219,7 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
          assertEquals(template.getImage().getUserMetadata().get("rootDeviceType"), "instance-store");
          assertEquals(template.getLocation().getId(), "us-east-1");
          assertEquals(getCores(template.getHardware()), 1.0d);
-         assertEquals(template.getHardware().getId(), "m1.small");
+         assertEquals(template.getHardware().getId(), "m3.medium"); // smallest non-deprecated supporting PV
 
          // ensure we cache the new image for next time
          assertEquals(context.getComputeService().listImages().size(), 1);
@@ -252,7 +252,7 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
          assertEquals(template.getImage().getUserMetadata().get("rootDeviceType"), "instance-store");
          assertEquals(template.getLocation().getId(), "us-east-1");
          assertEquals(getCores(template.getHardware()), 1.0d);
-         assertEquals(template.getHardware().getId(), "m1.small");
+         assertEquals(template.getHardware().getId(), "m3.medium");  // smallest non-deprecated supporting PV
 
          // ensure we cache the new image for next time
          assertEquals(context.getComputeService().listImages().size(), 1);
@@ -297,7 +297,7 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
          assertEquals(template.getImage().getUserMetadata().get("rootDeviceType"), "instance-store");
          assertEquals(template.getLocation().getId(), "eu-west-1");
          assertEquals(getCores(template.getHardware()), 1.0d);
-         assertEquals(template.getHardware().getId(), "m1.small");
+         assertEquals(template.getHardware().getId(), "m3.medium");  // smallest non-deprecated supporting PV
 
       } finally {
          if (context != null)

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/strategy/CreateKeyPairPlacementAndSecurityGroupsAsNeededAndReturnRunOptionsTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/strategy/CreateKeyPairPlacementAndSecurityGroupsAsNeededAndReturnRunOptionsTest.java
@@ -45,7 +45,6 @@ import org.jclouds.compute.domain.Template;
 import org.jclouds.compute.functions.GroupNamingConvention;
 import org.jclouds.compute.options.TemplateOptions;
 import org.jclouds.domain.LoginCredentials;
-import org.jclouds.ec2.compute.EC2TemplateBuilderTest;
 import org.jclouds.ec2.compute.domain.EC2HardwareBuilder;
 import org.jclouds.ec2.compute.domain.RegionAndName;
 import org.jclouds.ec2.compute.domain.RegionNameAndIngressRules;
@@ -140,7 +139,7 @@ public class CreateKeyPairPlacementAndSecurityGroupsAsNeededAndReturnRunOptionsT
       // setup constants
       String region = Region.US_EAST_1;
       String group = "group";
-      Hardware size = EC2TemplateBuilderTest.CC1_4XLARGE;
+      Hardware size = EC2HardwareBuilder.cc1_4xlarge().build();
       String systemGeneratedKeyPairName = "systemGeneratedKeyPair";
       String generatedGroup = "group";
       Set<String> generatedGroups = ImmutableSet.of(generatedGroup);
@@ -205,7 +204,7 @@ public class CreateKeyPairPlacementAndSecurityGroupsAsNeededAndReturnRunOptionsT
       // setup constants
       String region = Region.US_EAST_1;
       String group = "group";
-      Hardware size = EC2TemplateBuilderTest.CC1_4XLARGE;
+      Hardware size = EC2HardwareBuilder.cc1_4xlarge().build();
       String systemGeneratedKeyPairName = "systemGeneratedKeyPair";
       String generatedGroup = "group";
       Set<String> generatedGroups = ImmutableSet.of(generatedGroup);

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/PlacementGroupApiLiveTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/PlacementGroupApiLiveTest.java
@@ -165,13 +165,12 @@ public class PlacementGroupApiLiveTest extends BaseComputeServiceContextLiveTest
       assert availableTester.apply(group) : group;
    }
 
-   public void testStartCCInstance() throws Exception {
+   public void testStartHS1Instance() throws Exception {
 
       Template template = view.getComputeService().templateBuilder()
-               .fromHardware(EC2HardwareBuilder.cc2_8xlarge().build()).osFamily(OsFamily.AMZN_LINUX).build();
+               .fromHardware(EC2HardwareBuilder.hs1_8xlarge().build()).osFamily(OsFamily.AMZN_LINUX).build();
       assert template != null : "The returned template was null, but it should have a value.";
-      assertEquals(template.getHardware().getProviderId(), InstanceType.CC2_8XLARGE);
-      assertEquals(template.getImage().getUserMetadata().get("rootDeviceType"), "ebs");
+      assertEquals(template.getHardware().getProviderId(), InstanceType.HS1_8XLARGE);
       assertEquals(template.getImage().getUserMetadata().get("virtualizationType"), "hvm");
       assertEquals(template.getImage().getUserMetadata().get("hypervisor"), "xen");
 

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/SpotInstanceApiLiveTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/SpotInstanceApiLiveTest.java
@@ -139,10 +139,11 @@ public class SpotInstanceApiLiveTest  extends BaseComputeServiceContextLiveTest 
             assert spot.getSpotPrice() > 0 : spots;
             assertEquals(spot.getRegion(), region);
             assert in(
-                     ImmutableSet.of("Linux/UNIX", "Linux/UNIX (Amazon VPC)", "SUSE Linux", "SUSE Linux (Amazon VPC)",
+                    ImmutableSet.of("Linux/UNIX", "Linux/UNIX (Amazon VPC)", "SUSE Linux", "SUSE Linux (Amazon VPC)",
                               "Windows", "Windows (Amazon VPC)")).apply(spot.getProductDescription()) : spot;
-            assert in(
-                     ImmutableSet.of("c1.medium", "c1.xlarge", "cc1.4xlarge", "cg1.4xlarge", "cc2.8xlarge", "m1.large",
+            assert // sometimes get D2 type, which we don't yet enumerate
+                    spot.getInstanceType().startsWith("d2.") ||
+                    in(ImmutableSet.of("c1.medium", "c1.xlarge", "cc1.4xlarge", "cg1.4xlarge", "cc2.8xlarge", "m1.large",
                               "m1.small", "m1.medium", "m1.xlarge", "m2.2xlarge", "m2.4xlarge", "m2.xlarge", "m3.xlarge",
                               "m3.2xlarge", "t1.micro", "cr1.8xlarge", "c4.large", "c4.xlarge", "c4.2xlarge", "c4.4xlarge",
                               "c4.8xlarge")).apply(spot.getInstanceType()) : spot;


### PR DESCRIPTION
New generation hardware instance types prefer HVM, with some not supporting Paravirtual.  The code used to assume all AWS Hardware instance types were PV, causing the failure described at https://issues.apache.org/jira/browse/JCLOUDS-889 .

This also adds a `boolean deprecated` to `Hardware`, defaulting to `false`, with `TemplateBuilderImpl` preferring non-deprecated hardware types.  For AWS types, we deprecate those "previous generation" hardware instance types which AWS says should only be used where an image has been specially optimized for the type.  This means new-generation instance types will be preferred.