### PR TITLE
Use a configurable timeout for awaitConsistency

### DIFF
--- a/apis/openstack-swift/pom.xml
+++ b/apis/openstack-swift/pom.xml
@@ -44,6 +44,7 @@
     <jclouds.blobstore.httpstream.md5>e5de09672af9b386c30a311654d8541a</jclouds.blobstore.httpstream.md5>
     <jclouds.osgi.export>org.jclouds.openstack.swift.v1*;version="${project.version}"</jclouds.osgi.export>
     <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
+    <test.blobstore.await-consistency-timeout-seconds>30</test.blobstore.await-consistency-timeout-seconds>
   </properties>
 
   <dependencies>

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftBlobIntegrationLiveTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftBlobIntegrationLiveTest.java
@@ -19,16 +19,12 @@ package org.jclouds.openstack.swift.v1.blobstore.integration;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
 
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
-import org.jclouds.blobstore.attr.ConsistencyModel;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.integration.internal.BaseBlobIntegrationTest;
 import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import com.google.common.util.concurrent.Uninterruptibles;
 
 @Test(groups = "live", testName = "SwiftBlobIntegrationLiveTest")
 public class SwiftBlobIntegrationLiveTest extends BaseBlobIntegrationTest {
@@ -86,13 +82,6 @@ public class SwiftBlobIntegrationLiveTest extends BaseBlobIntegrationTest {
    @Override
    public void testCopyBlobReplaceMetadata() throws Exception {
       throw new SkipException("Swift only supports appending to user metadata, not replacing it");
-   }
-
-   @Override
-   protected void awaitConsistency() {
-      if (view.getConsistencyModel() == ConsistencyModel.EVENTUAL) {
-         Uninterruptibles.sleepUninterruptibly(30, TimeUnit.SECONDS);
-      }
    }
 
    @Override

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftBlobSignerLiveTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftBlobSignerLiveTest.java
@@ -19,13 +19,9 @@ package org.jclouds.openstack.swift.v1.blobstore.integration;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
 
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
-import org.jclouds.blobstore.attr.ConsistencyModel;
 import org.jclouds.blobstore.integration.internal.BaseBlobSignerLiveTest;
 import org.testng.annotations.Test;
-
-import com.google.common.util.concurrent.Uninterruptibles;
 
 @Test(groups = "live", testName = "SwiftBlobSignerLiveTest")
 public class SwiftBlobSignerLiveTest extends BaseBlobSignerLiveTest {
@@ -39,12 +35,5 @@ public class SwiftBlobSignerLiveTest extends BaseBlobSignerLiveTest {
       Properties props = super.setupProperties();
       setIfTestSystemPropertyPresent(props, CREDENTIAL_TYPE);
       return props;
-   }
-
-   @Override
-   protected void awaitConsistency() {
-      if (view.getConsistencyModel() == ConsistencyModel.EVENTUAL) {
-         Uninterruptibles.sleepUninterruptibly(30, TimeUnit.SECONDS);
-      }
    }
 }

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftContainerIntegrationLiveTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftContainerIntegrationLiveTest.java
@@ -20,14 +20,10 @@ import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CRED
 import static org.testng.Assert.assertTrue;
 
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
-import org.jclouds.blobstore.attr.ConsistencyModel;
 import org.jclouds.blobstore.integration.internal.BaseContainerIntegrationTest;
 import org.testng.annotations.Test;
 import org.testng.SkipException;
-
-import com.google.common.util.concurrent.Uninterruptibles;
 
 @Test(groups = "live", testName = "SwiftContainerIntegrationLiveTest")
 public class SwiftContainerIntegrationLiveTest extends BaseContainerIntegrationTest {
@@ -60,12 +56,5 @@ public class SwiftContainerIntegrationLiveTest extends BaseContainerIntegrationT
    @Override
    public void testDelimiter() throws Exception {
       throw new SkipException("openstack-swift does not implement pseudo-directories");
-   }
-
-   @Override
-   protected void awaitConsistency() {
-      if (view.getConsistencyModel() == ConsistencyModel.EVENTUAL) {
-         Uninterruptibles.sleepUninterruptibly(30, TimeUnit.SECONDS);
-      }
    }
 }

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobSignerLiveTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobSignerLiveTest.java
@@ -183,7 +183,7 @@ public class BaseBlobSignerLiveTest extends BaseBlobStoreIntegrationTest {
 
    protected void awaitConsistency() {
       if (view.getConsistencyModel() == ConsistencyModel.EVENTUAL) {
-         Uninterruptibles.sleepUninterruptibly(10, TimeUnit.SECONDS);
+         Uninterruptibles.sleepUninterruptibly(AWAIT_CONSISTENCY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
       }
    }
 }

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobStoreIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobStoreIntegrationTest.java
@@ -92,6 +92,9 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
     */
    private static volatile BlockingQueue<String> containerNames = new ArrayBlockingQueue<String>(containerCount);
 
+   protected static final int AWAIT_CONSISTENCY_TIMEOUT_SECONDS = Integer.parseInt(System.getProperty(
+         "test.blobstore.await-consistency-timeout-seconds", "10"));
+
    /**
     * There are a lot of retries here mainly from experience running inside amazon EC2.
     */
@@ -529,7 +532,7 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
 
    protected void awaitConsistency() {
       if (view.getConsistencyModel() == ConsistencyModel.EVENTUAL) {
-         Uninterruptibles.sleepUninterruptibly(10, TimeUnit.SECONDS);
+         Uninterruptibles.sleepUninterruptibly(AWAIT_CONSISTENCY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
       }
    }
 }

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
@@ -553,7 +553,7 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
 
    protected void awaitConsistency() {
       if (view.getConsistencyModel() == ConsistencyModel.EVENTUAL) {
-         Uninterruptibles.sleepUninterruptibly(10, TimeUnit.SECONDS);
+         Uninterruptibles.sleepUninterruptibly(AWAIT_CONSISTENCY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
       }
    }
 }


### PR DESCRIPTION
This allows setting to zero for strongly-consistency implementations
of s3 and swift stores.