### PR TITLE
Make home folder globally accessible when creating a user

### DIFF
--- a/compute/src/test/java/org/jclouds/compute/callables/RunScriptOnNodeUsingSshTest.java
+++ b/compute/src/test/java/org/jclouds/compute/callables/RunScriptOnNodeUsingSshTest.java
@@ -121,7 +121,9 @@ public class RunScriptOnNodeUsingSshTest {
       expect(sshClient.getUsername()).andReturn("tester");
       expect(sshClient.getHostAddress()).andReturn("somewhere.example.com");
       expect(
-            sshClient.exec("sudo sh <<'RUN_SCRIPT_AS_ROOT_SSH'\n" + "mkdir -p /home/users\n"
+            sshClient.exec("sudo sh <<'RUN_SCRIPT_AS_ROOT_SSH'\n"
+                  + "mkdir -p /home/users\n"
+                  + "chmod 0755 /home/users\n"
                   + "useradd -c testuser -s /bin/bash -m  -d /home/users/testuser testuser\n"
                   + "chown -R testuser /home/users/testuser\n" + "RUN_SCRIPT_AS_ROOT_SSH\n")).andReturn(
             new ExecResponse("done", null, 0));

--- a/compute/src/test/resources/initscript_with_java.sh
+++ b/compute/src/test/resources/initscript_with_java.sh
@@ -209,6 +209,7 @@ END_OF_JCLOUDS_SCRIPT
 	END_OF_JCLOUDS_FILE
 	chmod 0440 /etc/sudoers
 	mkdir -p /home/users
+	chmod 0755 /home/users
 	groupadd -f wheel
 	useradd -c 'defaultAdminUsername' -s /bin/bash -g wheel -m  -d /home/users/defaultAdminUsername -p 'crypt(randompassword)' defaultAdminUsername
 	mkdir -p /home/users/defaultAdminUsername/.ssh

--- a/compute/src/test/resources/initscript_with_jetty.sh
+++ b/compute/src/test/resources/initscript_with_jetty.sh
@@ -209,6 +209,7 @@ END_OF_JCLOUDS_SCRIPT
 	END_OF_JCLOUDS_FILE
 	chmod 0440 /etc/sudoers
 	mkdir -p /home/users
+	chmod 0755 /home/users
 	groupadd -f wheel
 	useradd -c 'web' -s /bin/bash -g wheel -m  -d /home/users/web -p 'crypt(randompassword)' web
 	mkdir -p /home/users/web/.ssh

--- a/compute/src/test/resources/runscript_adminUpdate.sh
+++ b/compute/src/test/resources/runscript_adminUpdate.sh
@@ -90,6 +90,7 @@ END_OF_JCLOUDS_SCRIPT
 	END_OF_JCLOUDS_FILE
 	chmod 0440 /etc/sudoers
 	mkdir -p /over/ridden
+	chmod 0755 /over/ridden
 	groupadd -f wheel
 	useradd -c 'foo' -s /bin/bash -g wheel -m  -d /over/ridden/foo -p 'crypt(randompassword)' foo
 	mkdir -p /over/ridden/foo/.ssh

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/login/UserAdd.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/login/UserAdd.java
@@ -186,9 +186,12 @@ public class UserAdd implements Statement {
       if (family == OsFamily.WINDOWS)
          throw new UnsupportedOperationException("windows not yet implemented");
       String homeDir = (home != null) ? home : (defaultHome + '/' + login);
+      String usersDir = homeDir.substring(0, homeDir.lastIndexOf('/'));
       ImmutableList.Builder<Statement> statements = ImmutableList.builder();
       // useradd cannot create the default homedir
-      statements.add(Statements.exec("{md} " + homeDir.substring(0, homeDir.lastIndexOf('/'))));
+      statements.add(Statements.exec("{md} " + usersDir));
+      // make sure the folder is globally accessible even with umask 0077
+      statements.add(Statements.exec("chmod 0755 " + usersDir));
 
       ImmutableMap.Builder<String, String> userAddOptions = ImmutableMap.builder();
       // Include the username as the full name for now.

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/login/UserAddTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/login/UserAddTest.java
@@ -29,29 +29,29 @@ public class UserAddTest {
 
    public void testUNIX() {
       assertEquals(UserAdd.builder().login("me").build().render(OsFamily.UNIX),
-               "mkdir -p /home/users\nuseradd -c me -s /bin/bash -m  -d /home/users/me me\nchown -R me /home/users/me\n");
+               "mkdir -p /home/users\nchmod 0755 /home/users\nuseradd -c me -s /bin/bash -m  -d /home/users/me me\nchown -R me /home/users/me\n");
    }
 
    public void testWithFullNameUNIX() {
       assertEquals(UserAdd.builder().login("me").fullName("JClouds Guy").build().render(OsFamily.UNIX),
-            "mkdir -p /home/users\nuseradd -c 'JClouds Guy' -s /bin/bash -m  -d /home/users/me me\nchown -R me /home/users/me\n");
+            "mkdir -p /home/users\nchmod 0755 /home/users\nuseradd -c 'JClouds Guy' -s /bin/bash -m  -d /home/users/me me\nchown -R me /home/users/me\n");
 
    }
 
    public void testWithBaseUNIX() {
       assertEquals(UserAdd.builder().login("me").defaultHome("/export/home").build().render(OsFamily.UNIX),
-               "mkdir -p /export/home\nuseradd -c me -s /bin/bash -m  -d /export/home/me me\nchown -R me /export/home/me\n");
+               "mkdir -p /export/home\nchmod 0755 /export/home\nuseradd -c me -s /bin/bash -m  -d /export/home/me me\nchown -R me /export/home/me\n");
    }
 
    public void testWithGroupUNIX() {
       assertEquals(UserAdd.builder().login("me").group("wheel").build().render(OsFamily.UNIX),
-               "mkdir -p /home/users\ngroupadd -f wheel\nuseradd -c me -s /bin/bash -g wheel -m  -d /home/users/me me\nchown -R me /home/users/me\n");
+               "mkdir -p /home/users\nchmod 0755 /home/users\ngroupadd -f wheel\nuseradd -c me -s /bin/bash -g wheel -m  -d /home/users/me me\nchown -R me /home/users/me\n");
    }
 
    public void testWithGroupsUNIX() {
       assertEquals(UserAdd.builder().login("me").groups(ImmutableList.of("wheel", "candy")).build().render(
                OsFamily.UNIX),
-               "mkdir -p /home/users\ngroupadd -f wheel\ngroupadd -f candy\nuseradd -c me -s /bin/bash -g wheel -G candy -m  -d /home/users/me me\nchown -R me /home/users/me\n");
+               "mkdir -p /home/users\nchmod 0755 /home/users\ngroupadd -f wheel\ngroupadd -f candy\nuseradd -c me -s /bin/bash -g wheel -G candy -m  -d /home/users/me me\nchown -R me /home/users/me\n");
    }
 
    Function<String, String> crypt = new Function<String, String>() {
@@ -63,30 +63,30 @@ public class UserAddTest {
 
    public void testWithPasswordUNIX() {
       String userAdd = UserAdd.builder().cryptFunction(crypt).login("me").password("password").group("wheel").build().render(OsFamily.UNIX);
-      assert userAdd.startsWith("mkdir -p /home/users\ngroupadd -f wheel\nuseradd -c me -s /bin/bash -g wheel -m  -d /home/users/me -p 'CRYPT'") : userAdd;
+      assert userAdd.startsWith("mkdir -p /home/users\nchmod 0755 /home/users\ngroupadd -f wheel\nuseradd -c me -s /bin/bash -g wheel -m  -d /home/users/me -p 'CRYPT'") : userAdd;
       assert userAdd.endsWith("' me\nchown -R me /home/users/me\n") : userAdd;
    }
 
    public void testWithSshAuthorizedKeyUNIX() {
       assertEquals(
                UserAdd.builder().login("me").authorizeRSAPublicKey("rsapublickey").build().render(OsFamily.UNIX),
-               "mkdir -p /home/users\nuseradd -c me -s /bin/bash -m  -d /home/users/me me\nmkdir -p /home/users/me/.ssh\ncat >> /home/users/me/.ssh/authorized_keys <<-'END_OF_JCLOUDS_FILE'\n\trsapublickey\nEND_OF_JCLOUDS_FILE\nchmod 600 /home/users/me/.ssh/authorized_keys\nchown -R me /home/users/me\n");
+               "mkdir -p /home/users\nchmod 0755 /home/users\nuseradd -c me -s /bin/bash -m  -d /home/users/me me\nmkdir -p /home/users/me/.ssh\ncat >> /home/users/me/.ssh/authorized_keys <<-'END_OF_JCLOUDS_FILE'\n\trsapublickey\nEND_OF_JCLOUDS_FILE\nchmod 600 /home/users/me/.ssh/authorized_keys\nchown -R me /home/users/me\n");
    }
 
    public void testWithSshInstalledKeyUNIX() {
       assertEquals(
                UserAdd.builder().login("me").installRSAPrivateKey("rsaprivate").build().render(OsFamily.UNIX),
-               "mkdir -p /home/users\nuseradd -c me -s /bin/bash -m  -d /home/users/me me\nmkdir -p /home/users/me/.ssh\nrm /home/users/me/.ssh/id_rsa\ncat >> /home/users/me/.ssh/id_rsa <<-'END_OF_JCLOUDS_FILE'\n\trsaprivate\nEND_OF_JCLOUDS_FILE\nchmod 600 /home/users/me/.ssh/id_rsa\nchown -R me /home/users/me\n");
+               "mkdir -p /home/users\nchmod 0755 /home/users\nuseradd -c me -s /bin/bash -m  -d /home/users/me me\nmkdir -p /home/users/me/.ssh\nrm /home/users/me/.ssh/id_rsa\ncat >> /home/users/me/.ssh/id_rsa <<-'END_OF_JCLOUDS_FILE'\n\trsaprivate\nEND_OF_JCLOUDS_FILE\nchmod 600 /home/users/me/.ssh/id_rsa\nchown -R me /home/users/me\n");
    }
 
    public void testWithHomeUNIX() {
       assertEquals(UserAdd.builder().login("me").home("/myhome/myme").build().render(
                OsFamily.UNIX),
-               "mkdir -p /myhome\nuseradd -c me -s /bin/bash -m  -d /myhome/myme me\nchown -R me /myhome/myme\n");
+               "mkdir -p /myhome\nchmod 0755 /myhome\nuseradd -c me -s /bin/bash -m  -d /myhome/myme me\nchown -R me /myhome/myme\n");
       
       assertEquals(UserAdd.builder().login("me").home("/myhome/myme").defaultHome("/ignoreddefault").build().render(
                               OsFamily.UNIX),
-                              "mkdir -p /myhome\nuseradd -c me -s /bin/bash -m  -d /myhome/myme me\nchown -R me /myhome/myme\n");
+                              "mkdir -p /myhome\nchmod 0755 /myhome\nuseradd -c me -s /bin/bash -m  -d /myhome/myme me\nchown -R me /myhome/myme\n");
    }
 
    @Test(expectedExceptions = UnsupportedOperationException.class)

