### PR TITLE
Add new Softlayer API method to return arbitrary VirtualGuest fields

### DIFF
--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/features/VirtualGuestApi.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/features/VirtualGuestApi.java
@@ -19,6 +19,7 @@ package org.jclouds.softlayer.features;
 import static org.jclouds.Fallbacks.FalseOnNotFoundOr404;
 import static org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import static org.jclouds.Fallbacks.VoidOnNotFoundOr404;
+
 import java.util.Set;
 
 import javax.inject.Named;
@@ -28,6 +29,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import org.jclouds.http.filters.BasicAuthentication;
@@ -71,8 +73,7 @@ public interface VirtualGuestApi {
    VirtualGuest createVirtualGuest(@BinderParam(VirtualGuestToJson.class) VirtualGuest virtualGuest);
 
    /**
-    * @param id
-    *           id of the virtual guest
+    * @param id id of the virtual guest
     * @return virtual guest or null if not found
     * @see <a href="http://sldn.softlayer.com/reference/services/SoftLayer_Virtual_Guest/getObject" />
     */
@@ -82,6 +83,20 @@ public interface VirtualGuestApi {
    @QueryParams(keys = "objectMask", values = GUEST_MASK)
    @Fallback(NullOnNotFoundOr404.class)
    VirtualGuest getVirtualGuest(@PathParam("id") long id);
+
+   /**
+    * Returns a {@link VirtualGuest} with <b>only</b> the fields listed in the filter string.
+    * @param id id of the virtual guest
+    * @param filter semicolon separated list of fields to return in the resulting object
+    * @return virtual guest or null if not found
+    * @see <a href="http://sldn.softlayer.com/reference/services/SoftLayer_Virtual_Guest/getObject" />
+    * @see <a href="http://sldn.softlayer.com/article/object-masks" />
+    */
+   @Named("VirtualGuests:get")
+   @GET
+   @Path("/SoftLayer_Virtual_Guest/{id}/getObject")
+   @Fallback(NullOnNotFoundOr404.class)
+   VirtualGuest getVirtualGuestFiltered(@PathParam("id") long id, @QueryParam("objectMask") String filter);
 
    /**
     * Delete a computing instance

--- a/providers/softlayer/src/test/java/org/jclouds/softlayer/features/VirtualGuestApiLiveTest.java
+++ b/providers/softlayer/src/test/java/org/jclouds/softlayer/features/VirtualGuestApiLiveTest.java
@@ -21,6 +21,7 @@ import static org.jclouds.softlayer.compute.strategy.SoftLayerComputeServiceAdap
 import static org.jclouds.util.Predicates2.retry;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import java.util.Properties;
 import java.util.Set;
@@ -111,9 +112,19 @@ public class VirtualGuestApiLiveTest extends BaseSoftLayerApiLiveTest {
    public void testGetVirtualGuest() throws Exception {
       VirtualGuest found = virtualGuestApi.getVirtualGuest(virtualGuest.getId());
       assertEquals(found, virtualGuest);
+      assertNull(found.getPrimaryBackendNetworkComponent(), "backendNetworkComponent should be null");
    }
 
    @Test(dependsOnMethods = "testGetVirtualGuest")
+   public void testGetVirtualGuestFiltered() throws Exception {
+      VirtualGuest found = virtualGuestApi.getVirtualGuestFiltered(virtualGuest.getId(), "id;primaryBackendNetworkComponent;primaryBackendNetworkComponent.networkVlan");
+      assertEquals(found.getId(), virtualGuest.getId());
+      assertNotNull(found.getPrimaryBackendNetworkComponent(), "backendNetworkComponent must be returned");
+      assertNotNull(found.getPrimaryBackendNetworkComponent().getNetworkVlan(), "backendNetworkComponent networkVlan must be returned");
+      assertTrue(found.getPrimaryBackendNetworkComponent().getNetworkVlan().getId() > 0, "backendNetworkComponent must have a valid networkVlan ID");
+   }
+
+   @Test(dependsOnMethods = "testGetVirtualGuestFiltered")
    public void testSetTagsOnVirtualGuest() throws Exception {
       ImmutableSet<String> tags = ImmutableSet.of("test", "jclouds");
       assertTrue(virtualGuestApi.setTags(virtualGuest.getId(), tags));

--- a/providers/softlayer/src/test/java/org/jclouds/softlayer/features/VirtualGuestApiMockTest.java
+++ b/providers/softlayer/src/test/java/org/jclouds/softlayer/features/VirtualGuestApiMockTest.java
@@ -29,12 +29,14 @@ import org.jclouds.softlayer.domain.OperatingSystem;
 import org.jclouds.softlayer.domain.VirtualGuest;
 import org.jclouds.softlayer.internal.BaseSoftLayerMockTest;
 import org.jclouds.softlayer.parse.GetCreateObjectOptionsParseTest;
+import org.jclouds.softlayer.parse.VirtualGuestFilteredParseTest;
 import org.jclouds.softlayer.parse.VirtualGuestParseTest;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableSet;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
+
+import com.google.common.collect.ImmutableSet;
 
 /**
  * Mock tests for the {@link org.jclouds.softlayer.features.VirtualGuestApi} class.
@@ -42,17 +44,29 @@ import com.squareup.okhttp.mockwebserver.MockWebServer;
 @Test(groups = "unit", testName = "VirtualGuestApiMockTest")
 public class VirtualGuestApiMockTest extends BaseSoftLayerMockTest {
 
-   public void testGetVirtualGuest() throws Exception {
-      MockWebServer server = mockWebServer(new MockResponse().setBody(payloadFromResource("/virtual_guest_get.json")));
-      VirtualGuestApi api = getVirtualGuestApi(server);
+    public void testGetVirtualGuest() throws Exception {
+       MockWebServer server = mockWebServer(new MockResponse().setBody(payloadFromResource("/virtual_guest_get.json")));
+       VirtualGuestApi api = getVirtualGuestApi(server);
 
-      try {
-         assertEquals(api.getVirtualGuest(3001812), new VirtualGuestParseTest().expected());
-         assertSent(server, "GET", "/SoftLayer_Virtual_Guest/3001812/getObject?objectMask=id%3Bhostname%3Bdomain%3BfullyQualifiedDomainName%3BpowerState%3BmaxCpu%3BmaxMemory%3BstatusId%3BoperatingSystem.passwords%3BprimaryBackendIpAddress%3BprimaryIpAddress%3BactiveTransactionCount%3BblockDevices.diskImage%3Bdatacenter%3BtagReferences%3BprivateNetworkOnlyFlag%3BsshKeys");
-      } finally {
-         server.shutdown();
-      }
-   }
+       try {
+          assertEquals(api.getVirtualGuest(3001812), new VirtualGuestParseTest().expected());
+          assertSent(server, "GET", "/SoftLayer_Virtual_Guest/3001812/getObject?objectMask=id%3Bhostname%3Bdomain%3BfullyQualifiedDomainName%3BpowerState%3BmaxCpu%3BmaxMemory%3BstatusId%3BoperatingSystem.passwords%3BprimaryBackendIpAddress%3BprimaryIpAddress%3BactiveTransactionCount%3BblockDevices.diskImage%3Bdatacenter%3BtagReferences%3BprivateNetworkOnlyFlag%3BsshKeys");
+       } finally {
+          server.shutdown();
+       }
+    }
+
+    public void testGetVirtualGuestFiltered() throws Exception {
+       MockWebServer server = mockWebServer(new MockResponse().setBody(payloadFromResource("/virtual_guest_get_filtered.json")));
+       VirtualGuestApi api = getVirtualGuestApi(server);
+
+       try {
+          assertEquals(api.getVirtualGuestFiltered(3001812, "id;primaryBackendNetworkComponent;primaryBackendNetworkComponent.networkVlan"), new VirtualGuestFilteredParseTest().expected());
+          assertSent(server, "GET", "/SoftLayer_Virtual_Guest/3001812/getObject?objectMask=id%3BprimaryBackendNetworkComponent%3BprimaryBackendNetworkComponent.networkVlan");
+       } finally {
+          server.shutdown();
+       }
+    }
 
    public void testGetNullVirtualGuest() throws Exception {
       MockWebServer server = mockWebServer(new MockResponse().setResponseCode(404));

--- a/providers/softlayer/src/test/java/org/jclouds/softlayer/parse/VirtualGuestFilteredParseTest.java
+++ b/providers/softlayer/src/test/java/org/jclouds/softlayer/parse/VirtualGuestFilteredParseTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.softlayer.parse;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.core.MediaType;
+
+import org.jclouds.softlayer.domain.NetworkVlan;
+import org.jclouds.softlayer.domain.VirtualGuest;
+import org.jclouds.softlayer.domain.VirtualGuestNetworkComponent;
+import org.jclouds.softlayer.internal.BaseSoftLayerParseTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit")
+public class VirtualGuestFilteredParseTest extends BaseSoftLayerParseTest<VirtualGuest> {
+
+   @Override
+   public String resource() {
+      return "/virtual_guest_get_filtered.json";
+   }
+
+   @Override
+   @Consumes(MediaType.APPLICATION_JSON)
+   public VirtualGuest expected() {
+      return VirtualGuest.builder()
+                              .id(3001812)
+                              .primaryBackendNetworkComponent(VirtualGuestNetworkComponent.builder()
+                                      .networkId(123456)
+                                      .networkVlan(NetworkVlan.builder()
+                                              .id(1234)
+                                              .name("abc")
+                                              .build())
+                                      .build())
+                              .build();
+   }
+}

--- a/providers/softlayer/src/test/resources/virtual_guest_get_filtered.json
+++ b/providers/softlayer/src/test/resources/virtual_guest_get_filtered.json
@@ -1,0 +1,10 @@
+{
+    "primaryBackendNetworkComponent": {
+        "networkId" : 123456,
+        "networkVlan": {
+            "id": 1234,
+            "name": "abc"
+        }
+    },
+    "id": 3001812
+}


### PR DESCRIPTION
Adds new method to `VirtualGuestApi` that allows the user to set the object-mask, therefore enabling arbitrary fields to be returned; for example the `NetworkVlan` object. Includes unit and live tests.