### PR TITLE
JCLOUDS-930: Regression in a File System test.

### DIFF
--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/FilesystemBlobStoreTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/FilesystemBlobStoreTest.java
@@ -525,8 +525,7 @@ public class FilesystemBlobStoreTest {
         checkForContainerContent(CONTAINER_NAME, dirs);
     }
 
-    // TODO: disable test due to unexpected trailing slash
-    @Test(dataProvider = "ignoreOnMacOSX", enabled = false)
+    @Test(dataProvider = "ignoreOnMacOSX")
     public void testListDirectoryBlobsS3FS() {
         blobStore.createContainerInLocation(null, CONTAINER_NAME);
         checkForContainerContent(CONTAINER_NAME, null);
@@ -540,7 +539,7 @@ public class FilesystemBlobStoreTest {
                 .inDirectory("");
         PageSet<? extends StorageMetadata> res = blobStore.list(CONTAINER_NAME, options);
         assertTrue(res.size() == 1);
-        assertEquals(res.iterator().next().getName(), d);
+        assertEquals(res.iterator().next().getName(), d + '/');
     }
 
 


### PR DESCRIPTION
Fix a regression in the file system blob store, where a test does not
expect the trailing delimiter character.