--- a/scriptbuilder/src/test/resources/test_adminaccess_flipped.sh
+++ b/scriptbuilder/src/test/resources/test_adminaccess_flipped.sh
@@ -5,6 +5,7 @@ root ALL = (ALL) ALL
 END_OF_FILE
 chmod 0440 /etc/sudoers
 mkdir -p /home/users
+chmod 0755 /home/users
 groupadd -f wheel
 useradd -c defaultAdminUsername -s /bin/bash -g wheel -d /home/users/defaultAdminUsername -p 'crypt(0)' defaultAdminUsername
 mkdir -p /home/users/defaultAdminUsername/.ssh

--- a/scriptbuilder/src/test/resources/test_adminaccess_params.sh
+++ b/scriptbuilder/src/test/resources/test_adminaccess_params.sh
@@ -4,6 +4,7 @@ cat > /etc/sudoers <<-'END_OF_JCLOUDS_FILE'
 END_OF_JCLOUDS_FILE
 chmod 0440 /etc/sudoers
 mkdir -p /over/ridden
+chmod 0755 /over/ridden
 groupadd -f wheel
 useradd -c 'foo' -s /bin/bash -g wheel -m  -d /over/ridden/foo -p 'crypt(bar)' foo
 mkdir -p /over/ridden/foo/.ssh

