### PR TITLE
JCLOUDS-857: remove spurious annotation

### DIFF
--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/functions/ListBlobsResponseToResourceList.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/functions/ListBlobsResponseToResourceList.java
@@ -25,7 +25,6 @@ import javax.inject.Singleton;
 import org.jclouds.azureblob.domain.ListBlobsResponse;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
-import org.jclouds.blobstore.domain.StorageType;
 import org.jclouds.blobstore.domain.internal.PageSetImpl;
 import org.jclouds.blobstore.functions.PrefixToResourceMetadata;
 
@@ -61,10 +60,7 @@ public class ListBlobsResponseToResourceList implements
 
       Map<String, StorageMetadata> nameToMd = Maps.uniqueIndex(contents, indexer);
       for (String prefix : from.getBlobPrefixes()) {
-         prefix = prefix.endsWith("/") ? prefix.substring(0, prefix.lastIndexOf('/')) : prefix;
-         if (!nameToMd.containsKey(prefix)
-                  || nameToMd.get(prefix).getType() != StorageType.RELATIVE_PATH)
-            contents.add(prefix2ResourceMd.apply(prefix));
+         contents.add(prefix2ResourceMd.apply(prefix));
       }
       return new PageSetImpl<StorageMetadata>(contents, from.getNextMarker());
    }

--- a/providers/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/UrlMapValidateResult.java
+++ b/providers/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/UrlMapValidateResult.java
@@ -34,7 +34,6 @@ public abstract class UrlMapValidateResult {
       return new AutoValue_UrlMapValidateResult(result);
    }
 
-   @SerializedNames({"loadSucceeded", "loadErrors", "testPassed", "testFailures"})
    public static UrlMapValidateResult create(Boolean loadSucceeded, List<String> loadErrors,
                               Boolean testPassed, List<UrlMapValidateResultInternal.TestFailure> testFailures) {
       return create(UrlMapValidateResultInternal.create(loadSucceeded, loadErrors, testPassed, testFailures));


### PR DESCRIPTION
Multiple constructors annotated with `@SerializedNames` confuses
`NamingStrategies.translateName` and causes failures with newer JDK.
Since the second constructor does not need this annotation we remote
it.