### PR TITLE
JCLOUDS-894: Expose multipart upload component operations

### DIFF
--- a/apis/atmos/src/main/java/org/jclouds/atmos/blobstore/AtmosBlobStore.java
+++ b/apis/atmos/src/main/java/org/jclouds/atmos/blobstore/AtmosBlobStore.java
@@ -19,6 +19,7 @@ package org.jclouds.atmos.blobstore;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.jclouds.atmos.options.PutOptions.Builder.publicRead;
 
+import java.util.List;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -38,6 +39,8 @@ import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobAccess;
 import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.domain.ContainerAccess;
+import org.jclouds.blobstore.domain.MultipartPart;
+import org.jclouds.blobstore.domain.MultipartUpload;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.functions.BlobToHttpGetOptions;
@@ -50,6 +53,7 @@ import org.jclouds.collect.Memoized;
 import org.jclouds.crypto.Crypto;
 import org.jclouds.domain.Location;
 import org.jclouds.http.options.GetOptions;
+import org.jclouds.io.Payload;
 
 import com.google.common.base.Supplier;
 import com.google.common.cache.CacheLoader;
@@ -281,5 +285,45 @@ public class AtmosBlobStore extends BaseBlobStore {
          return sync.createDirectory(container, publicRead()) != null;
       }
       return createContainerInLocation(location, container);
+   }
+
+   @Override
+   public MultipartUpload initiateMultipartUpload(String container, BlobMetadata blobMetadata) {
+      throw new UnsupportedOperationException("Atmos does not support multipart uploads");
+   }
+
+   @Override
+   public void abortMultipartUpload(MultipartUpload mpu) {
+      throw new UnsupportedOperationException("Atmos does not support multipart uploads");
+   }
+
+   @Override
+   public String completeMultipartUpload(MultipartUpload mpu, List<MultipartPart> parts) {
+      throw new UnsupportedOperationException("Atmos does not support multipart uploads");
+   }
+
+   @Override
+   public MultipartPart uploadMultipartPart(MultipartUpload mpu, int partNumber, Payload payload) {
+      throw new UnsupportedOperationException("Atmos does not support multipart uploads");
+   }
+
+   @Override
+   public List<MultipartPart> listMultipartUpload(MultipartUpload mpu) {
+      throw new UnsupportedOperationException("Atmos does not support multipart uploads");
+   }
+
+   @Override
+   public long getMinimumMultipartPartSize() {
+      throw new UnsupportedOperationException("Atmos does not support multipart uploads");
+   }
+
+   @Override
+   public long getMaximumMultipartPartSize() {
+      throw new UnsupportedOperationException("Atmos does not support multipart uploads");
+   }
+
+   @Override
+   public int getMaximumNumberOfParts() {
+      throw new UnsupportedOperationException("Atmos does not support multipart uploads");
    }
 }

--- a/apis/atmos/src/test/java/org/jclouds/atmos/blobstore/integration/AtmosIntegrationLiveTest.java
+++ b/apis/atmos/src/test/java/org/jclouds/atmos/blobstore/integration/AtmosIntegrationLiveTest.java
@@ -126,4 +126,18 @@ public class AtmosIntegrationLiveTest extends BaseBlobIntegrationTest {
       // TODO
    }
 
