### PR TITLE
JCLOUDS-883: Replace metadata during Swift copy

### DIFF
--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/features/ObjectApi.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/features/ObjectApi.java
@@ -19,6 +19,7 @@ package org.jclouds.openstack.swift.v1.features;
 import static com.google.common.net.HttpHeaders.EXPECT;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.OBJECT_COPY_FROM;
+import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.OBJECT_COPY_FRESH_METADATA;
 
 import java.util.Map;
 
@@ -309,7 +310,7 @@ public interface ObjectApi {
    @Named("object:copy")
    @PUT
    @Path("/{destinationObject}")
-   @Headers(keys = OBJECT_COPY_FROM, values = "/{sourceContainer}/{sourceObject}")
+   @Headers(keys = {OBJECT_COPY_FROM, OBJECT_COPY_FRESH_METADATA}, values = {"/{sourceContainer}/{sourceObject}", "True"})
    @Fallback(FalseOnKeyNotFound.class)
    boolean copy(@PathParam("destinationObject") String destinationObject,
          @PathParam("sourceContainer") String sourceContainer,

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/reference/SwiftHeaders.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/reference/SwiftHeaders.java
@@ -71,6 +71,7 @@ public final class SwiftHeaders {
    public static final String CONTAINER_WEB_MODE = "X-Web-Mode";
 
    public static final String OBJECT_COPY_FROM = "X-Copy-From";
+   public static final String OBJECT_COPY_FRESH_METADATA = "X-Fresh-Metadata";
    public static final String OBJECT_DELETE_AFTER = "X-Delete-After";
    public static final String OBJECT_DELETE_AT = "X-Delete-At";
    public static final String OBJECT_MANIFEST = "X-Object-Manifest";

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftBlobIntegrationLiveTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftBlobIntegrationLiveTest.java
@@ -80,11 +80,6 @@ public class SwiftBlobIntegrationLiveTest extends BaseBlobIntegrationTest {
    }
 
    @Override
-   public void testCopyBlobReplaceMetadata() throws Exception {
-      throw new SkipException("Swift only supports appending to user metadata, not replacing it");
-   }
-
-   @Override
    protected long getMinimumMultipartBlobSize() {
       return 1;
    }


### PR DESCRIPTION
Previously Swift copy would append metadata instead of replacing it.