### PR TITLE
Relax membership assertion for the prefix test.

### DIFF
--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerLiveTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerLiveTest.java
@@ -144,7 +144,7 @@ public class BaseContainerLiveTest extends BaseBlobStoreIntegrationTest {
          names.add(sm.getName());
       }
 
-      assertThat(names).containsExactlyElementsOf(expectedSet);
+      assertThat(names).containsOnlyElementsOf(expectedSet);
    }
 
    private void runCreateContainerInLocation(String payload, Location nonDefault) throws InterruptedException,


### PR DESCRIPTION
Relaxes the membership check in prefix testing. The check is no longer
sensitive to ordering of the results, as different providers may
append, prepend, or insert in sorted order the relative prefixes.