### PR TITLE
JCLOUDS-921 prioritise key over password in SSHClientConnection

### DIFF
--- a/drivers/sshj/src/main/java/org/jclouds/sshj/SSHClientConnection.java
+++ b/drivers/sshj/src/main/java/org/jclouds/sshj/SSHClientConnection.java
@@ -157,12 +157,12 @@ public class SSHClientConnection implements Connection<SSHClient> {
          ssh.setTimeout(sessionTimeout);
       }
       ssh.connect(hostAndPort.getHostText(), hostAndPort.getPortOrDefault(22));
-      if (loginCredentials.getOptionalPassword().isPresent()) {
-         ssh.authPassword(loginCredentials.getUser(), loginCredentials.getOptionalPassword().get());
-      } else if (loginCredentials.hasUnencryptedPrivateKey()) {
+      if (loginCredentials.hasUnencryptedPrivateKey()) {
          OpenSSHKeyFile key = new OpenSSHKeyFile();
          key.init(loginCredentials.getOptionalPrivateKey().get(), null);
          ssh.authPublickey(loginCredentials.getUser(), key);
+      } else if (loginCredentials.getOptionalPassword().isPresent()) {
+         ssh.authPassword(loginCredentials.getUser(), loginCredentials.getOptionalPassword().get());
       } else if (agentConnector.isPresent()) {
          AgentProxy proxy = new AgentProxy(agentConnector.get());
          ssh.auth(loginCredentials.getUser(), getAuthMethods(proxy));


### PR DESCRIPTION
From ticket:
If keyboard interactive login is not allowed on the box but the user also requires a sudo password the ssh fails as it prioritises the password.
If you remove the password then the sudo fails in the SudoAwareInitManager.
It would seem better to prioritise the key over the password in SSHClientConnection or possibly try both if they are both present, and the first fails.

This commit swaps the order of the if else check to use the ssh key if present.