### PR TITLE
Remove last marker test from ListContainerMarker.

### DIFF
--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
@@ -186,9 +186,6 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
          assert container.size() == 25 : String.format("size should have been 25, but was %d: %s", container.size(),
                container);
          assert container.getNextMarker() == null;
-
-         container = view.getBlobStore().list(containerName, afterMarker("z"));
-         assertThat(container.getNextMarker()).isNull();
       } finally {
          returnContainer(containerName);
       }


### PR DESCRIPTION
Azure does not allow arbitrary marker specification and the generic
testListContainerMarker test should not assume that the behavior is
possible. There is already a separate test for such scenario that is
skipped on Azure.