### PR TITLE
Subclass ObjectApiLiveTest in Cloudfiles providers

### DIFF
--- a/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/features/CloudFilesUKObjectApiLiveTest.java
+++ b/providers/rackspace-cloudfiles-uk/src/test/java/org/jclouds/rackspace/cloudfiles/uk/features/CloudFilesUKObjectApiLiveTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.features;
+
+import org.jclouds.rackspace.cloudfiles.v1.features.CloudFilesObjectApiLiveTest;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the live behavior of the OpenStack Object Storage {@link ObjectApi}
+ * via the {@link CloudFilesApi}.
+ */
+@Test(groups = "live", testName = "CloudFilesUKObjectApiLiveTest")
+public class CloudFilesUKObjectApiLiveTest extends CloudFilesObjectApiLiveTest {
+   public CloudFilesUKObjectApiLiveTest() {
+      provider = "rackspace-cloudfiles-uk";
+   }
+}

--- a/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/features/CloudFilesUSObjectApiLiveTest.java
+++ b/providers/rackspace-cloudfiles-us/src/test/java/org/jclouds/rackspace/cloudfiles/us/features/CloudFilesUSObjectApiLiveTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudfiles.v1.features;
+
+import org.jclouds.rackspace.cloudfiles.v1.features.CloudFilesObjectApiLiveTest;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the live behavior of the OpenStack Object Storage {@link ObjectApi}
+ * via the {@link CloudFilesApi}.
+ */
+@Test(groups = "live", testName = "CloudFilesUSObjectApiLiveTest")
+public class CloudFilesUSObjectApiLiveTest extends CloudFilesObjectApiLiveTest {
+   public CloudFilesUSObjectApiLiveTest() {
+      provider = "rackspace-cloudfiles-us";
+   }
+}


### PR DESCRIPTION
This allows tests to run.