+   @Override
+   public void testMultipartUploadNoPartsAbort() throws Exception {
+      throw new SkipException("Atmos does not support multipart uploads");
+   }
+
+   @Override
+   public void testMultipartUploadSinglePart() throws Exception {
+      throw new SkipException("Atmos does not support multipart uploads");
+   }
+
+   @Override
+   public void testMultipartUploadMultipleParts() throws Exception {
+      throw new SkipException("Atmos does not support multipart uploads");
+   }
 }

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/functions/ParseObjectFromResponse.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/functions/ParseObjectFromResponse.java
@@ -65,6 +65,9 @@ public class ParseObjectFromResponse implements Function<HttpResponse, SwiftObje
 
       String etag = from.getFirstHeaderOrNull(ETAG);
       if (etag != null) {
+         if (etag.startsWith("\"") && etag.endsWith("\"") && etag.length() > 1) {
+            etag = etag.substring(1, etag.length() - 1);
+         }
          payload.getContentMetadata().setContentMD5(HashCode.fromBytes(base16().lowerCase().decode(etag)));
       }
 

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftBlobIntegrationLiveTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftBlobIntegrationLiveTest.java
@@ -83,4 +83,14 @@ public class SwiftBlobIntegrationLiveTest extends BaseBlobIntegrationTest {
    public void testCopyBlobReplaceMetadata() throws Exception {
       throw new SkipException("Swift only supports appending to user metadata, not replacing it");
    }
+
+   @Override
+   public void testMultipartUploadSinglePart() throws Exception {
+      throw new SkipException("openstack-swift does not support setting blob metadata during multipart upload");
+   }
+
+   @Override
+   public void testMultipartUploadMultipleParts() throws Exception {
+      throw new SkipException("openstack-swift does not support setting blob metadata during multipart upload");
+   }
 }

--- a/apis/s3/src/main/java/org/jclouds/s3/S3Client.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/S3Client.java
@@ -99,6 +99,7 @@ import org.jclouds.s3.xml.DeleteResultHandler;
 import org.jclouds.s3.xml.ListAllMyBucketsHandler;
 import org.jclouds.s3.xml.ListBucketHandler;
 import org.jclouds.s3.xml.LocationConstraintHandler;
+import org.jclouds.s3.xml.PartIdsFromHttpResponse;
 import org.jclouds.s3.xml.PayerHandler;
 
 import com.google.inject.Provides;
@@ -717,4 +718,12 @@ public interface S3Client extends Closeable {
          BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName,
          @PathParam("key") String key, @QueryParam("uploadId") String uploadId,
          @BinderParam(BindPartIdsAndETagsToRequest.class) Map<Integer, String> parts);
+
+   @Named("ListMultipartParts")
+   @GET
+   @Path("/{key}")
+   @XMLResponseParser(PartIdsFromHttpResponse.class)
+   Map<Integer, String> listMultipartParts(@Bucket @EndpointParam(parser = AssignCorrectHostnameForBucket.class)
+         @BinderParam(BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName,
+         @PathParam("key") String key, @QueryParam("uploadId") String uploadId);
 }

--- a/apis/s3/src/main/java/org/jclouds/s3/xml/PartIdsFromHttpResponse.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/xml/PartIdsFromHttpResponse.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.s3.xml;
+
+import static org.jclouds.util.SaxUtils.currentOrNull;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+
+import org.jclouds.date.DateService;
+import org.jclouds.http.functions.ParseSax;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Parses the following XML document:
+ * <p/>
+ * ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01"
+ */
+public class PartIdsFromHttpResponse extends ParseSax.HandlerWithResult<Map<Integer, String>> {
+   private final StringBuilder currentText = new StringBuilder();
+
+   private final DateService dateParser;
+
+   private int partNumber;
+   private Date lastModfied;
+   private String eTag;
+   private long size;
+
+   private final ImmutableMap.Builder<Integer, String> parts = ImmutableMap.builder();
+
+   /** Some blobs have a non-hex suffix when created by multi-part uploads such Amazon S3. */
+   private static final Pattern ETAG_CONTENT_MD5_PATTERN = Pattern.compile("\"([0-9a-f]+)\"");
+
+   @Inject
+   public PartIdsFromHttpResponse(DateService dateParser) {
+      this.dateParser = dateParser;
+   }
+
+   public Map<Integer, String> getResult() {
+      return parts.build();
+   }
+
+   public void endElement(String uri, String name, String qName) {
+      if (qName.equals("PartNumber")) {
+         partNumber = Integer.parseInt(currentText.toString().trim());
+      } else if (qName.equals("LastModified")) {
+         lastModfied = dateParser.iso8601DateOrSecondsDateParse(currentOrNull(currentText));
+      } else if (qName.equals("ETag")) {
+         eTag = currentText.toString().trim();
+      } else if (qName.equals("Size")) {
+         size = Long.parseLong(currentText.toString().trim());
+      } else if (qName.equals("Part")) {
+         parts.put(partNumber, eTag);
+      }
+      currentText.setLength(0);
+   }
+
+   public void characters(char ch[], int start, int length) {
+      currentText.append(ch, start, length);
+   }
+}

