### PR TITLE
JCLOUDS-973 Extending the sudo's configuration

### DIFF
--- a/compute/src/test/resources/initscript_with_java.sh
+++ b/compute/src/test/resources/initscript_with_java.sh
@@ -204,6 +204,8 @@ END_OF_JCLOUDS_SCRIPT
 	rm -f $INSTANCE_HOME/rc
 	trap 'echo $?>$INSTANCE_HOME/rc' 0 1 2 3 15
 	cat > /etc/sudoers <<-'END_OF_JCLOUDS_FILE'
+		Defaults    env_reset
+		Defaults    secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 		root ALL = (ALL) ALL
 		%wheel ALL = (ALL) NOPASSWD:ALL
 	END_OF_JCLOUDS_FILE

--- a/compute/src/test/resources/initscript_with_jetty.sh
+++ b/compute/src/test/resources/initscript_with_jetty.sh
@@ -204,6 +204,8 @@ END_OF_JCLOUDS_SCRIPT
 	rm -f $INSTANCE_HOME/rc
 	trap 'echo $?>$INSTANCE_HOME/rc' 0 1 2 3 15
 	cat > /etc/sudoers <<-'END_OF_JCLOUDS_FILE'
+		Defaults    env_reset
+		Defaults    secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 		root ALL = (ALL) ALL
 		%wheel ALL = (ALL) NOPASSWD:ALL
 	END_OF_JCLOUDS_FILE

--- a/compute/src/test/resources/runscript_adminUpdate.sh
+++ b/compute/src/test/resources/runscript_adminUpdate.sh
@@ -85,6 +85,8 @@ END_OF_JCLOUDS_SCRIPT
 	rm -f $INSTANCE_HOME/rc
 	trap 'echo $?>$INSTANCE_HOME/rc' 0 1 2 3 15
 	cat > /etc/sudoers <<-'END_OF_JCLOUDS_FILE'
+		Defaults    env_reset
+		Defaults    secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 		root ALL = (ALL) ALL
 		%wheel ALL = (ALL) NOPASSWD:ALL
 	END_OF_JCLOUDS_FILE

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/login/Sudoers.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/login/Sudoers.java
@@ -41,7 +41,12 @@ public class Sudoers implements Statement {
       if (family == OsFamily.WINDOWS)
          throw new UnsupportedOperationException("windows not yet implemented");
       Builder<Statement> statements = ImmutableList.builder();
-      statements.add(createOrOverwriteFile(sudoers, ImmutableSet.of("root ALL = (ALL) ALL", "%wheel ALL = (ALL) NOPASSWD:ALL")));
+      statements.add(createOrOverwriteFile(sudoers, ImmutableSet.of(
+            "Defaults    env_reset",
+            "Defaults    secure_path=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"",
+            "root ALL = (ALL) ALL", 
+            "%wheel ALL = (ALL) NOPASSWD:ALL"))
+      );
       statements.add(exec("chmod 0440 " + sudoers));
       return new StatementList(statements.build()).render(family);
    }

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/login/SudoStatementsTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/login/SudoStatementsTest.java
@@ -28,6 +28,8 @@ public class SudoStatementsTest {
       assertEquals(
                SudoStatements.createWheel().render(OsFamily.UNIX),
                "cat > /etc/sudoers <<-'END_OF_JCLOUDS_FILE'\n" +
+               "\tDefaults    env_reset\n" +
+               "\tDefaults    secure_path=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"\n" +
                "\troot ALL = (ALL) ALL\n" +
                "\t%wheel ALL = (ALL) NOPASSWD:ALL\n" +
                "END_OF_JCLOUDS_FILE\n" +

--- a/scriptbuilder/src/test/resources/test_adminaccess_flipped.sh
+++ b/scriptbuilder/src/test/resources/test_adminaccess_flipped.sh
@@ -1,5 +1,7 @@
 rm /etc/sudoers
 cat >> /etc/sudoers <<'END_OF_FILE'
+Defaults    env_reset
+Defaults    secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 root ALL = (ALL) ALL
 %wheel ALL = (ALL) NOPASSWD:ALL
 END_OF_FILE

--- a/scriptbuilder/src/test/resources/test_adminaccess_params.sh
+++ b/scriptbuilder/src/test/resources/test_adminaccess_params.sh
@@ -1,4 +1,6 @@
 cat > /etc/sudoers <<-'END_OF_JCLOUDS_FILE'
+	Defaults    env_reset
+	Defaults    secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	root ALL = (ALL) ALL
 	%wheel ALL = (ALL) NOPASSWD:ALL
 END_OF_JCLOUDS_FILE

--- a/scriptbuilder/src/test/resources/test_adminaccess_params_and_fullname.sh
+++ b/scriptbuilder/src/test/resources/test_adminaccess_params_and_fullname.sh
@@ -1,4 +1,6 @@
 cat > /etc/sudoers <<-'END_OF_JCLOUDS_FILE'
+	Defaults    env_reset
+	Defaults    secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	root ALL = (ALL) ALL
 	%wheel ALL = (ALL) NOPASSWD:ALL
 END_OF_JCLOUDS_FILE

--- a/scriptbuilder/src/test/resources/test_adminaccess_standard.sh
+++ b/scriptbuilder/src/test/resources/test_adminaccess_standard.sh
@@ -1,4 +1,6 @@
 cat > /etc/sudoers <<-'END_OF_JCLOUDS_FILE'
+	Defaults    env_reset
+	Defaults    secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	root ALL = (ALL) ALL
 	%wheel ALL = (ALL) NOPASSWD:ALL
 END_OF_JCLOUDS_FILE


### PR DESCRIPTION
This PR provides an extension to the default sudo configuration to address the issue described in [JCLOUDS-973](https://issues.apache.org/jira/browse/JCLOUDS-973) via
- Adding env_reset to the default configuration in /etc/sudoers 
- Adding secure_path to the default configuration in /etc/sudoers
- secure_path value is
"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"