--- a/scriptbuilder/src/test/resources/test_adminaccess_params_and_fullname.sh
+++ b/scriptbuilder/src/test/resources/test_adminaccess_params_and_fullname.sh
@@ -4,6 +4,7 @@ cat > /etc/sudoers <<-'END_OF_JCLOUDS_FILE'
 END_OF_JCLOUDS_FILE
 chmod 0440 /etc/sudoers
 mkdir -p /over/ridden
+chmod 0755 /over/ridden
 groupadd -f wheel
 useradd -c 'JClouds Foo' -s /bin/bash -g wheel -m  -d /over/ridden/foo -p 'crypt(bar)' foo
 mkdir -p /over/ridden/foo/.ssh

--- a/scriptbuilder/src/test/resources/test_adminaccess_plainuser.sh
+++ b/scriptbuilder/src/test/resources/test_adminaccess_plainuser.sh
@@ -1,4 +1,5 @@
 mkdir -p /home/users
+chmod 0755 /home/users
 useradd -c 'defaultAdminUsername' -s /bin/bash -m  -d /home/users/defaultAdminUsername -p 'crypt(0)' defaultAdminUsername
 mkdir -p /home/users/defaultAdminUsername/.ssh
 cat >> /home/users/defaultAdminUsername/.ssh/authorized_keys <<-'END_OF_JCLOUDS_FILE'

--- a/scriptbuilder/src/test/resources/test_adminaccess_standard.sh
+++ b/scriptbuilder/src/test/resources/test_adminaccess_standard.sh
@@ -4,6 +4,7 @@ cat > /etc/sudoers <<-'END_OF_JCLOUDS_FILE'
 END_OF_JCLOUDS_FILE
 chmod 0440 /etc/sudoers
 mkdir -p /home/users
+chmod 0755 /home/users
 groupadd -f wheel
 useradd -c 'defaultAdminUsername' -s /bin/bash -g wheel -m  -d /home/users/defaultAdminUsername -p 'crypt(0)' defaultAdminUsername
 mkdir -p /home/users/defaultAdminUsername/.ssh


### PR DESCRIPTION
Certain hardened images will have `umask 0077` set for the root user, making the newly created `/home/users` folder inaccessible to non-root. This results in a failure when trying to ssh with the new account. Explicitly set permissions to be independent of default umask.