### PR TITLE
Allow other version strings with arbitrary labels

### DIFF
--- a/core/src/main/java/org/jclouds/JcloudsVersion.java
+++ b/core/src/main/java/org/jclouds/JcloudsVersion.java
@@ -37,11 +37,11 @@ public class JcloudsVersion {
     private static final String VERSION_PROPERTY_NAME = "version";
 
     /*
-     * x.y.z or x.y.z-alpha.n or x.y.z-beta.n or x.y.z-rc.n or x.y.z-SNAPSHOT -
-     * see http://semver.org.
+     * Matches x.y.z or x.y.z-alpha.n or x.y.z-beta.n or x.y.z-rc.n or x.y.z-SNAPSHOT - see http://semver.org/
+     * Also matches x.y.z-* as fallback, with any non-whitespace character sequence after the hyphen.
      */
     private static final Pattern SEMANTIC_VERSION_PATTERN =
-        Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(?:-(alpha|beta|rc)\\.(\\d+)|-SNAPSHOT)?");
+        Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(?:-(alpha|beta|rc)\\.(\\d+)|-SNAPSHOT|-\\S+)?");
     private static final String ALPHA_VERSION_IDENTIFIER = "alpha";
     private static final String BETA_VERSION_IDENTIFIER = "beta";
 


### PR DESCRIPTION
This allows building private forks with non-conflicting versions, since the current regular expression matching sematic versions is very restrictive. Versions such as `1.9.1-org-name.1` (for the first build of version 1.9.1 by some organisation) should be allowed. All of the checks for alpha or beta and the major, minor and patch properties in `JcloudsVersion` will still work as expected.