--- a/apis/s3/src/test/java/org/jclouds/s3/S3ClientLiveTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/S3ClientLiveTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.s3;
 
 import static com.google.common.hash.Hashing.md5;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.io.Payloads.newByteArrayPayload;
 import static org.jclouds.s3.options.CopyObjectOptions.Builder.ifSourceETagDoesntMatch;
 import static org.jclouds.s3.options.CopyObjectOptions.Builder.ifSourceETagMatches;
@@ -508,6 +509,8 @@ public class S3ClientLiveTest extends BaseBlobStoreIntegrationTest {
          String key = "constitution.txt";
          String uploadId = getApi().initiateMultipartUpload(containerName,
                   ObjectMetadataBuilder.create().key(key).contentMD5(oneHundredOneConstitutionsMD5.asBytes()).build());
+         assertThat(getApi().listMultipartParts(containerName, key, uploadId)).isEmpty();
+
          byte[] buffer = oneHundredOneConstitutions.read();
          assertEquals(oneHundredOneConstitutions.size(), (long) buffer.length);
 
@@ -526,6 +529,7 @@ public class S3ClientLiveTest extends BaseBlobStoreIntegrationTest {
             // available there.
             eTagOf1 = getApi().uploadPart(containerName, key, 1, uploadId, part1);
          }
+         assertThat(getApi().listMultipartParts(containerName, key, uploadId)).containsOnlyKeys(1);
 
          String eTag = getApi().completeMultipartUpload(containerName, key, uploadId, ImmutableMap.of(1, eTagOf1));
 

--- a/apis/s3/src/test/java/org/jclouds/s3/xml/PartIdsFromHttpResponseTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/xml/PartIdsFromHttpResponseTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.s3.xml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.jclouds.date.DateService;
+import org.jclouds.date.internal.SimpleDateFormatDateService;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.functions.BaseHandlerTest;
+import org.jclouds.http.functions.ParseSax;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Tests behavior of {@code PartIdsFromHttpResponse}
+ */
+// NOTE:without testName, this will not call @Before* and fail w/NPE during surefire
+@Test(groups = "unit", testName = "PartIdsFromHttpResponseTest")
+public final class PartIdsFromHttpResponseTest extends BaseHandlerTest {
+   private final DateService dateService = new SimpleDateFormatDateService();
+
+   @Test
+   public void test() {
+      Map<Integer, String> actual = createParser().parse(getClass().getResourceAsStream(
+            "/multipart-upload-list-parts.xml"));
+
+      Map<Integer, String> expected = ImmutableMap.of(
+            2, "\"7778aef83f66abc1fa1e8477f296d394\"",
+            3, "\"aaaa18db4cc2f85cedef654fccc4a4x8\"");
+
+      assertThat(actual).isEqualTo(expected);
+   }
+
+   private ParseSax<Map<Integer, String>> createParser() {
+      return factory.create(injector.getInstance(PartIdsFromHttpResponse.class)).setContext(
+               HttpRequest.builder().method("GET").endpoint("http://bucket.com").build());
+   }
+}

--- a/apis/s3/src/test/resources/multipart-upload-list-parts.xml
+++ b/apis/s3/src/test/resources/multipart-upload-list-parts.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ListPartsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Bucket>example-bucket</Bucket>
+  <Key>example-object</Key>
+  <UploadId>XXBsb2FkIElEIGZvciBlbHZpbmcncyVcdS1tb3ZpZS5tMnRzEEEwbG9hZA</UploadId>
+  <Initiator>
+      <ID>arn:aws:iam::111122223333:user/some-user-11116a31-17b5-4fb7-9df5-b288870f11xx</ID>
+      <DisplayName>umat-user-11116a31-17b5-4fb7-9df5-b288870f11xx</DisplayName>
+  </Initiator>
+  <Owner>
+    <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+    <DisplayName>someName</DisplayName>
+  </Owner>
+  <StorageClass>STANDARD</StorageClass>
+  <PartNumberMarker>1</PartNumberMarker>
+  <NextPartNumberMarker>3</NextPartNumberMarker>
+  <MaxParts>2</MaxParts>
+  <IsTruncated>true</IsTruncated>
+  <Part>
+    <PartNumber>2</PartNumber>
+    <LastModified>2010-11-10T20:48:34.000Z</LastModified>
+    <ETag>"7778aef83f66abc1fa1e8477f296d394"</ETag>
+    <Size>10485760</Size>
+  </Part>
+  <Part>
+    <PartNumber>3</PartNumber>
+    <LastModified>2010-11-10T20:48:33.000Z</LastModified>
+    <ETag>"aaaa18db4cc2f85cedef654fccc4a4x8"</ETag>
+    <Size>10485760</Size>
+  </Part>
+</ListPartsResult>

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/blobstore/SwiftBlobStore.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/blobstore/SwiftBlobStore.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.jclouds.Constants.PROPERTY_USER_THREADS;
 import static org.jclouds.openstack.swift.options.ListContainerOptions.Builder.withPrefix;
 
+import java.util.List;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -33,6 +34,8 @@ import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobAccess;
 import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.domain.ContainerAccess;
+import org.jclouds.blobstore.domain.MultipartPart;
+import org.jclouds.blobstore.domain.MultipartUpload;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.domain.internal.PageSetImpl;
@@ -47,6 +50,7 @@ import org.jclouds.blobstore.util.BlobUtils;
 import org.jclouds.collect.Memoized;
 import org.jclouds.domain.Location;
 import org.jclouds.http.options.GetOptions;
+import org.jclouds.io.Payload;
 import org.jclouds.openstack.swift.CommonSwiftClient;
 import org.jclouds.openstack.swift.blobstore.functions.BlobStoreListContainerOptionsToListContainerOptions;
 import org.jclouds.openstack.swift.blobstore.functions.BlobToObject;
@@ -335,5 +339,45 @@ public class SwiftBlobStore extends BaseBlobStore {
    @Override
    public void setBlobAccess(String containe, String namer, BlobAccess access) {
       throw new UnsupportedOperationException("not implemented");
+   }
+
+   @Override
+   public MultipartUpload initiateMultipartUpload(String container, BlobMetadata blobMetadata) {
+      throw new UnsupportedOperationException("Legacy Swift does not support multipart uploads");
+   }
+
+   @Override
+   public void abortMultipartUpload(MultipartUpload mpu) {
+      throw new UnsupportedOperationException("Legacy Swift does not support multipart uploads");
+   }
+
+   @Override
+   public String completeMultipartUpload(MultipartUpload mpu, List<MultipartPart> parts) {
+      throw new UnsupportedOperationException("Legacy Swift does not support multipart uploads");
+   }
+
+   @Override
+   public MultipartPart uploadMultipartPart(MultipartUpload mpu, int partNumber, Payload payload) {
+      throw new UnsupportedOperationException("Legacy Swift does not support multipart uploads");
+   }
+
+   @Override
+   public List<MultipartPart> listMultipartUpload(MultipartUpload mpu) {
+      throw new UnsupportedOperationException("Legacy Swift does not support multipart uploads");
+   }
+
+   @Override
+   public long getMinimumMultipartPartSize() {
+      throw new UnsupportedOperationException("Legacy Swift does not support multipart uploads");
+   }
+
+   @Override
+   public long getMaximumMultipartPartSize() {
+      throw new UnsupportedOperationException("Legacy Swift does not support multipart uploads");
+   }
+
+   @Override
+   public int getMaximumNumberOfParts() {
+      throw new UnsupportedOperationException("Legacy Swift does not support multipart uploads");
    }
 }

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/blobstore/integration/SwiftBlobIntegrationLiveTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/blobstore/integration/SwiftBlobIntegrationLiveTest.java
@@ -166,6 +166,21 @@ public class SwiftBlobIntegrationLiveTest extends BaseBlobIntegrationTest {
    }
 
    @Override
+   public void testMultipartUploadNoPartsAbort() throws Exception {
+      throw new SkipException("Legacy Swift does not support multipart uploads");
+   }
+
+   @Override
+   public void testMultipartUploadSinglePart() throws Exception {
+      throw new SkipException("Legacy Swift does not support multipart uploads");
+   }
+
+   @Override
+   public void testMultipartUploadMultipleParts() throws Exception {
+      throw new SkipException("Legacy Swift does not support multipart uploads");
+   }
+
+   @Override
    public void testSetBlobAccess() throws Exception {
       throw new SkipException("unsupported in swift");
    }

--- a/blobstore/pom.xml
+++ b/blobstore/pom.xml
@@ -59,6 +59,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
       <optional>true</optional>

--- a/blobstore/src/main/java/org/jclouds/blobstore/BlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/BlobStore.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.blobstore;
 
+import java.util.List;
 import java.util.Set;
 
 import com.google.common.annotations.Beta;
@@ -25,6 +26,8 @@ import org.jclouds.blobstore.domain.BlobAccess;
 import org.jclouds.blobstore.domain.BlobBuilder;
 import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.domain.ContainerAccess;
+import org.jclouds.blobstore.domain.MultipartPart;
+import org.jclouds.blobstore.domain.MultipartUpload;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.options.CopyOptions;
@@ -33,6 +36,7 @@ import org.jclouds.blobstore.options.GetOptions;
 import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.blobstore.options.PutOptions;
 import org.jclouds.domain.Location;
+import org.jclouds.io.Payload;
 import org.jclouds.javax.annotation.Nullable;
 
 /**
@@ -328,4 +332,28 @@ public interface BlobStore {
     */
    long countBlobs(String container, ListContainerOptions options);
 
+   @Beta
+   MultipartUpload initiateMultipartUpload(String container, BlobMetadata blob);
+
+   @Beta
+   // TODO: take parts?
+   void abortMultipartUpload(MultipartUpload mpu);
+
+   @Beta
+   String completeMultipartUpload(MultipartUpload mpu, List<MultipartPart> parts);
+
+   @Beta
+   MultipartPart uploadMultipartPart(MultipartUpload mpu, int partNumber, Payload payload);
+
+   @Beta
+   List<MultipartPart> listMultipartUpload(MultipartUpload mpu);
+
+   @Beta
+   long getMinimumMultipartPartSize();
+
+   @Beta
+   long getMaximumMultipartPartSize();
+
+   @Beta
+   int getMaximumNumberOfParts();
 }

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/MultipartPart.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/MultipartPart.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jclouds.blobstore.domain;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class MultipartPart {
+   public abstract int partNumber();
+   public abstract long partSize();
+   public abstract String partETag();
+
+   public static MultipartPart create(int partNumber, long partSize, String partETag) {
+      return new AutoValue_MultipartPart(partNumber, partSize, partETag);
+   }
+}

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/MultipartUpload.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/MultipartUpload.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jclouds.blobstore.domain;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class MultipartUpload {
+   public abstract String containerName();
+   public abstract String blobName();
+   public abstract String id();
+   public abstract BlobMetadata blobMetadata();
+
+   public static MultipartUpload create(String containerName, String blobName, String id, BlobMetadata blobMetadata) {
+      return new AutoValue_MultipartUpload(containerName, blobName, id, blobMetadata);
+   }
+}

