### PR TITLE
Azure Blob: do not filter out prefixes.

### DIFF
--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/functions/ListBlobsResponseToResourceList.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/functions/ListBlobsResponseToResourceList.java
@@ -25,7 +25,6 @@ import javax.inject.Singleton;
 import org.jclouds.azureblob.domain.ListBlobsResponse;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
-import org.jclouds.blobstore.domain.StorageType;
 import org.jclouds.blobstore.domain.internal.PageSetImpl;
 import org.jclouds.blobstore.functions.PrefixToResourceMetadata;
 
@@ -61,10 +60,7 @@ public class ListBlobsResponseToResourceList implements
 
       Map<String, StorageMetadata> nameToMd = Maps.uniqueIndex(contents, indexer);
       for (String prefix : from.getBlobPrefixes()) {
-         prefix = prefix.endsWith("/") ? prefix.substring(0, prefix.lastIndexOf('/')) : prefix;
-         if (!nameToMd.containsKey(prefix)
-                  || nameToMd.get(prefix).getType() != StorageType.RELATIVE_PATH)
-            contents.add(prefix2ResourceMd.apply(prefix));
+         contents.add(prefix2ResourceMd.apply(prefix));
       }
       return new PageSetImpl<StorageMetadata>(contents, from.getNextMarker());
    }


### PR DESCRIPTION
We should not filter out prefixes when listing containers, similarly
to the way swift behaves. This makes the marker blobs apparently to
the user.