### PR TITLE
JCLOUDS-930: LocalBlobStore -- marker regression.

### DIFF
--- a/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
@@ -297,9 +297,6 @@ public final class LocalBlobStore implements BlobStore {
                // Partial listing
                lastElement = contents.last();
                marker = lastElement.getName();
-               if (lastElement.getType() == StorageType.RELATIVE_PATH) {
-                  marker += "/";
-               }
             }
          }
 


### PR DESCRIPTION
We should not append a "/" to the marker when returning list results
in the case of directories (RELATIVE_PATH), as the names will already
include the delimiter.

Added a jclouds test to catch such regressions in the local store in
the future.