### PR TITLE
Avoid AutoValue shaded imports

### DIFF
--- a/resources/checkstyle.xml
+++ b/resources/checkstyle.xml
@@ -55,6 +55,10 @@
         <module name="UnusedImports">
             <property name="processJavadoc" value="true"/>
         </module>
+        <module name="IllegalImport">
+            <!-- Avoid importing AutoValue shaded packages such as Guava -->
+            <property name="illegalPkgs" value="sun,autovalue"/>
+        </module>
         <module name="WhitespaceAfter">
             <!-- TYPECAST disabled -->
             <property name="tokens" value="COMMA, SEMI"/>


### PR DESCRIPTION
Google Auto provides some shaded dependencies, such as Guava, that should not be directly imported. This pull request sets a checkstyle rule to make sure we don't add them by mistake.