### PR TITLE
JCLOUDS-827 updating sshj

### DIFF
--- a/drivers/bouncycastle/pom.xml
+++ b/drivers/bouncycastle/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-ext-jdk15on</artifactId>
-      <version>1.49</version>
+      <version>1.51</version>
     </dependency>
   </dependencies>
 

--- a/drivers/jsch/pom.xml
+++ b/drivers/jsch/pom.xml
@@ -90,12 +90,12 @@
     <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch.agentproxy.jsch</artifactId>
-      <version>0.0.8</version>
+      <version>0.0.9</version>
     </dependency>
     <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch.agentproxy.connector-factory</artifactId>
-      <version>0.0.8</version>
+      <version>0.0.9</version>
     </dependency>
   </dependencies>
 

--- a/drivers/sshj/pom.xml
+++ b/drivers/sshj/pom.xml
@@ -87,15 +87,14 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>net.schmizz</groupId>
+      <groupId>com.hierynomus</groupId>
       <artifactId>sshj</artifactId>
-      <version>0.8.1</version>
     </dependency>
     <!-- required by sshj -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.49</version>
+      <version>1.51</version>
       <exclusions>
         <!-- provided by the jclouds-bouncycastle driver -->
         <exclusion>
@@ -107,12 +106,26 @@
     <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch.agentproxy.sshj</artifactId>
-      <version>0.0.8</version>
+      <version>0.0.9</version>
+      <exclusions>
+        <!-- Required due to sshj groupId change -->
+        <exclusion>
+          <groupId>net.schmizz</groupId>
+          <artifactId>sshj</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch.agentproxy.connector-factory</artifactId>
-      <version>0.0.8</version>
+      <version>0.0.9</version>
+      <exclusions>
+        <exclusion>
+          <!-- Required due to sshj groupId change -->
+          <groupId>net.schmizz</groupId>
+          <artifactId>sshj</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -232,6 +232,7 @@
     <auto-service.version>1.0-rc2</auto-service.version>
     <auto-value.version>1.1</auto-value.version>
     <java-xmlbuilder.version>1.1</java-xmlbuilder.version>
+    <sshj.version>0.12.0</sshj.version>
     <http.proxyHost />
     <http.proxyPort />
     <jclouds.wire.httpstream.url>http://archive.apache.org/dist/commons/logging/binaries/commons-logging-1.1.1-bin.tar.gz</jclouds.wire.httpstream.url>
@@ -360,6 +361,18 @@
         <groupId>com.jamesmurty.utils</groupId>
         <artifactId>java-xmlbuilder</artifactId>
         <version>${java-xmlbuilder.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hierynomus</groupId>
+        <artifactId>sshj</artifactId>
+        <version>${sshj.version}</version>
+        <exclusions>
+        <!-- provided by the jclouds-bouncycastle driver -->
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+      </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -577,12 +590,12 @@
                 <dependency>
                   <groupId>com.jcraft</groupId>
                   <artifactId>jsch.agentproxy.core</artifactId>
-                  <version>0.0.8</version>
+                  <version>0.0.9</version>
                 </dependency>
                 <dependency>
                   <groupId>com.jcraft</groupId>
                   <artifactId>jsch.agentproxy.connector-factory</artifactId>
-                  <version>0.0.8</version>
+                  <version>0.0.9</version>
                 </dependency>
               </conflictingDependencies>
               <packages>


### PR DESCRIPTION
Moved sshj to the new com.hierynomus version.
This only needed a minor code change due to a method removal.

However, due to the changed groupId but the same package declarations
maven treats them as different and does not exclude the versions imported by
jsch.agentproxy so thse are manually excluded and updated to the 0.0.9 versions

Also sshj is depends on a newer version of BouncyCastle. This has been updated to 1.51.
The inclusion of the extended version in the bouncycastle driver causes a duplicate
class clash. This could be ignored in the project pom but I have reduced it to the
normal version. Users could still provide the extended version if they require it.