### PR TITLE
JCLOUDS-974: Upgrade to GSON 2.3.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.3</version>
+      <version>2.3.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
This may resolve issues with older versions of Maven.  Release notes:

https://sites.google.com/site/gson/gson-roadmap