--- a/blobstore/src/main/java/org/jclouds/blobstore/util/ForwardingBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/util/ForwardingBlobStore.java
@@ -19,6 +19,7 @@ package org.jclouds.blobstore.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.List;
 import java.util.Set;
 
 import com.google.common.collect.ForwardingObject;
@@ -30,6 +31,8 @@ import org.jclouds.blobstore.domain.BlobAccess;
 import org.jclouds.blobstore.domain.BlobBuilder;
 import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.domain.ContainerAccess;
+import org.jclouds.blobstore.domain.MultipartPart;
+import org.jclouds.blobstore.domain.MultipartUpload;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.options.CopyOptions;
@@ -38,6 +41,7 @@ import org.jclouds.blobstore.options.GetOptions;
 import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.blobstore.options.PutOptions;
 import org.jclouds.domain.Location;
+import org.jclouds.io.Payload;
 
 public abstract class ForwardingBlobStore extends ForwardingObject
       implements BlobStore {
@@ -213,5 +217,45 @@ public abstract class ForwardingBlobStore extends ForwardingObject
    @Override
    public long countBlobs(String container, ListContainerOptions options) {
       return delegate().countBlobs(container, options);
+   }
+
+   @Override
+   public MultipartUpload initiateMultipartUpload(String container, BlobMetadata blobMetadata) {
+      return delegate().initiateMultipartUpload(container, blobMetadata);
+   }
+
+   @Override
+   public void abortMultipartUpload(MultipartUpload mpu) {
+      delegate().abortMultipartUpload(mpu);
+   }
+
+   @Override
+   public String completeMultipartUpload(MultipartUpload mpu, List<MultipartPart> parts) {
+      return delegate().completeMultipartUpload(mpu, parts);
+   }
+
+   @Override
+   public MultipartPart uploadMultipartPart(MultipartUpload mpu, int partNumber, Payload payload) {
+      return delegate().uploadMultipartPart(mpu, partNumber, payload);
+   }
+
+   @Override
+   public List<MultipartPart> listMultipartUpload(MultipartUpload mpu) {
+      return delegate().listMultipartUpload(mpu);
+   }
+
+   @Override
+   public long getMinimumMultipartPartSize() {
+      return delegate().getMinimumMultipartPartSize();
+   }
+
+   @Override
+   public long getMaximumMultipartPartSize() {
+      return delegate().getMaximumMultipartPartSize();
+   }
+
+   @Override
+   public int getMaximumNumberOfParts() {
+      return delegate().getMaximumNumberOfParts();
    }
 }

