### PR TITLE
metadata and content metadata should have the same length

### DIFF
--- a/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
@@ -655,7 +655,9 @@ public final class LocalBlobStore implements BlobStore {
             byte[] byteArray = out.toByteArray();
             blob.setPayload(byteArray);
             HttpUtils.copy(cmd, blob.getPayload().getContentMetadata());
-            blob.getPayload().getContentMetadata().setContentLength(Long.valueOf(byteArray.length));
+            Long size = Long.valueOf(byteArray.length);
+            blob.getPayload().getContentMetadata().setContentLength(size);
+            blob.getMetadata().setSize(size);
          }
       }
       checkNotNull(blob.getPayload(), "payload " + blob);

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobStoreIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobStoreIntegrationTest.java
@@ -284,6 +284,7 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
    protected <T extends BlobMetadata> T validateMetadata(T md, String container, String name) {
       assertEquals(md.getName(), name);
       assertEquals(md.getContainer(), container);
+      assertEquals(md.getSize(), md.getContentMetadata().getContentLength());
       return md;
    }
 


### PR DESCRIPTION
for range get in a LocalBlobStore, metadata.getSize() has the
original blob size and contentMetadata.getContentLength() has
the actual payload size. Other blobstores have the same size
in both