### PR TITLE
[backport] Close connection after ExecChannel in sshj client

### DIFF
--- a/drivers/sshj/src/main/java/org/jclouds/sshj/SshjSshClient.java
+++ b/drivers/sshj/src/main/java/org/jclouds/sshj/SshjSshClient.java
@@ -501,8 +501,8 @@ public class SshjSshClient implements SshClient {
 
    class ExecChannelConnection implements Connection<ExecChannel> {
       private final String command;
-      private SessionChannel session;
       private Command output;
+      private Connection<Session> connection;
 
       ExecChannelConnection(String command) {
          this.command = checkNotNull(command, "command");
@@ -511,13 +511,19 @@ public class SshjSshClient implements SshClient {
       @Override
       public void clear() {
          Closeables2.closeQuietly(output);
-         Closeables2.closeQuietly(session);
+         try {
+             if (connection != null) {
+                 connection.clear();
+             }
+         } catch (Throwable e) {
+             Throwables.propagate(e);
+         }
       }
 
       @Override
       public ExecChannel create() throws Exception {
-         session = SessionChannel.class.cast(acquire(noPTYConnection()));
-         output = session.exec(command);
+         connection = noPTYConnection();
+         output = SessionChannel.class.cast(acquire(connection)).exec(command);
          return new ExecChannel(output.getOutputStream(), output.getInputStream(), output.getErrorStream(),
                   new Supplier<Integer>() {
 


### PR DESCRIPTION
ExecChannels created its own ssh connections that was not cleaned and SSH reader thread was leaked.

Backport of https://github.com/jclouds/jclouds/pull/778