--- a/blobstore/src/main/java/org/jclouds/blobstore/util/ReadOnlyBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/util/ReadOnlyBlobStore.java
@@ -17,17 +17,23 @@
 
 package org.jclouds.blobstore.util;
 
+import java.util.List;
+
 import org.jclouds.blobstore.BlobStore;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobAccess;
 import org.jclouds.blobstore.domain.BlobBuilder;
+import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.domain.ContainerAccess;
+import org.jclouds.blobstore.domain.MultipartPart;
+import org.jclouds.blobstore.domain.MultipartUpload;
 import org.jclouds.blobstore.options.CopyOptions;
 import org.jclouds.blobstore.options.CreateContainerOptions;
 import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.blobstore.options.PutOptions;
 import org.jclouds.domain.Location;
+import org.jclouds.io.Payload;
 
 public final class ReadOnlyBlobStore extends ForwardingBlobStore {
    public static BlobStore newReadOnlyBlobStore(BlobStore blobStore) {
@@ -126,6 +132,31 @@ public final class ReadOnlyBlobStore extends ForwardingBlobStore {
    @Override
    public void setBlobAccess(String container, String name,
          BlobAccess access) {
+      throw new UnsupportedOperationException("Read-only BlobStore");
+   }
+
+   @Override
+   public MultipartUpload initiateMultipartUpload(String container, BlobMetadata blobMetadata) {
+      throw new UnsupportedOperationException("Read-only BlobStore");
+   }
+
+   @Override
+   public void abortMultipartUpload(MultipartUpload mpu) {
+      throw new UnsupportedOperationException("Read-only BlobStore");
+   }
+
+   @Override
+   public String completeMultipartUpload(MultipartUpload mpu, List<MultipartPart> parts) {
+      throw new UnsupportedOperationException("Read-only BlobStore");
+   }
+
+   @Override
+   public MultipartPart uploadMultipartPart(MultipartUpload mpu, int partNumber, Payload payload) {
+      throw new UnsupportedOperationException("Read-only BlobStore");
+   }
+
+   @Override
+   public List<MultipartPart> listMultipartUpload(MultipartUpload mpu) {
       throw new UnsupportedOperationException("Read-only BlobStore");
    }
 }

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/blobstore/AWSS3BlobStore.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/blobstore/AWSS3BlobStore.java
@@ -40,6 +40,7 @@ import org.jclouds.collect.Memoized;
 import org.jclouds.domain.Location;
 import org.jclouds.s3.blobstore.S3BlobStore;
 import org.jclouds.s3.blobstore.functions.BlobToObject;
+import org.jclouds.s3.blobstore.functions.BlobToObjectMetadata;
 import org.jclouds.s3.blobstore.functions.BucketToResourceList;
 import org.jclouds.s3.blobstore.functions.ContainerToBucketListOptions;
 import org.jclouds.s3.blobstore.functions.ObjectToBlob;
@@ -69,12 +70,13 @@ public class AWSS3BlobStore extends S3BlobStore {
             Function<Set<BucketMetadata>, PageSet<? extends StorageMetadata>> convertBucketsToStorageMetadata,
             ContainerToBucketListOptions container2BucketListOptions, BucketToResourceList bucket2ResourceList,
             ObjectToBlob object2Blob, BlobToHttpGetOptions blob2ObjectGetOptions, BlobToObject blob2Object,
+            BlobToObjectMetadata blob2ObjectMetadata,
             ObjectToBlobMetadata object2BlobMd, Provider<FetchBlobMetadata> fetchBlobMetadataProvider,
             LoadingCache<String, AccessControlList> bucketAcls,
             Provider<MultipartUploadStrategy> multipartUploadStrategy) {
       super(context, blobUtils, defaultLocation, locations, sync, convertBucketsToStorageMetadata,
                container2BucketListOptions, bucket2ResourceList, object2Blob, blob2ObjectGetOptions, blob2Object,
-               object2BlobMd, fetchBlobMetadataProvider, bucketAcls,
+               blob2ObjectMetadata, object2BlobMd, fetchBlobMetadataProvider, bucketAcls,
                multipartUploadStrategy);
       this.bucketAcls = bucketAcls;
       this.blob2Object = blob2Object;

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/AzureBlobClient.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/AzureBlobClient.java
@@ -396,7 +396,7 @@ public interface AzureBlobClient extends Closeable {
    @GET
    @Path("{container}/{name}")
    @XMLResponseParser(BlobBlocksResultsHandler.class)
-   @QueryParams(keys = { "comp" }, values = { "blocklist" })
+   @QueryParams(keys = { "comp", "blocklisttype" }, values = { "blocklist", "all" })
    ListBlobBlocksResponse getBlockList(
          @PathParam("container") @ParamValidators(ContainerNameValidator.class) String container,
          @PathParam("name") String name);


### PR DESCRIPTION
@danbroudy @kahing @timuralp @zack-shoylev Please review.  This commit exposes all the component multipart upload operations.  Unfortunately providers have different requirements for part sizes, aborting, adding metadata during initate or complete, and whether the provider offers composite objects (Swift) or merely partial uploads (S3).  I did my best here but give the new `BlobStore` methods extra scrutiny.  Still noodling over how to support this with the local blobstores but it will likely be similar to Swift.

@danbroudy @zack-shoylev I would appreciate your help with GCS and Swift, respectively.  I took a whack at the latter but it needs some more work around part sizes.