### PR TITLE
replace old style asserts with AssertJ's assertThat

### DIFF
--- a/apis/atmos/src/test/java/org/jclouds/atmos/AtmosClientLiveTest.java
+++ b/apis/atmos/src/test/java/org/jclouds/atmos/AtmosClientLiveTest.java
@@ -18,6 +18,7 @@ package org.jclouds.atmos;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Preconditions.checkState;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.util.Predicates2.retry;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
@@ -117,7 +118,7 @@ public class AtmosClientLiveTest extends BaseBlobStoreIntegrationTest {
    @Test
    public void testListDirectorys() throws Exception {
       BoundedSet<? extends DirectoryEntry> response = getApi().listDirectories();
-      assert null != response;
+      assertThat(null != response).isTrue();
    }
 
    String privateDirectory;
@@ -140,7 +141,7 @@ public class AtmosClientLiveTest extends BaseBlobStoreIntegrationTest {
       BoundedSet<? extends DirectoryEntry> response = getApi().listDirectories();
       for (DirectoryEntry id : response) {
          BoundedSet<? extends DirectoryEntry> r2 = getApi().listDirectory(id.getObjectName());
-         assert r2 != null;
+         assertThat(r2 != null).isTrue();
       }
       // subsequent creation should fail
       assertNull(getApi().createDirectory(privateDirectory));
@@ -155,11 +156,11 @@ public class AtmosClientLiveTest extends BaseBlobStoreIntegrationTest {
       createOrReplaceObject("object4", data, hashCode, "meta-value1");
       BoundedSet<? extends DirectoryEntry> r2 = getApi().listDirectory(privateDirectory, ListOptions.Builder.limit(1));
       assertEquals(r2.size(), 1);
-      assert r2.getToken() != null;
+      assertThat(r2.getToken() != null).isTrue();
       assertEquals(Iterables.getLast(Sets.newTreeSet(r2)).getObjectName(), "object2");
       r2 = getApi().listDirectory(privateDirectory, ListOptions.Builder.token(r2.getToken()));
       assertEquals(r2.size(), 2);
-      assert r2.getToken() == null;
+      assertThat(r2.getToken() == null).isTrue();
       assertEquals(Iterables.getLast(Sets.newTreeSet(r2)).getObjectName(), "object4");
    }
 
@@ -270,26 +271,26 @@ public class AtmosClientLiveTest extends BaseBlobStoreIntegrationTest {
 
    private static void verifyMetadata(String metadataValue, AtmosObject getBlob) {
       assertEquals(getBlob.getContentMetadata().getContentLength(), Long.valueOf(16));
-      assert getBlob.getContentMetadata().getContentType().startsWith("text/plain");
+      assertThat(getBlob.getContentMetadata().getContentType().startsWith("text/plain")).isTrue();
       assertEquals(getBlob.getUserMetadata().getMetadata().get("Metadata"), metadataValue);
       SystemMetadata md = getBlob.getSystemMetadata();
       assertEquals(md.getSize(), 16);
-      assert md.getGroupID() != null;
+      assertThat(md.getGroupID() != null).isTrue();
       assertEquals(md.getHardLinkCount(), 1);
-      assert md.getInceptionTime() != null;
-      assert md.getLastAccessTime() != null;
-      assert md.getLastMetadataModification() != null;
-      assert md.getLastUserDataModification() != null;
-      assert md.getObjectID() != null;
+      assertThat(md.getInceptionTime() != null).isTrue();
+      assertThat(md.getLastAccessTime() != null).isTrue();
+      assertThat(md.getLastMetadataModification() != null).isTrue();
+      assertThat(md.getLastUserDataModification() != null).isTrue();
+      assertThat(md.getObjectID() != null).isTrue();
       assertEquals(md.getObjectName(), "object");
-      assert md.getPolicyName() != null;
+      assertThat(md.getPolicyName() != null).isTrue();
       assertEquals(md.getType(), FileType.REGULAR);
-      assert md.getUserID() != null;
+      assertThat(md.getUserID() != null).isTrue();
 
       try {
          Strings2.toStringAndClose(URI.create(
-                  "http://accesspoint.emccis.com/rest/objects/" + getBlob.getSystemMetadata().getObjectID()).toURL()
-                  .openStream());
+                 "http://accesspoint.emccis.com/rest/objects/" + getBlob.getSystemMetadata().getObjectID()).toURL()
+                 .openStream());
          fail("shouldn't have worked, since it is private");
       } catch (IOException e) {
 
@@ -330,9 +331,9 @@ public class AtmosClientLiveTest extends BaseBlobStoreIntegrationTest {
          getApi().deletePath(path);
       } catch (KeyNotFoundException ex) {
       }
-      assert !getApi().pathExists(path);
+      assertThat(!getApi().pathExists(path)).isTrue();
       System.err.printf("path %s doesn't exist%n", path);
-      assert !getApi().pathExists(path);
+      assertThat(!getApi().pathExists(path)).isTrue();
       System.err.printf("path %s doesn't exist%n", path);
 
    }

--- a/apis/atmos/src/test/java/org/jclouds/atmos/blobstore/integration/AtmosIntegrationLiveTest.java
+++ b/apis/atmos/src/test/java/org/jclouds/atmos/blobstore/integration/AtmosIntegrationLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.atmos.blobstore.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
@@ -79,22 +80,22 @@ public class AtmosIntegrationLiveTest extends BaseBlobIntegrationTest {
    // not supported
    @Override
    protected void checkContentDisposition(Blob blob, String contentDisposition) {
-      assert blob.getPayload().getContentMetadata().getContentDisposition() == null;
-      assert blob.getMetadata().getContentMetadata().getContentDisposition() == null;
+      assertThat(blob.getPayload().getContentMetadata().getContentDisposition() == null).isTrue();
+      assertThat(blob.getMetadata().getContentMetadata().getContentDisposition() == null).isTrue();
    }
 
    // not supported
    @Override
    protected void checkContentEncoding(Blob blob, String contentEncoding) {
-      assert blob.getPayload().getContentMetadata().getContentEncoding() == null;
-      assert blob.getMetadata().getContentMetadata().getContentEncoding() == null;
+      assertThat(blob.getPayload().getContentMetadata().getContentEncoding() == null).isTrue();
+      assertThat(blob.getMetadata().getContentMetadata().getContentEncoding() == null).isTrue();
    }
 
    // not supported
    @Override
    protected void checkContentLanguage(Blob blob, String contentLanguage) {
-      assert blob.getPayload().getContentMetadata().getContentLanguage() == null;
-      assert blob.getMetadata().getContentMetadata().getContentLanguage() == null;
+      assertThat(blob.getPayload().getContentMetadata().getContentLanguage() == null).isTrue();
+      assertThat(blob.getMetadata().getContentMetadata().getContentLanguage() == null).isTrue();
    }
 
    @Override

--- a/apis/atmos/src/test/java/org/jclouds/atmos/options/ListOptionsTest.java
+++ b/apis/atmos/src/test/java/org/jclouds/atmos/options/ListOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.atmos.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
@@ -52,18 +53,18 @@ public class ListOptionsTest {
 
    public void testNoMeta() {
       ListOptions options = new ListOptions();
-      assert !options.metaIncluded();
+      assertThat(!options.metaIncluded()).isTrue();
    }
 
    public void testMeta() {
       ListOptions options = new ListOptions().includeMeta();
       assertEquals(ImmutableList.of("1"), options.buildRequestHeaders().get("x-emc-include-meta"));
-      assert options.metaIncluded();
+      assertThat(options.metaIncluded()).isTrue();
    }
 
    public void testMetaStatic() {
       ListOptions options = ListOptions.Builder.includeMeta();
       assertEquals(ImmutableList.of("1"), options.buildRequestHeaders().get("x-emc-include-meta"));
-      assert options.metaIncluded();
+      assertThat(options.metaIncluded()).isTrue();
    }
 }

--- a/apis/byon/src/test/java/org/jclouds/byon/BYONComputeServiceLiveTest.java
+++ b/apis/byon/src/test/java/org/jclouds/byon/BYONComputeServiceLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.byon;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.compute.options.RunScriptOptions.Builder.wrapInInitScript;
 import static org.jclouds.scriptbuilder.domain.Statements.exec;
 
@@ -76,8 +77,8 @@ public class BYONComputeServiceLiveTest {
                Predicates.<NodeMetadata> alwaysTrue(), exec("id"), wrapInInitScript(false).runAsRoot(false));
 
       for (Entry<? extends NodeMetadata, ExecResponse> response : responses.entrySet())
-         assert response.getValue().getOutput().trim().contains(System.getProperty("user.name")) : response.getKey()
-                  + ": " + response.getValue();
+         assertThat(response.getValue().getOutput().trim().contains(System.getProperty("user.name"))).as(response.getKey()
+                  + ": " + response.getValue()).isTrue();
    }
 
    @AfterClass(groups = "live")

--- a/apis/chef/src/test/java/org/jclouds/chef/handlers/ChefApiErrorRetryHandlerTest.java
+++ b/apis/chef/src/test/java/org/jclouds/chef/handlers/ChefApiErrorRetryHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.chef.handlers;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -48,7 +49,7 @@ public class ChefApiErrorRetryHandlerTest {
 
       ChefApiErrorRetryHandler handler = new ChefApiErrorRetryHandler(retry);
 
-      assert !handler.shouldRetryRequest(command, response);
+      assertThat(!handler.shouldRetryRequest(command, response)).isTrue();
 
       verify(retry);
       verify(command);
@@ -72,7 +73,7 @@ public class ChefApiErrorRetryHandlerTest {
 
       ChefApiErrorRetryHandler handler = new ChefApiErrorRetryHandler(retry);
 
-      assert !handler.shouldRetryRequest(command, response);
+      assertThat(!handler.shouldRetryRequest(command, response)).isTrue();
 
       verify(retry);
       verify(command);
@@ -106,7 +107,7 @@ public class ChefApiErrorRetryHandlerTest {
 
       ChefApiErrorRetryHandler handler = new ChefApiErrorRetryHandler(retry);
 
-      assert handler.shouldRetryRequest(command, response);
+      assertThat(handler.shouldRetryRequest(command, response)).isTrue();
 
       verify(retry);
       verify(command);

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/compute/CloudStackComputeServiceAdapterLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/compute/CloudStackComputeServiceAdapterLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.compute;
 import static com.google.common.collect.Iterables.getFirst;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
@@ -103,7 +104,7 @@ public class CloudStackComputeServiceAdapterLiveTest extends BaseCloudStackApiLi
 
       loginCredentials = prioritizeCredentialsFromTemplate.apply(template, vm.getCredentials());
 
-      assert InetAddresses.isInetAddress(address) : vm;
+      assertThat(InetAddresses.isInetAddress(address)).as(String.valueOf(vm)).isTrue();
       HostAndPort socket = HostAndPort.fromParts(address, 22);
       checkSSH(socket);
    }
@@ -124,7 +125,7 @@ public class CloudStackComputeServiceAdapterLiveTest extends BaseCloudStackApiLi
       assertFalse(Iterables.isEmpty(templates));
 
       for (org.jclouds.cloudstack.domain.Template template : templates) {
-         assert TemplatePredicates.isReady().apply(template) : template;
+         assertThat(TemplatePredicates.isReady().apply(template)).as(String.valueOf(template)).isTrue();
       }
    }
 

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/compute/CloudStackExperimentLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/compute/CloudStackExperimentLiveTest.java
@@ -35,6 +35,7 @@ import java.util.logging.Logger;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.get;
 import static com.google.common.collect.Sets.newTreeSet;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.cloudstack.options.CreateNetworkOptions.Builder.vlan;
 import static org.jclouds.cloudstack.options.ListNetworkOfferingsOptions.Builder.specifyVLAN;
 
@@ -76,7 +77,7 @@ public class CloudStackExperimentLiveTest extends BaseCloudStackApiLiveTest {
       Network network = null;
       Set<? extends NodeMetadata> nodes = null;
       try {
-         assert !view.getComputeService().listAssignableLocations().isEmpty();
+         assertThat(!view.getComputeService().listAssignableLocations().isEmpty()).isTrue();
 
          Template template = view.getComputeService().templateBuilder().build();
 
@@ -103,7 +104,7 @@ public class CloudStackExperimentLiveTest extends BaseCloudStackApiLiveTest {
          // launch the VM
          nodes = view.getComputeService().createNodesInGroup(group, 1, template);
 
-         assert !nodes.isEmpty();
+         assertThat(!nodes.isEmpty()).isTrue();
 
       } catch (RunNodesException e) {
          Logger.getAnonymousLogger().log(Level.SEVERE, "error creating nodes", e);

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/AccountApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/AccountApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import org.jclouds.cloudstack.domain.Account;
@@ -36,45 +37,45 @@ public class AccountApiLiveTest extends BaseCloudStackApiLiveTest {
    }
 
    protected void checkAccount(Account account) {
-      assert account.getId() != null : account;
+      assertThat(account.getId() != null).as(String.valueOf(account)).isTrue();
       assertEquals(account.toString(), client.getAccountApi().getAccount(account.getId()).toString());
-      assert account.getName() != null : account;
-      assert account.getType() != null && account.getType() != Account.Type.UNRECOGNIZED : account;
-      assert account.getDomain() != null : account;
-      assert account.getDomainId() != null : account;
-      assert account.getUsers() != null : account;
+      assertThat(account.getName() != null).as(String.valueOf(account)).isTrue();
+      assertThat(account.getType() != null && account.getType() != Account.Type.UNRECOGNIZED).as(String.valueOf(account)).isTrue();
+      assertThat(account.getDomain() != null).as(String.valueOf(account)).isTrue();
+      assertThat(account.getDomainId() != null).as(String.valueOf(account)).isTrue();
+      assertThat(account.getUsers() != null).as(String.valueOf(account)).isTrue();
       for (User user : account.getUsers()) {
-         assert user.getName() != null : user;
-         assert user.getAccountType().equals(account.getType()) : user;
-         assert user.getDomain().equals(account.getDomain()) : user;
-         assert user.getDomainId().equals(account.getDomainId()) : user;
-         assert user.getCreated() != null : user;
-         assert user.getEmail() != null : user;
-         assert user.getLastName() != null : user;
-         assert user.getFirstName() != null : user;
-         assert user.getId() != null : user;
-         assert user.getState() != null : user;
+         assertThat(user.getName() != null).as(String.valueOf(user)).isTrue();
+         assertThat(user.getAccountType().equals(account.getType())).as(String.valueOf(user)).isTrue();
+         assertThat(user.getDomain().equals(account.getDomain())).as(String.valueOf(user)).isTrue();
+         assertThat(user.getDomainId().equals(account.getDomainId())).as(String.valueOf(user)).isTrue();
+         assertThat(user.getCreated() != null).as(String.valueOf(user)).isTrue();
+         assertThat(user.getEmail() != null).as(String.valueOf(user)).isTrue();
+         assertThat(user.getLastName() != null).as(String.valueOf(user)).isTrue();
+         assertThat(user.getFirstName() != null).as(String.valueOf(user)).isTrue();
+         assertThat(user.getId() != null).as(String.valueOf(user)).isTrue();
+         assertThat(user.getState() != null).as(String.valueOf(user)).isTrue();
       }
-      assert account.getIPsAvailable() == null || account.getIPsAvailable() >= 0 : account;
-      assert account.getIPLimit() == null || account.getIPLimit() >= 0 : account;
-      assert account.getIPs() >= 0 : account;
-      assert account.getReceivedBytes() >= 0 : account;
-      assert account.getSentBytes() >= 0 : account;
-      assert account.getSnapshotsAvailable() == null || account.getSnapshotsAvailable() >= 0 : account;
-      assert account.getSnapshotLimit() == null || account.getSnapshotLimit() >= 0 : account;
-      assert account.getSnapshots() >= 0 : account;
-      assert account.getState() != null && account.getState() != Account.State.UNRECOGNIZED : account;
-      assert account.getTemplatesAvailable() == null || account.getTemplatesAvailable() >= 0 : account;
-      assert account.getTemplateLimit() == null || account.getTemplateLimit() >= 0 : account;
-      assert account.getTemplates() >= 0 : account;
-      assert account.getVMsAvailable() == null || account.getVMsAvailable() >= 0 : account;
-      assert account.getVMLimit() == null || account.getVMLimit() >= 0 : account;
-      assert account.getVMsRunning() >= 0 : account;
-      assert account.getVMsStopped() >= 0 : account;
-      assert account.getVMs() >= 0 : account;
-      assert account.getVolumesAvailable() == null || account.getVolumesAvailable() >= 0 : account;
-      assert account.getVolumeLimit() == null || account.getVolumeLimit() >= 0 : account;
-      assert account.getVolumes() >= 0 : account;
+      assertThat(account.getIPsAvailable() == null || account.getIPsAvailable() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getIPLimit() == null || account.getIPLimit() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getIPs() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getReceivedBytes() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getSentBytes() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getSnapshotsAvailable() == null || account.getSnapshotsAvailable() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getSnapshotLimit() == null || account.getSnapshotLimit() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getSnapshots() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getState() != null && account.getState() != Account.State.UNRECOGNIZED).as(String.valueOf(account)).isTrue();
+      assertThat(account.getTemplatesAvailable() == null || account.getTemplatesAvailable() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getTemplateLimit() == null || account.getTemplateLimit() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getTemplates() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getVMsAvailable() == null || account.getVMsAvailable() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getVMLimit() == null || account.getVMLimit() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getVMsRunning() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getVMsStopped() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getVMs() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getVolumesAvailable() == null || account.getVolumesAvailable() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getVolumeLimit() == null || account.getVolumeLimit() >= 0).as(String.valueOf(account)).isTrue();
+      assertThat(account.getVolumes() >= 0).as(String.valueOf(account)).isTrue();
    }
 
 }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/AddressApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/AddressApiLiveTest.java
@@ -18,6 +18,7 @@ package org.jclouds.cloudstack.features;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -70,7 +71,7 @@ public class AddressApiLiveTest extends BaseCloudStackApiLiveTest {
       if (!networksEnabled)
          return;
       Set<PublicIPAddress> response = client.getAddressApi().listPublicIPAddresses();
-      assert null != response;
+      assertThat(null != response).isTrue();
       assertTrue(response.size() > 0);
       for (PublicIPAddress ip : response) {
          PublicIPAddress newDetails = getOnlyElement(client.getAddressApi().listPublicIPAddresses(
@@ -82,13 +83,13 @@ public class AddressApiLiveTest extends BaseCloudStackApiLiveTest {
 
    protected void checkIP(PublicIPAddress ip) {
       assertEquals(ip.getId(), client.getAddressApi().getPublicIPAddress(ip.getId()).getId());
-      assert ip.getId() != null : ip;
-      assert ip.getAccount() != null : ip;
-      assert ip.getDomain() != null : ip;
-      assert ip.getDomainId() != null : ip;
-      assert ip.getState() != null : ip;
-      assert ip.getZoneId() != null : ip;
-      assert ip.getZoneName() != null : ip;
+      assertThat(ip.getId() != null).as(String.valueOf(ip)).isTrue();
+      assertThat(ip.getAccount() != null).as(String.valueOf(ip)).isTrue();
+      assertThat(ip.getDomain() != null).as(String.valueOf(ip)).isTrue();
+      assertThat(ip.getDomainId() != null).as(String.valueOf(ip)).isTrue();
+      assertThat(ip.getState() != null).as(String.valueOf(ip)).isTrue();
+      assertThat(ip.getZoneId() != null).as(String.valueOf(ip)).isTrue();
+      assertThat(ip.getZoneName() != null).as(String.valueOf(ip)).isTrue();
 
    }
 }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/AsyncJobApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/AsyncJobApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -35,37 +36,37 @@ public class AsyncJobApiLiveTest extends BaseCloudStackApiLiveTest {
    @Test(enabled = true)
    public void testListAsyncJobs() throws Exception {
       Set<AsyncJob<?>> response = client.getAsyncJobApi().listAsyncJobs();
-      assert null != response;
+      assertThat(null != response).isTrue();
 
       long asyncJobCount = response.size();
       assertTrue(asyncJobCount >= 0);
 
       for (AsyncJob<?> asyncJob : response) {
-         assert asyncJob.getCmd() != null : asyncJob;
-         assert asyncJob.getUserId() != null : asyncJob;
+         assertThat(asyncJob.getCmd() != null).as(String.valueOf(asyncJob)).isTrue();
+         assertThat(asyncJob.getUserId() != null).as(String.valueOf(asyncJob)).isTrue();
          checkJob(asyncJob);
 
          AsyncJob<?> query = client.getAsyncJobApi().getAsyncJob(asyncJob.getId());
          assertEquals(query.getId(), asyncJob.getId());
 
-         assert query.getResultType() != null : query;
+         assertThat(query.getResultType() != null).as(String.valueOf(query)).isTrue();
          checkJob(query);
       }
    }
 
    private void checkJob(AsyncJob<?> query) {
-      assert query.getStatus().code() >= 0 : query;
-      assert query.getResultCode().code() >= 0 : query;
-      assert query.getProgress() >= 0 : query;
+      assertThat(query.getStatus().code() >= 0).as(String.valueOf(query)).isTrue();
+      assertThat(query.getResultCode().code() >= 0).as(String.valueOf(query)).isTrue();
+      assertThat(query.getProgress() >= 0).as(String.valueOf(query)).isTrue();
       if (query.getResultCode() == ResultCode.SUCCESS) {
          if (query.getResult() != null) {
             assertEquals(query.getResult().getClass().getPackage(), AsyncJob.class.getPackage());
          }
       } else if (query.getResultCode() == ResultCode.FAIL) {
-         assert query.getResult() == null : query;
-         assert query.getError() != null : query;
+         assertThat(query.getResult() == null).as(String.valueOf(query)).isTrue();
+         assertThat(query.getError() != null).as(String.valueOf(query)).isTrue();
       } else {
-         assert query.getResult() == null : query;
+         assertThat(query.getResult() == null).as(String.valueOf(query)).isTrue();
       }
    }
 

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/ConfigurationApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/ConfigurationApiLiveTest.java
@@ -20,6 +20,8 @@ import org.jclouds.cloudstack.domain.Capabilities;
 import org.jclouds.cloudstack.internal.BaseCloudStackApiLiveTest;
 import org.testng.annotations.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Tests behavior of {@code ConfigurationApiLiveTest}
  */
@@ -28,8 +30,8 @@ public class ConfigurationApiLiveTest extends BaseCloudStackApiLiveTest {
 
    public void testListCapabilities() throws Exception {
       Capabilities response = client.getConfigurationApi().listCapabilities();
-      assert null != response;
-      assert null != response.getCloudStackVersion();
+      assertThat(null != response).isTrue();
+      assertThat(null != response.getCloudStackVersion()).isTrue();
    }
 
 }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/DomainUserApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/DomainUserApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.cloudstack.features.GlobalAccountApiLiveTest.createTestAccount;
 import static org.jclouds.cloudstack.features.GlobalUserApiLiveTest.createTestUser;
 import static org.testng.Assert.assertEquals;
@@ -43,8 +44,8 @@ public class DomainUserApiLiveTest extends BaseCloudStackApiLiveTest {
 
       Set<User> users = domainAdminClient.getUserClient().listUsers();
 
-      assert !users.isEmpty();
-      assert users.contains(user); // contains the current user
+      assertThat(!users.isEmpty()).isTrue();
+      assertThat(users.contains(user)).isTrue(); // contains the current user
 
       for (User user : users) {
          checkUser(user);
@@ -52,9 +53,9 @@ public class DomainUserApiLiveTest extends BaseCloudStackApiLiveTest {
    }
 
    private void checkUser(User user) {
-      assert user.getId() != null;
-      assert user.getAccount() != null;
-      assert user.getDomain() != null;
+      assertThat(user.getId() != null).isTrue();
+      assertThat(user.getAccount() != null).isTrue();
+      assertThat(user.getDomain() != null).isTrue();
    }
 
    @Test

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/EventApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/EventApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertTrue;
 
 import java.util.Set;
@@ -32,7 +33,7 @@ public class EventApiLiveTest extends BaseCloudStackApiLiveTest {
 
    public void testlistEventTypes() throws Exception {
       final Set<String> response = client.getEventApi().listEventTypes();
-      assert null != response;
+      assertThat(null != response).isTrue();
       assertTrue(response.size() > 0);
       for (String type : response) {
          checkEventType(type);
@@ -41,7 +42,7 @@ public class EventApiLiveTest extends BaseCloudStackApiLiveTest {
 
    public void testlistEvents() throws Exception {
       final Set<Event> response = client.getEventApi().listEvents();
-      assert null != response;
+      assertThat(null != response).isTrue();
       assertTrue(response.size() > 0);
       for (Event event : response) {
          checkEvent(event);
@@ -49,19 +50,19 @@ public class EventApiLiveTest extends BaseCloudStackApiLiveTest {
    }
 
    private void checkEvent(Event event) {
-      assert event.getAccount() != null : event;
-      assert event.getCreated() != null : event;
-      assert event.getDescription() != null : event;
-      assert event.getDomain() != null : event;
-      assert event.getId() != null : event;
-      assert event.getLevel() != null : event;
-      assert event.getState() != null : event;
-      assert event.getType() != null : event;
-      assert event.getUsername() != null : event;
+      assertThat(event.getAccount() != null).as(String.valueOf(event)).isTrue();
+      assertThat(event.getCreated() != null).as(String.valueOf(event)).isTrue();
+      assertThat(event.getDescription() != null).as(String.valueOf(event)).isTrue();
+      assertThat(event.getDomain() != null).as(String.valueOf(event)).isTrue();
+      assertThat(event.getId() != null).as(String.valueOf(event)).isTrue();
+      assertThat(event.getLevel() != null).as(String.valueOf(event)).isTrue();
+      assertThat(event.getState() != null).as(String.valueOf(event)).isTrue();
+      assertThat(event.getType() != null).as(String.valueOf(event)).isTrue();
+      assertThat(event.getUsername() != null).as(String.valueOf(event)).isTrue();
    }
 
    protected void checkEventType(String eventType) {
-      assert eventType != null : eventType;
+      assertThat(eventType != null).as(eventType).isTrue();
    }
 
 }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/FirewallApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/FirewallApiLiveTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.cloudstack.features;
 
 import static com.google.common.collect.Iterables.find;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.cloudstack.predicates.NetworkPredicates.supportsPortForwarding;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -114,7 +115,7 @@ public class FirewallApiLiveTest extends BaseCloudStackApiLiveTest {
    @Test(dependsOnMethods = "testCreatePortForwardingRule")
    public void testListPortForwardingRules() throws Exception {
       Set<PortForwardingRule> response = client.getFirewallApi().listPortForwardingRules();
-      assert null != response;
+      assertThat(null != response).isTrue();
       assertTrue(response.size() > 0);
       for (final PortForwardingRule rule : response) {
          checkPortForwardingRule(rule);
@@ -142,7 +143,7 @@ public class FirewallApiLiveTest extends BaseCloudStackApiLiveTest {
    public void testListFirewallRules() {
       Set<FirewallRule> rules = client.getFirewallApi().listFirewallRules();
 
-      assert rules != null;
+      assertThat(rules != null).isTrue();
       assertTrue(!rules.isEmpty());
 
       for (FirewallRule rule : rules) {
@@ -171,7 +172,7 @@ public class FirewallApiLiveTest extends BaseCloudStackApiLiveTest {
    public void testListEgressFirewallRules() {
       Set<FirewallRule> rules = client.getFirewallApi().listEgressFirewallRules();
 
-      assert rules != null;
+      assertThat(rules != null).isTrue();
       assertTrue(!rules.isEmpty());
 
       for (FirewallRule rule : rules) {
@@ -202,32 +203,32 @@ public class FirewallApiLiveTest extends BaseCloudStackApiLiveTest {
    protected void checkFirewallRule(FirewallRule rule) {
       assertEquals(rule,
          client.getFirewallApi().getFirewallRule(rule.getId()));
-      assert rule.getId() != null : rule;
-      assert rule.getStartPort() > 0 : rule;
-      assert rule.getEndPort() >= rule.getStartPort() : rule;
-      assert rule.getProtocol() != null;
+      assertThat(rule.getId() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getStartPort() > 0).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getEndPort() >= rule.getStartPort()).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getProtocol() != null).isTrue();
    }
 
    protected void checkEgressFirewallRule(FirewallRule rule) {
       assertEquals(rule,
               client.getFirewallApi().getEgressFirewallRule(rule.getId()));
-      assert rule.getId() != null : rule;
-      assert rule.getStartPort() > 0 : rule;
-      assert rule.getEndPort() >= rule.getStartPort() : rule;
-      assert rule.getProtocol() != null;
+      assertThat(rule.getId() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getStartPort() > 0).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getEndPort() >= rule.getStartPort()).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getProtocol() != null).isTrue();
    }
 
    protected void checkPortForwardingRule(PortForwardingRule rule) {
       assertEquals(rule,
          client.getFirewallApi().getPortForwardingRule(rule.getId()));
-      assert rule.getId() != null : rule;
-      assert rule.getIPAddress() != null : rule;
-      assert rule.getIPAddressId() != null : rule;
-      assert rule.getPrivatePort() > 0 : rule;
-      assert rule.getProtocol() != null : rule;
-      assert rule.getPublicPort() > 0 : rule;
-      assert rule.getState() != null : rule;
-      assert rule.getVirtualMachineId() != null : rule;
-      assert rule.getVirtualMachineName() != null : rule;
+      assertThat(rule.getId() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getIPAddress() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getIPAddressId() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getPrivatePort() > 0).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getProtocol() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getPublicPort() > 0).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getState() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getVirtualMachineId() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getVirtualMachineName() != null).as(String.valueOf(rule)).isTrue();
    }
 }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GlobalAlertApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GlobalAlertApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertTrue;
@@ -37,7 +38,7 @@ public class GlobalAlertApiLiveTest extends BaseCloudStackApiLiveTest {
       skipIfNotGlobalAdmin();
 
       final Set<Alert> response = globalAdminClient.getAlertClient().listAlerts();
-      assert null != response;
+      assertThat(null != response).isTrue();
       assertTrue(response.size() > 0);
       int count = 0;
       for (Alert alert : response) {

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GlobalConfigurationApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GlobalConfigurationApiLiveTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.cloudstack.features;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.cloudstack.options.ListConfigurationEntriesOptions.Builder.name;
 import static org.testng.Assert.assertEquals;
 
@@ -51,8 +52,8 @@ public class GlobalConfigurationApiLiveTest extends BaseCloudStackApiLiveTest {
          categories.add(entry.getCategory());
       }
 
-      assert categories.containsAll(ImmutableSet.<Object>of("Network", "Advanced",
-         "Storage", "Usage", "Snapshots", "Account Defaults", "Console Proxy", "Alert"));
+      assertThat(categories.containsAll(ImmutableSet.<Object>of("Network", "Advanced",
+         "Storage", "Usage", "Snapshots", "Account Defaults", "Console Proxy", "Alert"))).isTrue();
    }
 
    @Test
@@ -63,13 +64,13 @@ public class GlobalConfigurationApiLiveTest extends BaseCloudStackApiLiveTest {
          .getConfigurationApi().listConfigurationEntries();
 
       long expungeDelay = Long.parseLong(getValueByName(entries, "expunge.delay"));
-      assert expungeDelay > 0;
+      assertThat(expungeDelay > 0).isTrue();
 
       globalAdminClient.getConfigurationApi()
          .updateConfigurationEntry("expunge.delay", "" + (expungeDelay + 1));
 
       long newDelay = Long.parseLong(getOnlyElement(globalAdminClient.getConfigurationApi()
-         .listConfigurationEntries(name("expunge.delay"))).getValue());
+              .listConfigurationEntries(name("expunge.delay"))).getValue());
       assertEquals(newDelay, expungeDelay + 1);
 
       globalAdminClient.getConfigurationApi()
@@ -79,9 +80,9 @@ public class GlobalConfigurationApiLiveTest extends BaseCloudStackApiLiveTest {
    private void checkConfigurationEntry(ConfigurationEntry entry) {
       assertEquals(entry, getEntryByName(globalAdminClient.getConfigurationApi()
          .listConfigurationEntries(name(entry.getName())), entry.getName()));
-      assert entry.getCategory() != null : entry;
+      assertThat(entry.getCategory() != null).as(String.valueOf(entry)).isTrue();
       // Description apparently can be null, so ... assert entry.getDescription() != null : entry;
-      assert entry.getName() != null : entry;
+      assertThat(entry.getName() != null).as(String.valueOf(entry)).isTrue();
    }
 
    private String getValueByName(Set<ConfigurationEntry> entries, String name) {

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GlobalHostApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GlobalHostApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
@@ -41,7 +42,7 @@ public class GlobalHostApiLiveTest extends BaseCloudStackApiLiveTest {
       skipIfNotGlobalAdmin();
 
       Set<Host> hosts = globalAdminClient.getHostClient().listHosts();
-      assert !hosts.isEmpty() : hosts;
+      assertThat(!hosts.isEmpty()).as(String.valueOf(hosts)).isTrue();
 
       for (Host host : hosts) {
          checkHost(host);
@@ -50,16 +51,16 @@ public class GlobalHostApiLiveTest extends BaseCloudStackApiLiveTest {
 
    private void checkHost(Host host) {
       if (host.getType() == Host.Type.ROUTING) {
-         assert host.getCpuNumber() > 0;
-         assert host.getAverageLoad() >= 0;
-         assert host.getHypervisor() != null;
+         assertThat(host.getCpuNumber() > 0).isTrue();
+         assertThat(host.getAverageLoad() >= 0).isTrue();
+         assertThat(host.getHypervisor() != null).isTrue();
       }
-      assert host.getEvents() != null;
+      assertThat(host.getEvents() != null).isTrue();
       if (host.getType() == Host.Type.SECONDARY_STORAGE_VM) {
-         assert host.getName().startsWith("s-");
+         assertThat(host.getName().startsWith("s-")).isTrue();
       }
       if (host.getType() == Host.Type.CONSOLE_PROXY) {
-         assert host.getName().startsWith("v-");
+         assertThat(host.getName().startsWith("v-")).isTrue();
       }
    }
 
@@ -68,7 +69,7 @@ public class GlobalHostApiLiveTest extends BaseCloudStackApiLiveTest {
       skipIfNotGlobalAdmin();
 
       Set<Cluster> clusters = globalAdminClient.getHostClient().listClusters();
-      assert !clusters.isEmpty() : clusters;
+      assertThat(!clusters.isEmpty()).as(String.valueOf(clusters)).isTrue();
 
       for (Cluster cluster : clusters) {
          checkCluster(cluster);

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GlobalPodApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GlobalPodApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
@@ -51,7 +52,7 @@ public class GlobalPodApiLiveTest extends BaseCloudStackApiLiveTest {
       skipIfNotGlobalAdmin();
 
       Set<Pod> response = globalAdminClient.getPodClient().listPods();
-      assert null != response;
+      assertThat(null != response).isTrue();
       long podCount = response.size();
       assertTrue(podCount >= 0);
 

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GlobalUserApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GlobalUserApiLiveTest.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.hash.Hashing.md5;
 import static com.google.common.io.BaseEncoding.base16;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.cloudstack.features.GlobalAccountApiLiveTest.createTestAccount;
 import static org.jclouds.cloudstack.options.UpdateUserOptions.Builder.userName;
 import static org.testng.Assert.assertEquals;
@@ -89,7 +90,7 @@ public class GlobalUserApiLiveTest extends BaseCloudStackApiLiveTest {
       CloudStackApi client = context.getApi();
       Set<Account> accounts = client.getAccountApi().listAccounts();
 
-      assert !accounts.isEmpty();
+      assertThat(!accounts.isEmpty()).isTrue();
 
       context.close();
    }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GlobalVlanApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GlobalVlanApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.cloudstack.options.ListNetworksOptions.Builder.zoneId;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -58,7 +59,7 @@ public class GlobalVlanApiLiveTest extends BaseCloudStackApiLiveTest {
       skipIfNotGlobalAdmin();
 
       Set<VlanIPRange> response = globalAdminClient.getVlanClient().listVlanIPRanges();
-      assert null != response;
+      assertThat(null != response).isTrue();
       long rangeCount = response.size();
       assertTrue(rangeCount >= 0);
 

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GuestOSApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GuestOSApiLiveTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.cloudstack.features;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -37,7 +38,7 @@ public class GuestOSApiLiveTest extends BaseCloudStackApiLiveTest {
 
    public void testListOSTypes() throws Exception {
       Set<OSType> response = client.getGuestOSApi().listOSTypes();
-      assert null != response;
+      assertThat(null != response).isTrue();
       assertTrue(response.size() > 0);
       for (OSType type : response) {
          OSType newDetails = getOnlyElement(client.getGuestOSApi().listOSTypes(
@@ -49,7 +50,7 @@ public class GuestOSApiLiveTest extends BaseCloudStackApiLiveTest {
 
    public void testListOSCategories() throws Exception {
       Map<String, String> response = client.getGuestOSApi().listOSCategories();
-      assert null != response;
+      assertThat(null != response).isTrue();
       assertTrue(response.size() > 0);
       for (Entry<String, String> category : response.entrySet()) {
          checkOSCategory(category);
@@ -58,15 +59,15 @@ public class GuestOSApiLiveTest extends BaseCloudStackApiLiveTest {
 
    protected void checkOSCategory(Entry<String, String> category) {
       assertEquals(category, client.getGuestOSApi().getOSCategory(category.getKey()));
-      assert category.getKey() != null : category;
-      assert category.getValue() != null : category;
+      assertThat(category.getKey() != null).as(String.valueOf(category)).isTrue();
+      assertThat(category.getValue() != null).as(String.valueOf(category)).isTrue();
    }
 
    protected void checkOSType(OSType type) {
       assertEquals(type.getId(), client.getGuestOSApi().getOSType(type.getId()).getId());
-      assert type.getId() != null : type;
-      assert type.getOSCategoryId() != null : type;
-      assert type.getDescription() != null : type;
+      assertThat(type.getId() != null).as(String.valueOf(type)).isTrue();
+      assertThat(type.getOSCategoryId() != null).as(String.valueOf(type)).isTrue();
+      assertThat(type.getDescription() != null).as(String.valueOf(type)).isTrue();
 
    }
 

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/HypervisorApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/HypervisorApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertTrue;
 
 import java.util.Set;
@@ -32,11 +33,11 @@ public class HypervisorApiLiveTest extends BaseCloudStackApiLiveTest {
 
    public void testListHypervisors() throws Exception {
       Set<String> response = client.getHypervisorApi().listHypervisors();
-      assert null != response;
+      assertThat(null != response).isTrue();
       assertTrue(response.size() > 0);
       for (Zone zone : client.getZoneApi().listZones()) {
          Set<String> zoneHype = client.getHypervisorApi().listHypervisorsInZone(zone.getId());
-         assert response.containsAll(zoneHype);
+         assertThat(response.containsAll(zoneHype)).isTrue();
       }
    }
 

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/LimitApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/LimitApiLiveTest.java
@@ -22,6 +22,8 @@ import org.jclouds.cloudstack.domain.ResourceLimit;
 import org.jclouds.cloudstack.internal.BaseCloudStackApiLiveTest;
 import org.testng.annotations.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Tests behavior of {@code LimitApi}
  */
@@ -37,8 +39,8 @@ public class LimitApiLiveTest extends BaseCloudStackApiLiveTest {
    }
 
    private void checkResourceLimit(ResourceLimit resourceLimit) {
-      assert resourceLimit.getAccount() != null : resourceLimit;
-      assert resourceLimit.getDomain() != null : resourceLimit;
-      assert resourceLimit.getResourceType() != ResourceLimit.ResourceType.UNRECOGNIZED : resourceLimit;
+      assertThat(resourceLimit.getAccount() != null).as(String.valueOf(resourceLimit)).isTrue();
+      assertThat(resourceLimit.getDomain() != null).as(String.valueOf(resourceLimit)).isTrue();
+      assertThat(resourceLimit.getResourceType() != ResourceLimit.ResourceType.UNRECOGNIZED).as(String.valueOf(resourceLimit)).isTrue();
    }
 }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/LoadBalancerApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/LoadBalancerApiLiveTest.java
@@ -18,6 +18,7 @@ package org.jclouds.cloudstack.features;
 
 import static com.google.common.collect.Iterables.find;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.cloudstack.predicates.NetworkPredicates.hasLoadBalancerService;
 import static org.jclouds.cloudstack.predicates.NetworkPredicates.isVirtualNetwork;
 import static org.jclouds.util.Predicates2.retry;
@@ -190,7 +191,7 @@ public class LoadBalancerApiLiveTest extends BaseCloudStackApiLiveTest {
 
    public void testListLoadBalancerRules() throws Exception {
       Set<LoadBalancerRule> response = client.getLoadBalancerApi().listLoadBalancerRules();
-      assert null != response;
+      assertThat(null != response).isTrue();
       assertTrue(response.size() > 0);
       for (LoadBalancerRule rule : response) {
          LoadBalancerRule newDetails = findRuleWithId(rule.getId());
@@ -212,16 +213,16 @@ public class LoadBalancerApiLiveTest extends BaseCloudStackApiLiveTest {
 
    protected void checkRule(LoadBalancerRule rule) {
       assertEquals(rule.getId(), findRuleWithId(rule.getId()).getId());
-      assert rule.getId() != null : rule;
-      assert rule.getAccount() != null : rule;
-      assert rule.getAlgorithm() != null : rule;
-      assert rule.getPrivatePort() > 0 : rule;
-      assert rule.getPublicPort() > 0 : rule;
-      assert rule.getDomain() != null : rule;
-      assert rule.getDomainId() != null : rule;
-      assert rule.getState() != null : rule;
-      assert rule.getName() != null : rule;
-      assert rule.getPublicIP() != null : rule;
-      assert rule.getPublicIPId() != null : rule;
+      assertThat(rule.getId() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getAccount() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getAlgorithm() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getPrivatePort() > 0).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getPublicPort() > 0).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getDomain() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getDomainId() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getState() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getName() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getPublicIP() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getPublicIPId() != null).as(String.valueOf(rule)).isTrue();
    }
 }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/NATApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/NATApiLiveTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.cloudstack.features;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -37,7 +38,7 @@ public class NATApiLiveTest extends BaseCloudStackApiLiveTest {
    // takes too long
    public void testListIPForwardingRules() throws Exception {
       Set<IPForwardingRule> response = client.getNATApi().listIPForwardingRules();
-      assert null != response;
+      assertThat(null != response).isTrue();
       assertTrue(response.size() > 0);
       for (IPForwardingRule rule : response) {
          IPForwardingRule newDetails = getOnlyElement(client.getNATApi().listIPForwardingRules(
@@ -49,15 +50,15 @@ public class NATApiLiveTest extends BaseCloudStackApiLiveTest {
 
    protected void checkRule(IPForwardingRule rule) {
       assertEquals(rule.getId(), client.getNATApi().getIPForwardingRule(rule.getId()).getId());
-      assert rule.getId() != null : rule;
-      assert rule.getIPAddress() != null : rule;
-      assert rule.getIPAddressId() != null : rule;
-      assert rule.getStartPort() > 0 : rule;
-      assert rule.getProtocol() != null : rule;
-      assert rule.getEndPort() > 0 : rule;
-      assert rule.getState() != null : rule;
-      assert rule.getVirtualMachineId() != null : rule;
-      assert rule.getVirtualMachineName() != null : rule;
+      assertThat(rule.getId() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getIPAddress() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getIPAddressId() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getStartPort() > 0).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getProtocol() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getEndPort() > 0).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getState() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getVirtualMachineId() != null).as(String.valueOf(rule)).isTrue();
+      assertThat(rule.getVirtualMachineName() != null).as(String.valueOf(rule)).isTrue();
 
    }
 }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/NetworkApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/NetworkApiLiveTest.java
@@ -19,6 +19,7 @@ package org.jclouds.cloudstack.features;
 import static com.google.common.collect.Iterables.find;
 import static com.google.common.collect.Iterables.get;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.cloudstack.options.CreateNetworkOptions.Builder.vlan;
 import static org.jclouds.cloudstack.options.ListNetworkOfferingsOptions.Builder.specifyVLAN;
 import static org.jclouds.cloudstack.options.ListNetworksOptions.Builder.accountInDomain;
@@ -133,7 +134,7 @@ public class NetworkApiLiveTest extends BaseCloudStackApiLiveTest {
          return;
       Set<Network> response = client.getNetworkApi().listNetworks(
             accountInDomain(user.getAccount(), user.getDomainId()));
-      assert null != response;
+      assertThat(null != response).isTrue();
       long networkCount = response.size();
       assertTrue(networkCount >= 0);
       for (Network network : response) {
@@ -145,40 +146,40 @@ public class NetworkApiLiveTest extends BaseCloudStackApiLiveTest {
    }
 
    private void checkNetwork(Network network) {
-      assert network.getId() != null : network;
-      assert network.getName() != null : network;
-      assert network.getDNS().size() != 0 : network;
-      assert network.getGuestIPType() != null && network.getGuestIPType() != GuestIPType.UNRECOGNIZED : network;
-      assert network.getBroadcastDomainType() != null : network;
-      assert network.getDisplayText() != null : network;
+      assertThat(network.getId() != null).as(String.valueOf(network)).isTrue();
+      assertThat(network.getName() != null).as(String.valueOf(network)).isTrue();
+      assertThat(network.getDNS().size() != 0).as(String.valueOf(network)).isTrue();
+      assertThat(network.getGuestIPType() != null && network.getGuestIPType() != GuestIPType.UNRECOGNIZED).as(String.valueOf(network)).isTrue();
+      assertThat(network.getBroadcastDomainType() != null).as(String.valueOf(network)).isTrue();
+      assertThat(network.getDisplayText() != null).as(String.valueOf(network)).isTrue();
       // Network domain can be null sometimes
       // assert network.getNetworkDomain() != null : network;
-      assert network.getNetworkOfferingAvailability() != null : network;
-      assert network.getNetworkOfferingDisplayText() != null : network;
-      assert network.getNetworkOfferingId() != null : network;
-      assert network.getNetworkOfferingName() != null : network;
-      assert network.getRelated() != null : network;
-      assert network.getServices().size() != 0 : network;
-      assert network.getState() != null : network;
-      assert network.getTrafficType() != null : network;
-      assert network.getZoneId() != null : network;
-      assert network.getDomain() != null : network;
+      assertThat(network.getNetworkOfferingAvailability() != null).as(String.valueOf(network)).isTrue();
+      assertThat(network.getNetworkOfferingDisplayText() != null).as(String.valueOf(network)).isTrue();
+      assertThat(network.getNetworkOfferingId() != null).as(String.valueOf(network)).isTrue();
+      assertThat(network.getNetworkOfferingName() != null).as(String.valueOf(network)).isTrue();
+      assertThat(network.getRelated() != null).as(String.valueOf(network)).isTrue();
+      assertThat(network.getServices().size() != 0).as(String.valueOf(network)).isTrue();
+      assertThat(network.getState() != null).as(String.valueOf(network)).isTrue();
+      assertThat(network.getTrafficType() != null).as(String.valueOf(network)).isTrue();
+      assertThat(network.getZoneId() != null).as(String.valueOf(network)).isTrue();
+      assertThat(network.getDomain() != null).as(String.valueOf(network)).isTrue();
       switch (network.getGuestIPType()) {
       case VIRTUAL:
-         assert network.getNetmask() == null : network;
-         assert network.getGateway() == null : network;
-         assert network.getVLAN() == null : network;
-         assert network.getStartIP() == null : network;
-         assert network.getEndIP() == null : network;
+         assertThat(network.getNetmask() == null).as(String.valueOf(network)).isTrue();
+         assertThat(network.getGateway() == null).as(String.valueOf(network)).isTrue();
+         assertThat(network.getVLAN() == null).as(String.valueOf(network)).isTrue();
+         assertThat(network.getStartIP() == null).as(String.valueOf(network)).isTrue();
+         assertThat(network.getEndIP() == null).as(String.valueOf(network)).isTrue();
          break;
       case DIRECT:
          // TODO: I've found a network that doesn't have a netmask associated
-         assert network.getNetmask() != null : network;
-         assert network.getGateway() != null : network;
-         assert network.getVLAN() != null : network;
+         assertThat(network.getNetmask() != null).as(String.valueOf(network)).isTrue();
+         assertThat(network.getGateway() != null).as(String.valueOf(network)).isTrue();
+         assertThat(network.getVLAN() != null).as(String.valueOf(network)).isTrue();
          assertEquals(network.getBroadcastURI(), URI.create("vlan://" + network.getVLAN()));
-         assert network.getStartIP() != null : network;
-         assert network.getEndIP() != null : network;
+         assertThat(network.getStartIP() != null).as(String.valueOf(network)).isTrue();
+         assertThat(network.getEndIP() != null).as(String.valueOf(network)).isTrue();
          break;
       }
    }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/OfferingApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/OfferingApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -45,7 +46,7 @@ public class OfferingApiLiveTest extends BaseCloudStackApiLiveTest {
 
    public void testListDiskOfferings() throws Exception {
       Set<DiskOffering> response = client.getOfferingApi().listDiskOfferings();
-      assert null != response;
+      assertThat(null != response).isTrue();
       long offeringCount = response.size();
       assertTrue(offeringCount >= 0);
       for (DiskOffering offering : response) {
@@ -54,12 +55,12 @@ public class OfferingApiLiveTest extends BaseCloudStackApiLiveTest {
                ListDiskOfferingsOptions.Builder.id(offering.getId())));
            assertEquals(offering, newDetails);
            assertEquals(offering, client.getOfferingApi().getDiskOffering(offering.getId()));
-           assert offering.getId() != null : offering;
-           assert offering.getName() != null : offering;
-           assert offering.getCreated() != null : offering;
-           assert offering.getDisplayText() != null : offering;
-           assert offering.getDiskSize() > 0 || (offering.getDiskSize() == 0 && offering.isCustomized()) : offering;
-           assert offering.getTags() != null : offering;
+           assertThat(offering.getId() != null).as(String.valueOf(offering)).isTrue();
+           assertThat(offering.getName() != null).as(String.valueOf(offering)).isTrue();
+           assertThat(offering.getCreated() != null).as(String.valueOf(offering)).isTrue();
+           assertThat(offering.getDisplayText() != null).as(String.valueOf(offering)).isTrue();
+           assertThat(offering.getDiskSize() > 0 || (offering.getDiskSize() == 0 && offering.isCustomized())).as(String.valueOf(offering)).isTrue();
+           assertThat(offering.getTags() != null).as(String.valueOf(offering)).isTrue();
 
          } catch (NoSuchElementException e) {
             // This bug is present both in 2.2.8 and 2.2.12
@@ -70,7 +71,7 @@ public class OfferingApiLiveTest extends BaseCloudStackApiLiveTest {
 
    public void testListServiceOfferings() throws Exception {
       Set<ServiceOffering> response = client.getOfferingApi().listServiceOfferings();
-      assert null != response;
+      assertThat(null != response).isTrue();
       long offeringCount = response.size();
       assertTrue(offeringCount >= 0);
       for (ServiceOffering offering : response) {
@@ -78,20 +79,20 @@ public class OfferingApiLiveTest extends BaseCloudStackApiLiveTest {
                ListServiceOfferingsOptions.Builder.id(offering.getId())));
          assertEquals(offering, newDetails);
 
-         assert offering.getId() != null : offering;
-         assert offering.getName() != null : offering;
-         assert offering.getDisplayText() != null : offering;
-         assert offering.getCpuNumber() > 0 : offering;
-         assert offering.getCpuSpeed() > 0 : offering;
-         assert offering.getMemory() > 0 : offering;
-         assert offering.getStorageType() != null && StorageType.UNRECOGNIZED != offering.getStorageType() : offering;
-         assert offering.getTags() != null : offering;
+         assertThat(offering.getId() != null).as(String.valueOf(offering)).isTrue();
+         assertThat(offering.getName() != null).as(String.valueOf(offering)).isTrue();
+         assertThat(offering.getDisplayText() != null).as(String.valueOf(offering)).isTrue();
+         assertThat(offering.getCpuNumber() > 0).as(String.valueOf(offering)).isTrue();
+         assertThat(offering.getCpuSpeed() > 0).as(String.valueOf(offering)).isTrue();
+         assertThat(offering.getMemory() > 0).as(String.valueOf(offering)).isTrue();
+         assertThat(offering.getStorageType() != null && StorageType.UNRECOGNIZED != offering.getStorageType()).as(String.valueOf(offering)).isTrue();
+         assertThat(offering.getTags() != null).as(String.valueOf(offering)).isTrue();
       }
    }
 
    public void testListNetworkOfferings() throws Exception {
       Set<NetworkOffering> response = client.getOfferingApi().listNetworkOfferings();
-      assert null != response;
+      assertThat(null != response).isTrue();
       long offeringCount = response.size();
       assertTrue(offeringCount >= 0);
       for (NetworkOffering offering : response) {
@@ -99,12 +100,12 @@ public class OfferingApiLiveTest extends BaseCloudStackApiLiveTest {
                ListNetworkOfferingsOptions.Builder.id(offering.getId())));
          assertEquals(offering, newDetails);
          assertEquals(offering, client.getOfferingApi().getNetworkOffering(offering.getId()));
-         assert offering.getId() != null : offering;
-         assert offering.getName() != null : offering;
-         assert offering.getDisplayText() != null : offering;
-         assert offering.getMaxConnections() == null || offering.getMaxConnections() > 0 : offering;
-         assert offering.getTrafficType() != null && TrafficType.UNRECOGNIZED != offering.getTrafficType() : offering;
-         assert offering.getTags() != null : offering;
+         assertThat(offering.getId() != null).as(String.valueOf(offering)).isTrue();
+         assertThat(offering.getName() != null).as(String.valueOf(offering)).isTrue();
+         assertThat(offering.getDisplayText() != null).as(String.valueOf(offering)).isTrue();
+         assertThat(offering.getMaxConnections() == null || offering.getMaxConnections() > 0).as(String.valueOf(offering)).isTrue();
+         assertThat(offering.getTrafficType() != null && TrafficType.UNRECOGNIZED != offering.getTrafficType()).as(String.valueOf(offering)).isTrue();
+         assertThat(offering.getTags() != null).as(String.valueOf(offering)).isTrue();
       }
    }
 }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/SSHKeyPairApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/SSHKeyPairApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
@@ -84,7 +85,7 @@ public class SSHKeyPairApiLiveTest extends BaseCloudStackApiLiveTest {
    }
 
    protected void checkSSHKeyPair(SshKeyPair pair) {
-      assert pair.getName() != null : pair;
+      assertThat(pair.getName() != null).as(String.valueOf(pair)).isTrue();
       assertEquals(pair.getFingerprint(),
          client.getSSHKeyPairApi().getSSHKeyPair(pair.getName()).getFingerprint());
    }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/SecurityGroupApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/SecurityGroupApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -134,15 +135,15 @@ public class SecurityGroupApiLiveTest extends BaseCloudStackApiLiveTest {
 
       });
 
-      assert ICMPPingRule.getId() != null : ICMPPingRule;
-      assert "icmp".equals(ICMPPingRule.getProtocol()) : ICMPPingRule;
-      assert ICMPPingRule.getStartPort() == -1 : ICMPPingRule;
-      assert ICMPPingRule.getEndPort() == -1 : ICMPPingRule;
-      assert ICMPPingRule.getICMPCode() == 0 : ICMPPingRule;
-      assert ICMPPingRule.getICMPType() == 8 : ICMPPingRule;
-      assert ICMPPingRule.getAccount() == null : ICMPPingRule;
-      assert ICMPPingRule.getSecurityGroupName() == null : ICMPPingRule;
-      assert cidr.equals(ICMPPingRule.getCIDR()) : ICMPPingRule;
+      assertThat(ICMPPingRule.getId() != null).as(String.valueOf(ICMPPingRule)).isTrue();
+      assertThat("icmp".equals(ICMPPingRule.getProtocol())).as(String.valueOf(ICMPPingRule)).isTrue();
+      assertThat(ICMPPingRule.getStartPort() == -1).as(String.valueOf(ICMPPingRule)).isTrue();
+      assertThat(ICMPPingRule.getEndPort() == -1).as(String.valueOf(ICMPPingRule)).isTrue();
+      assertThat(ICMPPingRule.getICMPCode() == 0).as(String.valueOf(ICMPPingRule)).isTrue();
+      assertThat(ICMPPingRule.getICMPType() == 8).as(String.valueOf(ICMPPingRule)).isTrue();
+      assertThat(ICMPPingRule.getAccount() == null).as(String.valueOf(ICMPPingRule)).isTrue();
+      assertThat(ICMPPingRule.getSecurityGroupName() == null).as(String.valueOf(ICMPPingRule)).isTrue();
+      assertThat(cidr.equals(ICMPPingRule.getCIDR())).as(String.valueOf(ICMPPingRule)).isTrue();
 
       IngressRule SSHRule = Iterables.find(group.getIngressRules(), new Predicate<IngressRule>() {
 
@@ -153,15 +154,15 @@ public class SecurityGroupApiLiveTest extends BaseCloudStackApiLiveTest {
 
       });
 
-      assert SSHRule.getId() != null : SSHRule;
-      assert "tcp".equals(SSHRule.getProtocol()) : SSHRule;
-      assert SSHRule.getStartPort() == 22 : SSHRule;
-      assert SSHRule.getEndPort() == 22 : SSHRule;
-      assert SSHRule.getICMPCode() == -1 : SSHRule;
-      assert SSHRule.getICMPType() == -1 : SSHRule;
-      assert SSHRule.getAccount() == null : SSHRule;
-      assert SSHRule.getSecurityGroupName() == null : SSHRule;
-      assert cidr.equals(SSHRule.getCIDR()) : SSHRule;
+      assertThat(SSHRule.getId() != null).as(String.valueOf(SSHRule)).isTrue();
+      assertThat("tcp".equals(SSHRule.getProtocol())).as(String.valueOf(SSHRule)).isTrue();
+      assertThat(SSHRule.getStartPort() == 22).as(String.valueOf(SSHRule)).isTrue();
+      assertThat(SSHRule.getEndPort() == 22).as(String.valueOf(SSHRule)).isTrue();
+      assertThat(SSHRule.getICMPCode() == -1).as(String.valueOf(SSHRule)).isTrue();
+      assertThat(SSHRule.getICMPType() == -1).as(String.valueOf(SSHRule)).isTrue();
+      assertThat(SSHRule.getAccount() == null).as(String.valueOf(SSHRule)).isTrue();
+      assertThat(SSHRule.getSecurityGroupName() == null).as(String.valueOf(SSHRule)).isTrue();
+      assertThat(cidr.equals(SSHRule.getCIDR())).as(String.valueOf(SSHRule)).isTrue();
 
    }
 
@@ -193,12 +194,12 @@ public class SecurityGroupApiLiveTest extends BaseCloudStackApiLiveTest {
          assertEquals(group, client.getSecurityGroupApi().getSecurityGroup(group.getId()));
          assertEquals(group, client.getSecurityGroupApi().getSecurityGroupByName(group.getName()));
       }
-      assert group.getId() != null : group;
-      assert group.getName() != null : group;
-      assert group.getAccount() != null : group;
-      assert group.getDomain() != null : group;
-      assert group.getDomainId() != null : group;
-      assert group.getIngressRules() != null : group;
+      assertThat(group.getId() != null).as(String.valueOf(group)).isTrue();
+      assertThat(group.getName() != null).as(String.valueOf(group)).isTrue();
+      assertThat(group.getAccount() != null).as(String.valueOf(group)).isTrue();
+      assertThat(group.getDomain() != null).as(String.valueOf(group)).isTrue();
+      assertThat(group.getDomainId() != null).as(String.valueOf(group)).isTrue();
+      assertThat(group.getIngressRules() != null).as(String.valueOf(group)).isTrue();
    }
 
    @Test

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/TemplateApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/TemplateApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.cloudstack.options.ListTemplatesOptions.Builder.zoneId;
 import static org.jclouds.util.Predicates2.retry;
 import static org.testng.Assert.assertEquals;
@@ -64,7 +65,7 @@ public class TemplateApiLiveTest extends BaseCloudStackApiLiveTest {
    @Test
    public void testListTemplates() throws Exception {
       Set<Template> response = client.getTemplateApi().listTemplates();
-      assert null != response;
+      assertThat(null != response).isTrue();
       long templateCount = response.size();
       assertTrue(templateCount >= 0);
       for (Template template : response) {
@@ -74,23 +75,23 @@ public class TemplateApiLiveTest extends BaseCloudStackApiLiveTest {
 
          assertEquals(template, newDetails);
          assertEquals(template, client.getTemplateApi().getTemplateInZone(template.getId(), template.getZoneId()));
-         assert template.getId() != null : template;
-         assert template.getName() != null : template;
-         assert template.getDisplayText() != null : template;
-         assert template.getCreated() != null : template;
-         assert template.getFormat() != null && template.getFormat() != Template.Format.UNRECOGNIZED : template;
-         assert template.getOSType() != null : template;
-         assert template.getOSTypeId() != null : template;
-         assert template.getAccount() != null : template;
-         assert template.getZone() != null : template;
-         assert template.getZoneId() != null : template;
-         assert template.getStatus() == null ||
-            template.getStatus() == Template.Status.DOWNLOADED : template;
-         assert template.getType() != null && template.getType() != Template.Type.UNRECOGNIZED : template;
-         assert template.getHypervisor() != null : template;
-         assert template.getDomain() != null : template;
-         assert template.getDomainId() != null : template;
-         assert template.getSize() > 0 : template;
+         assertThat(template.getId() != null).as(String.valueOf(template)).isTrue();
+         assertThat(template.getName() != null).as(String.valueOf(template)).isTrue();
+         assertThat(template.getDisplayText() != null).as(String.valueOf(template)).isTrue();
+         assertThat(template.getCreated() != null).as(String.valueOf(template)).isTrue();
+         assertThat(template.getFormat() != null && template.getFormat() != Template.Format.UNRECOGNIZED).as(String.valueOf(template)).isTrue();
+         assertThat(template.getOSType() != null).as(String.valueOf(template)).isTrue();
+         assertThat(template.getOSTypeId() != null).as(String.valueOf(template)).isTrue();
+         assertThat(template.getAccount() != null).as(String.valueOf(template)).isTrue();
+         assertThat(template.getZone() != null).as(String.valueOf(template)).isTrue();
+         assertThat(template.getZoneId() != null).as(String.valueOf(template)).isTrue();
+         assertThat(template.getStatus() == null ||
+            template.getStatus() == Template.Status.DOWNLOADED).as(String.valueOf(template)).isTrue();
+         assertThat(template.getType() != null && template.getType() != Template.Type.UNRECOGNIZED).as(String.valueOf(template)).isTrue();
+         assertThat(template.getHypervisor() != null).as(String.valueOf(template)).isTrue();
+         assertThat(template.getDomain() != null).as(String.valueOf(template)).isTrue();
+         assertThat(template.getDomainId() != null).as(String.valueOf(template)).isTrue();
+         assertThat(template.getSize() > 0).as(String.valueOf(template)).isTrue();
       }
    }
 
@@ -201,7 +202,7 @@ public class TemplateApiLiveTest extends BaseCloudStackApiLiveTest {
       if (vmForRegistration != null) {
          assertTrue(jobComplete.apply(client.getVirtualMachineApi().stopVirtualMachine(vmForRegistration.getId())), vmForRegistration.toString());
          assertTrue(jobComplete.apply(client.getVirtualMachineApi().destroyVirtualMachine(vmForRegistration.getId())), vmForRegistration.toString());
-         assert virtualMachineDestroyed.apply(vmForRegistration);
+         assertThat(virtualMachineDestroyed.apply(vmForRegistration)).isTrue();
       }
       if (createdTemplate != null) {
          AsyncCreateResponse deleteJob = client.getTemplateApi().deleteTemplate(createdTemplate.getId());

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/VirtualMachineApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/VirtualMachineApiLiveTest.java
@@ -23,6 +23,7 @@ import static com.google.common.collect.Iterables.get;
 import static com.google.common.collect.Iterables.getFirst;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Sets.filter;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.cloudstack.options.ListNetworksOptions.Builder.isDefault;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -164,7 +165,7 @@ public class VirtualMachineApiLiveTest extends BaseCloudStackApiLiveTest {
          });
       VirtualMachine vm = jobWithResult.getResult();
       if (vm.isPasswordEnabled()) {
-         assert vm.getPassword() != null : vm;
+         assertThat(vm.getPassword() != null).as(String.valueOf(vm)).isTrue();
       }
       assertTrue(virtualMachineRunning.apply(vm));
       assertEquals(vm.getServiceOfferingId(), serviceOfferingId);
@@ -180,8 +181,8 @@ public class VirtualMachineApiLiveTest extends BaseCloudStackApiLiveTest {
       if (vm.getPassword() != null) {
          conditionallyCheckSSH();
       }
-      assert in(ImmutableSet.of("ROOT", "NetworkFilesystem", "IscsiLUN", "VMFS", "PreSetup"))
-         .apply(vm.getRootDeviceType()) : vm;
+      assertThat(in(ImmutableSet.of("ROOT", "NetworkFilesystem", "IscsiLUN", "VMFS", "PreSetup"))
+         .apply(vm.getRootDeviceType())).as(String.valueOf(vm)).isTrue();
       checkVm(vm);
    }
 
@@ -257,7 +258,7 @@ public class VirtualMachineApiLiveTest extends BaseCloudStackApiLiveTest {
                assertEquals(nic.getIPAddress(), ipAddress);
             }
          }
-         assert hasStaticIpNic;
+         assertThat(hasStaticIpNic).isTrue();
          checkVm(vm);
 
       } finally {
@@ -282,7 +283,7 @@ public class VirtualMachineApiLiveTest extends BaseCloudStackApiLiveTest {
    private void conditionallyCheckSSH() {
       if (vm.getPassword() != null && !loginCredentials.getOptionalPassword().isPresent())
          loginCredentials = loginCredentials.toBuilder().password(vm.getPassword()).build();
-      assert HostSpecifier.isValid(vm.getIPAddress());
+      assertThat(HostSpecifier.isValid(vm.getIPAddress())).isTrue();
       if (!InetAddresses2.isPrivateIPAddress(vm.getIPAddress())) {
          // not sure if the network is public or not, so we have to test
          HostAndPort socket = HostAndPort.fromParts(vm.getIPAddress(), 22);
@@ -334,7 +335,7 @@ public class VirtualMachineApiLiveTest extends BaseCloudStackApiLiveTest {
    @Test
    public void testListVirtualMachines() throws Exception {
       Set<VirtualMachine> response = client.getVirtualMachineApi().listVirtualMachines();
-      assert null != response;
+      assertThat(null != response).isTrue();
       assertTrue(response.size() > 0);
       for (VirtualMachine vm : response) {
          VirtualMachine newDetails = getOnlyElement(client.getVirtualMachineApi().listVirtualMachines(
@@ -346,53 +347,53 @@ public class VirtualMachineApiLiveTest extends BaseCloudStackApiLiveTest {
 
    protected void checkVm(VirtualMachine vm) {
       assertEquals(vm.getId(), client.getVirtualMachineApi().getVirtualMachine(vm.getId()).getId());
-      assert vm.getId() != null : vm;
-      assert vm.getName() != null : vm;
+      assertThat(vm.getId() != null).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getName() != null).as(String.valueOf(vm)).isTrue();
       // vm.getDisplayName() can be null, so skip that check.
-      assert vm.getAccount() != null : vm;
-      assert vm.getDomain() != null : vm;
-      assert vm.getDomainId() != null : vm;
-      assert vm.getCreated() != null : vm;
-      assert vm.getState() != null : vm;
-      assert vm.getZoneId() != null : vm;
-      assert vm.getZoneName() != null : vm;
-      assert vm.getTemplateId() != null : vm;
-      assert vm.getTemplateName() != null : vm;
-      assert vm.getServiceOfferingId() != null : vm;
-      assert vm.getServiceOfferingName() != null : vm;
-      assert vm.getCpuCount() > 0 : vm;
-      assert vm.getCpuSpeed() > 0 : vm;
-      assert vm.getMemory() > 0 : vm;
-      assert vm.getGuestOSId() != null : vm;
-      assert vm.getRootDeviceId() != null : vm;
+      assertThat(vm.getAccount() != null).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getDomain() != null).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getDomainId() != null).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getCreated() != null).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getState() != null).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getZoneId() != null).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getZoneName() != null).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getTemplateId() != null).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getTemplateName() != null).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getServiceOfferingId() != null).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getServiceOfferingName() != null).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getCpuCount() > 0).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getCpuSpeed() > 0).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getMemory() > 0).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getGuestOSId() != null).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getRootDeviceId() != null).as(String.valueOf(vm)).isTrue();
       // assert vm.getRootDeviceType() != null : vm;
       if (vm.getJobId() != null)
-         assert vm.getJobStatus() != null : vm;
-      assert vm.getNICs() != null && !vm.getNICs().isEmpty() : vm;
+         assertThat(vm.getJobStatus() != null).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getNICs() != null && !vm.getNICs().isEmpty()).as(String.valueOf(vm)).isTrue();
       for (NIC nic : vm.getNICs()) {
-         assert nic.getId() != null : vm;
-         assert nic.getNetworkId() != null : vm;
-         assert nic.getTrafficType() != null : vm;
-         assert nic.getGuestIPType() != null : vm;
+         assertThat(nic.getId() != null).as(String.valueOf(vm)).isTrue();
+         assertThat(nic.getNetworkId() != null).as(String.valueOf(vm)).isTrue();
+         assertThat(nic.getTrafficType() != null).as(String.valueOf(vm)).isTrue();
+         assertThat(nic.getGuestIPType() != null).as(String.valueOf(vm)).isTrue();
          switch (vm.getState()) {
          case RUNNING:
-            assert nic.getNetmask() != null : vm;
-            assert nic.getGateway() != null : vm;
-            assert nic.getIPAddress() != null : vm;
+            assertThat(nic.getNetmask() != null).as(String.valueOf(vm)).isTrue();
+            assertThat(nic.getGateway() != null).as(String.valueOf(vm)).isTrue();
+            assertThat(nic.getIPAddress() != null).as(String.valueOf(vm)).isTrue();
             break;
          case STARTING:
-            assert nic.getNetmask() == null : vm;
-            assert nic.getGateway() == null : vm;
-            assert nic.getIPAddress() == null : vm;
+            assertThat(nic.getNetmask() == null).as(String.valueOf(vm)).isTrue();
+            assertThat(nic.getGateway() == null).as(String.valueOf(vm)).isTrue();
+            assertThat(nic.getIPAddress() == null).as(String.valueOf(vm)).isTrue();
             break;
          default:
-            assert nic.getNetmask() != null : vm;
-            assert nic.getGateway() != null : vm;
-            assert nic.getIPAddress() != null : vm;
+            assertThat(nic.getNetmask() != null).as(String.valueOf(vm)).isTrue();
+            assertThat(nic.getGateway() != null).as(String.valueOf(vm)).isTrue();
+            assertThat(nic.getIPAddress() != null).as(String.valueOf(vm)).isTrue();
          }
 
       }
-      assert vm.getSecurityGroups() != null && vm.getSecurityGroups().size() > 0 : vm;
-      assert vm.getHypervisor() != null : vm;
+      assertThat(vm.getSecurityGroups() != null && vm.getSecurityGroups().size() > 0).as(String.valueOf(vm)).isTrue();
+      assertThat(vm.getHypervisor() != null).as(String.valueOf(vm)).isTrue();
    }
 }

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/ZoneApiLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/ZoneApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -37,7 +38,7 @@ public class ZoneApiLiveTest extends BaseCloudStackApiLiveTest {
 
    public void testListZones() throws Exception {
       Set<Zone> response = client.getZoneApi().listZones();
-      assert null != response;
+      assertThat(null != response).isTrue();
       long zoneCount = response.size();
       assertTrue(zoneCount >= 0);
       for (Zone zone : response) {
@@ -45,9 +46,9 @@ public class ZoneApiLiveTest extends BaseCloudStackApiLiveTest {
                ListZonesOptions.Builder.id(zone.getId())));
          assertEquals(zone, newDetails);
          assertEquals(zone, client.getZoneApi().getZone(zone.getId()));
-         assert zone.getId() != null : zone;
-         assert zone.getName() != null : zone;
-         assert zone.getNetworkType() != null && zone.getNetworkType() != NetworkType.UNRECOGNIZED : zone;
+         assertThat(zone.getId() != null).as(String.valueOf(zone)).isTrue();
+         assertThat(zone.getName() != null).as(String.valueOf(zone)).isTrue();
+         assertThat(zone.getNetworkType() != null && zone.getNetworkType() != NetworkType.UNRECOGNIZED).as(String.valueOf(zone)).isTrue();
          switch (zone.getNetworkType()) {
          case ADVANCED:
             // TODO
@@ -57,12 +58,12 @@ public class ZoneApiLiveTest extends BaseCloudStackApiLiveTest {
             // assert zone.getGuestCIDRAddress() != null : zone;
             break;
          case BASIC:
-            assert zone.getVLAN() == null : zone;
-            assert zone.getDNS().size() > 0 : zone;
-            assert zone.getInternalDNS().size() > 0 : zone;
-            assert zone.getDomain() == null : zone;
-            assert zone.getDomainId() == null : zone;
-            assert zone.getGuestCIDRAddress() == null : zone;
+            assertThat(zone.getVLAN() == null).as(String.valueOf(zone)).isTrue();
+            assertThat(zone.getDNS().size() > 0).as(String.valueOf(zone)).isTrue();
+            assertThat(zone.getInternalDNS().size() > 0).as(String.valueOf(zone)).isTrue();
+            assertThat(zone.getDomain() == null).as(String.valueOf(zone)).isTrue();
+            assertThat(zone.getDomainId() == null).as(String.valueOf(zone)).isTrue();
+            assertThat(zone.getGuestCIDRAddress() == null).as(String.valueOf(zone)).isTrue();
             break;
          }
 

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/predicates/NetworkPredicatesTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/predicates/NetworkPredicatesTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.predicates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.cloudstack.predicates.NetworkPredicates.defaultNetworkInZone;
 import static org.jclouds.cloudstack.predicates.NetworkPredicates.hasLoadBalancerService;
 import static org.jclouds.cloudstack.predicates.NetworkPredicates.supportsPortForwarding;
@@ -38,9 +39,9 @@ public class NetworkPredicatesTest {
    public void testHasLoadBalancerService() {
       Network network = Network.builder().id("204").services(ImmutableSet.of(NetworkService.builder().name("Lb").build())).build();
 
-      assert hasLoadBalancerService().apply(network);
-      assert !supportsStaticNAT().apply(network);
-      assert !supportsPortForwarding().apply(network);
+      assertThat(hasLoadBalancerService().apply(network)).isTrue();
+      assertThat(!supportsStaticNAT().apply(network)).isTrue();
+      assertThat(!supportsPortForwarding().apply(network)).isTrue();
 
    }
 
@@ -53,9 +54,9 @@ public class NetworkPredicatesTest {
                         ImmutableMap.<String, String> of("StaticNat", "true")).build()))
             .build();
 
-      assert !hasLoadBalancerService().apply(network);
-      assert supportsStaticNAT().apply(network);
-      assert !supportsPortForwarding().apply(network);
+      assertThat(!hasLoadBalancerService().apply(network)).isTrue();
+      assertThat(supportsStaticNAT().apply(network)).isTrue();
+      assertThat(!supportsPortForwarding().apply(network)).isTrue();
    }
 
    public void testNoSupport() {
@@ -63,9 +64,9 @@ public class NetworkPredicatesTest {
             .services(ImmutableSet.of(NetworkService.builder().name("Firewall").capabilities(
                   ImmutableMap.<String, String> of()).build())).build();
 
-      assert !hasLoadBalancerService().apply(network);
-      assert !supportsStaticNAT().apply(network);
-      assert !supportsPortForwarding().apply(network);
+      assertThat(!hasLoadBalancerService().apply(network)).isTrue();
+      assertThat(!supportsStaticNAT().apply(network)).isTrue();
+      assertThat(!supportsPortForwarding().apply(network)).isTrue();
    }
 
    public void testSupportsPortForwardingFindsWhenFirewallHasPortForwardingFeature() {
@@ -76,9 +77,9 @@ public class NetworkPredicatesTest {
                   ImmutableSet.of(NetworkService.builder().name("Firewall").capabilities(
                         ImmutableMap.<String, String> of("PortForwarding", "true")).build())).build();
 
-      assert !hasLoadBalancerService().apply(network);
-      assert !supportsStaticNAT().apply(network);
-      assert supportsPortForwarding().apply(network);
+      assertThat(!hasLoadBalancerService().apply(network)).isTrue();
+      assertThat(!supportsStaticNAT().apply(network)).isTrue();
+      assertThat(supportsPortForwarding().apply(network)).isTrue();
    }
 
    public void testSupportsPortForwardingAndStaticNATWhenFirewallHasFeatures() {
@@ -89,8 +90,8 @@ public class NetworkPredicatesTest {
                   ImmutableSet.of(NetworkService.builder().name("Firewall").capabilities(
                         ImmutableMap.<String, String> of("StaticNat", "true", "PortForwarding", "true")).build())).build();
 
-      assert Predicates.and(supportsPortForwarding(), supportsStaticNAT()).apply(network);
-      assert !hasLoadBalancerService().apply(network);
+      assertThat(Predicates.and(supportsPortForwarding(), supportsStaticNAT()).apply(network)).isTrue();
+      assertThat(!hasLoadBalancerService().apply(network)).isTrue();
 
    }
 

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/predicates/PublicIPAddressPredicatesTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/predicates/PublicIPAddressPredicatesTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.cloudstack.predicates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.cloudstack.predicates.PublicIPAddressPredicates.available;
 
 import org.jclouds.cloudstack.domain.PublicIPAddress;
@@ -27,14 +28,14 @@ public class PublicIPAddressPredicatesTest {
    public void testIsAvailableWhenAllocated() {
       PublicIPAddress address = PublicIPAddress.builder().state(PublicIPAddress.State.ALLOCATED).id("204").build();
 
-      assert available().apply(address);
+      assertThat(available().apply(address)).isTrue();
 
    }
 
    public void testIsNotAvailableWhenNotAllocated() {
       PublicIPAddress address = PublicIPAddress.builder().state(PublicIPAddress.State.ALLOCATING).id("204").build();
 
-      assert !available().apply(address);
+      assertThat(!available().apply(address)).isTrue();
 
    }
 
@@ -42,7 +43,7 @@ public class PublicIPAddressPredicatesTest {
       PublicIPAddress address = PublicIPAddress.builder().state(PublicIPAddress.State.ALLOCATED).virtualMachineId("1")
             .id("204").build();
 
-      assert !available().apply(address);
+      assertThat(!available().apply(address)).isTrue();
 
    }
 
@@ -50,7 +51,7 @@ public class PublicIPAddressPredicatesTest {
       PublicIPAddress address = PublicIPAddress.builder().state(PublicIPAddress.State.ALLOCATED).isSourceNAT(true)
             .id("204").build();
 
-      assert !available().apply(address);
+      assertThat(!available().apply(address)).isTrue();
 
    }
 
@@ -58,7 +59,7 @@ public class PublicIPAddressPredicatesTest {
       PublicIPAddress address = PublicIPAddress.builder().state(PublicIPAddress.State.ALLOCATED).isStaticNAT(true)
             .id("204").build();
 
-      assert !available().apply(address);
+      assertThat(!available().apply(address)).isTrue();
 
    }
 }

--- a/apis/ec2/src/test/java/org/jclouds/ec2/CloudApplicationArchitecturesEC2ApiLiveTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/CloudApplicationArchitecturesEC2ApiLiveTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.ec2;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.options.RunInstancesOptions.Builder.asType;
 import static org.jclouds.util.Predicates2.retry;
 import static org.jclouds.scriptbuilder.domain.Statements.exec;
@@ -194,11 +195,11 @@ public class CloudApplicationArchitecturesEC2ApiLiveTest extends BaseComputeServ
 
       assertEquals(null, client.getInstanceApi().get().getRootDeviceNameForInstanceInRegion(null, instanceId));
 
-      assert client.getInstanceApi().get().getRamdiskForInstanceInRegion(null, instanceId).startsWith("ari-");
+      assertThat(client.getInstanceApi().get().getRamdiskForInstanceInRegion(null, instanceId).startsWith("ari-")).isTrue();
 
       assertEquals(false, client.getInstanceApi().get().isApiTerminationDisabledForInstanceInRegion(null, instanceId));
 
-      assert client.getInstanceApi().get().getKernelForInstanceInRegion(null, instanceId).startsWith("aki-");
+      assertThat(client.getInstanceApi().get().getKernelForInstanceInRegion(null, instanceId).startsWith("aki-")).isTrue();
 
       assertEquals(InstanceType.M1_SMALL,
             client.getInstanceApi().get().getInstanceTypeForInstanceInRegion(null, instanceId));
@@ -298,7 +299,7 @@ public class CloudApplicationArchitecturesEC2ApiLiveTest extends BaseComputeServ
       try {
          ssh.connect();
          ExecResponse uptime = ssh.exec("uptime");
-         assert uptime.getOutput().indexOf("0 min") != -1 : "reboot didn't work: " + uptime;
+         assertThat(uptime.getOutput().indexOf("0 min") != -1).as("reboot didn't work: " + uptime).isTrue();
       } finally {
          if (ssh != null)
             ssh.disconnect();
@@ -314,7 +315,7 @@ public class CloudApplicationArchitecturesEC2ApiLiveTest extends BaseComputeServ
             .describeAddressesInRegion(null, address));
 
       assertEquals(compare.getPublicIp(), address);
-      assert compare.getInstanceId() == null;
+      assertThat(compare.getInstanceId() == null).isTrue();
 
       client.getElasticIPAddressApi().get().associateAddressInRegion(null, address, instanceId);
 
@@ -336,7 +337,7 @@ public class CloudApplicationArchitecturesEC2ApiLiveTest extends BaseComputeServ
       compare = Iterables.getLast(client.getElasticIPAddressApi().get().describeAddressesInRegion(null, address));
 
       assertEquals(compare.getPublicIp(), address);
-      assert compare.getInstanceId() == null;
+      assertThat(compare.getInstanceId() == null).isTrue();
 
       reservation = Iterables.getOnlyElement(client.getInstanceApi().get().describeInstancesInRegion(null, instanceId));
       // assert reservation.getRunningInstances().last().getIpAddress() == null;
@@ -345,23 +346,23 @@ public class CloudApplicationArchitecturesEC2ApiLiveTest extends BaseComputeServ
 
    private RunningInstance blockUntilWeCanSshIntoInstance(RunningInstance instance) throws UnknownHostException {
       System.out.printf("%d: %s awaiting instance to run %n", System.currentTimeMillis(), instance.getId());
-      assert runningTester.apply(instance);
+      assertThat(runningTester.apply(instance)).isTrue();
 
       instance = getInstance(instance.getId());
 
       System.out
             .printf("%d: %s awaiting instance to have ip assigned %n", System.currentTimeMillis(), instance.getId());
-      assert hasIpTester.apply(instance);
+      assertThat(hasIpTester.apply(instance)).isTrue();
 
       System.out.printf("%d: %s awaiting ssh service to start%n", System.currentTimeMillis(), instance.getIpAddress());
-      assert socketTester.apply(HostAndPort.fromParts(instance.getIpAddress(), 22));
+      assertThat(socketTester.apply(HostAndPort.fromParts(instance.getIpAddress(), 22))).isTrue();
 
       System.out.printf("%d: %s ssh service started%n", System.currentTimeMillis(), instance.getDnsName());
       sshPing(instance);
       System.out.printf("%d: %s ssh connection made%n", System.currentTimeMillis(), instance.getId());
 
       System.out.printf("%d: %s awaiting http service to start%n", System.currentTimeMillis(), instance.getIpAddress());
-      assert socketTester.apply(HostAndPort.fromParts(instance.getIpAddress(), 80));
+      assertThat(socketTester.apply(HostAndPort.fromParts(instance.getIpAddress(), 80))).isTrue();
       System.out.printf("%d: %s http service started%n", System.currentTimeMillis(), instance.getDnsName());
       return instance;
    }

--- a/apis/ec2/src/test/java/org/jclouds/ec2/compute/EC2ComputeServiceLiveTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/compute/EC2ComputeServiceLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.compute;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -140,7 +141,7 @@ public class EC2ComputeServiceLiveTest extends BaseComputeServiceLiveTest {
          options.as(EC2TemplateOptions.class).keyPair(result.getKeyName());
          
          // pass in the private key, so that we can run a script with it
-         assert result.getKeyMaterial() != null : result;
+         assertThat(result.getKeyMaterial() != null).as(String.valueOf(result)).isTrue();
          options.overrideLoginPrivateKey(result.getKeyMaterial());
          
          // an arbitrary command to run
@@ -148,8 +149,8 @@ public class EC2ComputeServiceLiveTest extends BaseComputeServiceLiveTest {
          
          Set<? extends NodeMetadata> nodes = client.createNodesInGroup(group, 1, options);
          NodeMetadata first = Iterables.get(nodes, 0);
-         assert first.getCredentials() != null : first;
-         assert first.getCredentials().identity != null : first;
+         assertThat(first.getCredentials() != null).as(String.valueOf(first)).isTrue();
+         assertThat(first.getCredentials().identity != null).as(String.valueOf(first)).isTrue();
 
          // Verify that the output of createNodesInGroup is the same.
          assertEquals(client.createNodesInGroup(group, 1, options), nodes, "Idempotency failing - got different instances");
@@ -166,7 +167,7 @@ public class EC2ComputeServiceLiveTest extends BaseComputeServiceLiveTest {
          // make sure our dummy group has no rules
          SecurityGroup secgroup = Iterables.getOnlyElement(securityGroupClient.describeSecurityGroupsInRegion(null,
                   "jclouds#" + group));
-         assert secgroup.size() == 0 : secgroup;
+         assertThat(secgroup.size() == 0).as(String.valueOf(secgroup)).isTrue();
 
          // try to run a script with the original keyPair
          runScriptWithCreds(group, first.getOperatingSystem(),

--- a/apis/ec2/src/test/java/org/jclouds/ec2/compute/EC2TemplateBuilderLiveTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/compute/EC2TemplateBuilderLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.compute;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.http.internal.TrackingJavaUrlHttpCommandExecutorService.getArgsForRequestAtIndex;
 import static org.jclouds.http.internal.TrackingJavaUrlHttpCommandExecutorService.getInvokerOfRequest;
 import static org.jclouds.http.internal.TrackingJavaUrlHttpCommandExecutorService.getInvokerOfRequestAtIndex;
@@ -76,7 +77,7 @@ public abstract class EC2TemplateBuilderLiveTest extends BaseTemplateBuilderLive
             }
          });
          
-         assert filteredCommandsInvoked.size() == 1 : commandsInvoked;
+         assertThat(filteredCommandsInvoked.size() == 1).as(String.valueOf(commandsInvoked)).isTrue();
          assertInvokedCommand(getInvokerOfRequestAtIndex(filteredCommandsInvoked, 0), Invokable.from(AMIApi.class
                   .getMethod("describeImagesInRegion", String.class, DescribeImagesOptions[].class)));
          assertDescribeImagesOptionsEquals((DescribeImagesOptions[])getArgsForRequestAtIndex(filteredCommandsInvoked, 0).get(1), 
@@ -87,7 +88,7 @@ public abstract class EC2TemplateBuilderLiveTest extends BaseTemplateBuilderLive
             context.close();
       }
    }
-   
+
    private static void assertDescribeImagesOptionsEquals(DescribeImagesOptions[] actual, String expectedImageId) {
       assertEquals(actual.length, 1);
       assertEquals(actual[0].getImageIds(), ImmutableSet.of(expectedImageId));

--- a/apis/ec2/src/test/java/org/jclouds/ec2/compute/EC2TemplateBuilderTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/compute/EC2TemplateBuilderTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.ec2.compute;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -100,7 +101,7 @@ public class EC2TemplateBuilderTest {
    public void testTemplateChoiceForInstanceByHardwareId() throws Exception {
       Template template = newTemplateBuilder().os64Bit(true).hardwareId("m2.xlarge").locationId("us-east-1").build();
 
-      assert template != null : "The returned template was null, but it should have a value.";
+      assertThat(template != null).as("The returned template was null, but it should have a value.").isTrue();
       // assert m2_xlarge().build().equals(template.getHardware()) : format(
       // "Incorrect image determined by the template. Expected: %s. Found: %s.", "m2.xlarge",
       // String.valueOf(template.getHardware()));
@@ -111,10 +112,10 @@ public class EC2TemplateBuilderTest {
    public void testTemplateChoiceForInstanceByFastest() throws Exception {
       Template template = newTemplateBuilder().fastest().build();
 
-      assert template != null : "The returned template was null, but it should have a value.";
-      assert g2_2xlarge().build().equals(template.getHardware()) : format(
+      assertThat(template != null).as("The returned template was null, but it should have a value.").isTrue();
+      assertThat(g2_2xlarge().build().equals(template.getHardware())).as(format(
                "Incorrect image determined by the template. Expected: %s. Found: %s.", g2_2xlarge(), template
-                        .getHardware().getId());
+                        .getHardware().getId())).isTrue();
    }
 
    /**
@@ -128,7 +129,7 @@ public class EC2TemplateBuilderTest {
       Template template = newTemplateBuilder().os64Bit(true).minRam(17510).minCores(6.5).smallest().locationId(
                "us-east-1").build();
 
-      assert template != null : "The returned template was null, but it should have a value.";
+      assertThat(template != null).as("The returned template was null, but it should have a value.").isTrue();
       assertEquals(template.getHardware().getId(), m2_4xlarge().build().getId());
    }
 
@@ -145,17 +146,17 @@ public class EC2TemplateBuilderTest {
       Template template = newTemplateBuilder().os64Bit(true).minRam(17510).minCores(6.7).smallest().locationId(
                "us-east-1").build();
 
-      assert template != null : "The returned template was null, but it should have a value.";
-      assert !m2_xlarge().build().equals(template.getHardware()) : format(
+      assertThat(template != null).as("The returned template was null, but it should have a value.").isTrue();
+      assertThat(!m2_xlarge().build().equals(template.getHardware())).as(format(
                "Incorrect image determined by the template. Expected: not %s. Found: %s.", "m2.xlarge", template
-                        .getHardware().getId());
+                        .getHardware().getId())).isTrue();
    }
 
    @Test
    public void testTemplateChoiceForInstanceByImageId() throws Exception {
       Template template = newTemplateBuilder().imageId("us-east-1/bogus-image").build();
 
-      assert template != null : "The returned template was null, but it should have a value.";
+      assertThat(template != null).as("The returned template was null, but it should have a value.").isTrue();
       assertEquals(template.getImage().getId(), "us-east-1/bogus-image");
       assertEquals(template.getHardware().getId(), HARDWARE_SUPPORTING_BOGUS.getId());
    }
@@ -180,7 +181,7 @@ public class EC2TemplateBuilderTest {
 
       Template template = newTemplateBuilder(images, imageCache).imageId("us-east-1/bogus-image").build();
 
-      assert template != null : "The returned template was null, but it should have a value.";
+      assertThat(template != null).as("The returned template was null, but it should have a value.").isTrue();
       assertEquals(template.getImage().getId(), "us-east-1/bogus-image");
       assertEquals(template.getHardware().getId(), HARDWARE_SUPPORTING_BOGUS.getId());
    }

--- a/apis/ec2/src/test/java/org/jclouds/ec2/compute/functions/RunningInstanceToNodeMetadataTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/compute/functions/RunningInstanceToNodeMetadataTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.compute.functions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.m1_small;
 import static org.testng.Assert.assertEquals;
 
@@ -63,7 +64,7 @@ public class RunningInstanceToNodeMetadataTest {
    public void testAllStatesCovered() {
 
       for (InstanceState status : InstanceState.values()) {
-         assert EC2ComputeServiceDependenciesModule.toPortableNodeStatus.containsKey(status) : status;
+         assertThat(EC2ComputeServiceDependenciesModule.toPortableNodeStatus.containsKey(status)).as(String.valueOf(status)).isTrue();
       }
 
    }

--- a/apis/ec2/src/test/java/org/jclouds/ec2/compute/options/EC2TemplateOptionsTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/compute/options/EC2TemplateOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.compute.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.compute.options.EC2TemplateOptions.Builder.authorizePublicKey;
 import static org.jclouds.ec2.compute.options.EC2TemplateOptions.Builder.blockOnPort;
 import static org.jclouds.ec2.compute.options.EC2TemplateOptions.Builder.inboundPorts;
@@ -149,21 +150,21 @@ public class EC2TemplateOptionsTest {
       EC2TemplateOptions options = new EC2TemplateOptions();
       options.noKeyPair();
       assertEquals(options.getKeyPair(), null);
-      assert !options.shouldAutomaticallyCreateKeyPair();
+      assertThat(!options.shouldAutomaticallyCreateKeyPair()).isTrue();
    }
 
    @Test
    public void testFalsenoKeyPair() {
       EC2TemplateOptions options = new EC2TemplateOptions();
       assertEquals(options.getKeyPair(), null);
-      assert options.shouldAutomaticallyCreateKeyPair();
+      assertThat(options.shouldAutomaticallyCreateKeyPair()).isTrue();
    }
 
    @Test
    public void testnoKeyPairStatic() {
       EC2TemplateOptions options = noKeyPair();
       assertEquals(options.getKeyPair(), null);
-      assert !options.shouldAutomaticallyCreateKeyPair();
+      assertThat(!options.shouldAutomaticallyCreateKeyPair()).isTrue();
    }
 
    // superclass tests

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/AMIApiLiveTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/AMIApiLiveTest.java
@@ -22,6 +22,7 @@ import static com.google.common.collect.Iterables.getFirst;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Sets.newHashSet;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.options.DescribeImagesOptions.Builder.imageIds;
 import static org.jclouds.ec2.options.RegisterImageBackedByEbsOptions.Builder.addNewBlockDevice;
 import static org.jclouds.util.Predicates2.retry;
@@ -240,7 +241,7 @@ public class AMIApiLiveTest extends BaseComputeServiceContextLiveTest {
                device.getVolumeId());
          snapshotsToDelete.add(snapshot.getId());
          Predicate<Snapshot> snapshotted = retry(new SnapshotCompleted(ec2Api.getElasticBlockStoreApi().get()), 600, 10, SECONDS);
-         assert snapshotted.apply(snapshot);
+         assertThat(snapshotted.apply(snapshot)).isTrue();
          return snapshot;
       } finally {
          if (instanceId != null)

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/AvailabilityZoneAndRegionApiLiveTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/AvailabilityZoneAndRegionApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.options.DescribeAvailabilityZonesOptions.Builder.availabilityZones;
 import static org.jclouds.ec2.options.DescribeRegionsOptions.Builder.regions;
 import static org.testng.Assert.assertEquals;
@@ -59,7 +60,7 @@ public class AvailabilityZoneAndRegionApiLiveTest extends BaseComputeServiceCont
       for (String region : ec2Api.getConfiguredRegions()) {
          Set<AvailabilityZoneInfo> allResults = client.describeAvailabilityZonesInRegion(region);
          assertNotNull(allResults);
-         assert !allResults.isEmpty() : allResults.size();
+         assertThat(!allResults.isEmpty()).as(String.valueOf(allResults.size())).isTrue();
          Iterator<AvailabilityZoneInfo> iterator = allResults.iterator();
          String id1 = iterator.next().getZone();
          Set<AvailabilityZoneInfo> oneResult = client.describeAvailabilityZonesInRegion(region,
@@ -75,7 +76,7 @@ public class AvailabilityZoneAndRegionApiLiveTest extends BaseComputeServiceCont
       SortedMap<String, URI> allResults = Maps.newTreeMap();
       allResults.putAll(client.describeRegions());
       assertNotNull(allResults);
-      assert !allResults.isEmpty() : allResults.size();
+      assertThat(!allResults.isEmpty()).as(String.valueOf(allResults.size())).isTrue();
       Iterator<Entry<String, URI>> iterator = allResults.entrySet().iterator();
       String r1 = iterator.next().getKey();
       SortedMap<String, URI> oneResult = Maps.newTreeMap();

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/ElasticBlockStoreApiLiveTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/ElasticBlockStoreApiLiveTest.java
@@ -19,6 +19,7 @@ package org.jclouds.ec2.features;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.options.CreateVolumeOptions.Builder.fromSnapshotId;
 import static org.jclouds.ec2.options.CreateVolumeOptions.Builder.withSize;
 import static org.jclouds.ec2.options.DescribeSnapshotsOptions.Builder.snapshotIds;
@@ -140,7 +141,7 @@ public class ElasticBlockStoreApiLiveTest extends BaseComputeServiceContextLiveT
    void testCreateSnapshotInRegion() {
       Snapshot snapshot = client.createSnapshotInRegion(defaultRegion, volumeId);
       Predicate<Snapshot> snapshotted = retry(new SnapshotCompleted(client), 600, 10, SECONDS);
-      assert snapshotted.apply(snapshot);
+      assertThat(snapshotted.apply(snapshot)).isTrue();
 
       Snapshot result = Iterables.getOnlyElement(client.describeSnapshotsInRegion(defaultRegion,
             snapshotIds(snapshot.getId())));
@@ -155,7 +156,7 @@ public class ElasticBlockStoreApiLiveTest extends BaseComputeServiceContextLiveT
       assertNotNull(volume);
 
       Predicate<Volume> availabile = retry(new VolumeAvailable(client), 600, 10, SECONDS);
-      assert availabile.apply(volume);
+      assertThat(availabile.apply(volume)).isTrue();
 
       Volume result = Iterables.getOnlyElement(client.describeVolumesInRegion(defaultRegion, volume.getId()));
       assertEquals(volume.getId(), result.getId());
@@ -173,7 +174,7 @@ public class ElasticBlockStoreApiLiveTest extends BaseComputeServiceContextLiveT
       assertNotNull(volume);
 
       Predicate<Volume> availabile = retry(new VolumeAvailable(client), 600, 10, SECONDS);
-      assert availabile.apply(volume);
+      assertThat(availabile.apply(volume)).isTrue();
 
       Volume result = Iterables.getOnlyElement(client.describeVolumesInRegion(defaultRegion, volume.getId()));
       assertEquals(volume.getId(), result.getId());
@@ -190,7 +191,7 @@ public class ElasticBlockStoreApiLiveTest extends BaseComputeServiceContextLiveT
       assertNotNull(volume);
 
       Predicate<Volume> availabile = retry(new VolumeAvailable(client), 600, 10, SECONDS);
-      assert availabile.apply(volume);
+      assertThat(availabile.apply(volume)).isTrue();
 
       Volume result = Iterables.getOnlyElement(client.describeVolumesInRegion(defaultRegion, volume.getId()));
       assertEquals(volume.getId(), result.getId());
@@ -296,7 +297,7 @@ public class ElasticBlockStoreApiLiveTest extends BaseComputeServiceContextLiveT
    @Test(dependsOnMethods = "testDeleteVolumeInRegion")
    void testDeleteSnapshotInRegion() {
       client.deleteSnapshotInRegion(defaultRegion, snapshot.getId());
-      assert client.describeSnapshotsInRegion(defaultRegion, snapshotIds(snapshot.getId())).size() == 0;
+      assertThat(client.describeSnapshotsInRegion(defaultRegion, snapshotIds(snapshot.getId())).size() == 0).isTrue();
    }
 
    @AfterClass(groups = { "integration", "live" })

--- a/apis/ec2/src/test/java/org/jclouds/ec2/features/SecurityGroupApiLiveTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/features/SecurityGroupApiLiveTest.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Predicates.in;
 import static com.google.common.collect.Iterables.all;
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -253,8 +254,8 @@ public class SecurityGroupApiLiveTest extends BaseComputeServiceContextLiveTest 
       public void run() {
          try {
             Set<SecurityGroup> oneResult = client.describeSecurityGroupsInRegion(null, group);
-            assert all(getOnlyElement(oneResult), permission) : permission
-                  + ": " + oneResult;
+            assertThat(all(getOnlyElement(oneResult), permission)).as(permission
+                  + ": " + oneResult).isTrue();
          } catch (Exception e) {
             throw new AssertionError(e);
          }

--- a/apis/ec2/src/test/java/org/jclouds/ec2/options/BundleInstanceS3StorageOptionsTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/options/BundleInstanceS3StorageOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.options.BundleInstanceS3StorageOptions.Builder.bucketOwnedBy;
 import static org.testng.Assert.assertEquals;
 
@@ -34,8 +35,8 @@ public class BundleInstanceS3StorageOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(BundleInstanceS3StorageOptions.class);
-      assert !String.class.isAssignableFrom(BundleInstanceS3StorageOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(BundleInstanceS3StorageOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(BundleInstanceS3StorageOptions.class)).isTrue();
    }
 
    @Test

--- a/apis/ec2/src/test/java/org/jclouds/ec2/options/CreateImageOptionsTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/options/CreateImageOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.options.CreateImageOptions.Builder.noReboot;
 import static org.jclouds.ec2.options.CreateImageOptions.Builder.withDescription;
 import static org.testng.Assert.assertEquals;
@@ -32,8 +33,8 @@ public class CreateImageOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(CreateImageOptions.class);
-      assert !String.class.isAssignableFrom(CreateImageOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(CreateImageOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(CreateImageOptions.class)).isTrue();
    }
 
    @Test

--- a/apis/ec2/src/test/java/org/jclouds/ec2/options/CreateSnapshotOptionsTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/options/CreateSnapshotOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.options.CreateSnapshotOptions.Builder.withDescription;
 import static org.testng.Assert.assertEquals;
 
@@ -31,8 +32,8 @@ public class CreateSnapshotOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(CreateSnapshotOptions.class);
-      assert !String.class.isAssignableFrom(CreateSnapshotOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(CreateSnapshotOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(CreateSnapshotOptions.class)).isTrue();
    }
 
    @Test

--- a/apis/ec2/src/test/java/org/jclouds/ec2/options/CreateVolumeOptionsTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/options/CreateVolumeOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.options.CreateVolumeOptions.Builder.fromSnapshotId;
 import static org.jclouds.ec2.options.CreateVolumeOptions.Builder.isEncrypted;
 import static org.jclouds.ec2.options.CreateVolumeOptions.Builder.volumeType;
@@ -34,8 +35,8 @@ public class CreateVolumeOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(CreateVolumeOptions.class);
-      assert !String.class.isAssignableFrom(CreateVolumeOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(CreateVolumeOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(CreateVolumeOptions.class)).isTrue();
    }
 
    @Test

--- a/apis/ec2/src/test/java/org/jclouds/ec2/options/DescribeImagesOptionsTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/options/DescribeImagesOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.options.DescribeImagesOptions.Builder.executableBy;
 import static org.jclouds.ec2.options.DescribeImagesOptions.Builder.imageIds;
 import static org.jclouds.ec2.options.DescribeImagesOptions.Builder.ownedBy;
@@ -33,8 +34,8 @@ public class DescribeImagesOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(DescribeImagesOptions.class);
-      assert !String.class.isAssignableFrom(DescribeImagesOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(DescribeImagesOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(DescribeImagesOptions.class)).isTrue();
    }
 
    @Test

--- a/apis/ec2/src/test/java/org/jclouds/ec2/options/DescribeSnapshotsOptionsTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/options/DescribeSnapshotsOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.options.DescribeSnapshotsOptions.Builder.ownedBy;
 import static org.jclouds.ec2.options.DescribeSnapshotsOptions.Builder.restorableBy;
 import static org.jclouds.ec2.options.DescribeSnapshotsOptions.Builder.snapshotIds;
@@ -33,8 +34,8 @@ public class DescribeSnapshotsOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(DescribeSnapshotsOptions.class);
-      assert !String.class.isAssignableFrom(DescribeSnapshotsOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(DescribeSnapshotsOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(DescribeSnapshotsOptions.class)).isTrue();
    }
 
    @Test

--- a/apis/ec2/src/test/java/org/jclouds/ec2/options/DetachVolumeOptionsTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/options/DetachVolumeOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.options.DetachVolumeOptions.Builder.fromDevice;
 import static org.jclouds.ec2.options.DetachVolumeOptions.Builder.fromInstance;
 import static org.testng.Assert.assertEquals;
@@ -32,8 +33,8 @@ public class DetachVolumeOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(DetachVolumeOptions.class);
-      assert !String.class.isAssignableFrom(DetachVolumeOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(DetachVolumeOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(DetachVolumeOptions.class)).isTrue();
    }
 
    @Test

--- a/apis/ec2/src/test/java/org/jclouds/ec2/options/RegisterImageBackedByEbsOptionsTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/options/RegisterImageBackedByEbsOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.options.RegisterImageBackedByEbsOptions.Builder.addBlockDeviceFromSnapshot;
 import static org.jclouds.ec2.options.RegisterImageBackedByEbsOptions.Builder.addEphemeralBlockDeviceFromSnapshot;
 import static org.jclouds.ec2.options.RegisterImageBackedByEbsOptions.Builder.addNewBlockDevice;
@@ -40,8 +41,8 @@ public class RegisterImageBackedByEbsOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(RegisterImageBackedByEbsOptions.class);
-      assert !String.class.isAssignableFrom(RegisterImageBackedByEbsOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(RegisterImageBackedByEbsOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(RegisterImageBackedByEbsOptions.class)).isTrue();
    }
 
    @Test

--- a/apis/ec2/src/test/java/org/jclouds/ec2/options/RegisterImageOptionsTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/options/RegisterImageOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.options.RegisterImageOptions.Builder.asArchitecture;
 import static org.jclouds.ec2.options.RegisterImageOptions.Builder.withDescription;
 import static org.jclouds.ec2.options.RegisterImageOptions.Builder.withKernelId;
@@ -35,8 +36,8 @@ public class RegisterImageOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(RegisterImageOptions.class);
-      assert !String.class.isAssignableFrom(RegisterImageOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(RegisterImageOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(RegisterImageOptions.class)).isTrue();
    }
 
    @Test

--- a/apis/ec2/src/test/java/org/jclouds/ec2/options/RunInstancesOptionsTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/options/RunInstancesOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ec2.options.RunInstancesOptions.Builder.asType;
 import static org.jclouds.ec2.options.RunInstancesOptions.Builder.withBlockDeviceMappings;
 import static org.jclouds.ec2.options.RunInstancesOptions.Builder.withClientToken;
@@ -40,8 +41,8 @@ public class RunInstancesOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(RunInstancesOptions.class);
-      assert !String.class.isAssignableFrom(RunInstancesOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(RunInstancesOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(RunInstancesOptions.class)).isTrue();
    }
 
    @Test

--- a/apis/ec2/src/test/java/org/jclouds/ec2/xml/BaseEC2HandlerTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/xml/BaseEC2HandlerTest.java
@@ -39,6 +39,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Provides;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Test(groups = "unit")
 public abstract class BaseEC2HandlerTest extends BaseHandlerTest {
    protected String defaultRegion = Region.US_EAST_1;
@@ -77,6 +79,6 @@ public abstract class BaseEC2HandlerTest extends BaseHandlerTest {
          }
       });
       factory = injector.getInstance(ParseSax.Factory.class);
-      assert factory != null;
+      assertThat(factory != null).isTrue();
    }
 }

--- a/apis/ec2/src/test/java/org/jclouds/ec2/xml/DescribeAvailabilityZonesResponseHandlerTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/xml/DescribeAvailabilityZonesResponseHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -56,7 +57,7 @@ public class DescribeAvailabilityZonesResponseHandlerTest extends BaseHandlerTes
 
       });
       factory = injector.getInstance(ParseSax.Factory.class);
-      assert factory != null;
+      assertThat(factory != null).isTrue();
    }
 
    public void testApplyInputStream() {

--- a/apis/ec2/src/test/java/org/jclouds/ec2/xml/DescribeInstanceAttributeTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/xml/DescribeInstanceAttributeTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -57,7 +58,7 @@ public class DescribeInstanceAttributeTest extends BaseHandlerTest {
       BooleanValueHandler handler = injector.getInstance(BooleanValueHandler.class);
       Boolean result = factory.create(handler).parse(is);
 
-      assert !result;
+      assertThat(!result).isTrue();
    }
 
    public void testStringValueHandler() {

--- a/apis/ec2/src/test/java/org/jclouds/ec2/xml/DescribeInstancesResponseHandlerTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/xml/DescribeInstancesResponseHandlerTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.ec2.xml;
 
 import static com.google.common.collect.Iterables.get;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -60,7 +61,7 @@ public class DescribeInstancesResponseHandlerTest extends BaseEC2HandlerTest {
    protected void setUpInjector() {
       super.setUpInjector();
       dateService = injector.getInstance(DateService.class);
-      assert dateService != null;
+      assertThat(dateService != null).isTrue();
    }
 
    public void testWhenRunning() throws UnknownHostException {

--- a/apis/ec2/src/test/java/org/jclouds/ec2/xml/DescribeRegionsResponseHandlerTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/xml/DescribeRegionsResponseHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -57,7 +58,7 @@ public class DescribeRegionsResponseHandlerTest extends BaseHandlerTest {
 
       });
       factory = injector.getInstance(ParseSax.Factory.class);
-      assert factory != null;
+      assertThat(factory != null).isTrue();
    }
 
    public void testApplyInputStream() {

--- a/apis/ec2/src/test/java/org/jclouds/ec2/xml/InstanceStateChangeHandlerTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/xml/InstanceStateChangeHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -44,7 +45,7 @@ public class InstanceStateChangeHandlerTest extends BaseEC2HandlerTest {
    protected void setUpInjector() {
       super.setUpInjector();
       dateService = injector.getInstance(DateService.class);
-      assert dateService != null;
+      assertThat(dateService != null).isTrue();
    }
 
    public void testTerminate() {

--- a/apis/ec2/src/test/java/org/jclouds/ec2/xml/KeyPairResponseHandlerTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/xml/KeyPairResponseHandlerTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 package org.jclouds.ec2.xml;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
@@ -67,8 +68,8 @@ public class KeyPairResponseHandlerTest extends BaseEC2HandlerTest {
 
       assertEquals(result, expected);
 
-      assert SshKeys.privateKeyHasSha1(result.getKeyMaterial(), result.getSha1OfPrivateKey());
-      assert SshKeys.privateKeyHasFingerprint(result.getKeyMaterial(), result.getFingerprint());
+      assertThat(SshKeys.privateKeyHasSha1(result.getKeyMaterial(), result.getSha1OfPrivateKey())).isTrue();
+      assertThat(SshKeys.privateKeyHasFingerprint(result.getKeyMaterial(), result.getFingerprint())).isTrue();
 
    }
 

--- a/apis/ec2/src/test/java/org/jclouds/ec2/xml/RunInstancesResponseHandlerTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/xml/RunInstancesResponseHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ec2.xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -46,7 +47,7 @@ public class RunInstancesResponseHandlerTest extends BaseEC2HandlerTest {
    protected void setUpInjector() {
       super.setUpInjector();
       dateService = injector.getInstance(DateService.class);
-      assert dateService != null;
+      assertThat(dateService != null).isTrue();
    }
 
    public void testEC2() {

--- a/apis/elasticstack/src/test/java/org/jclouds/elasticstack/ElasticStackApiLiveTest.java
+++ b/apis/elasticstack/src/test/java/org/jclouds/elasticstack/ElasticStackApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.elasticstack;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.util.Predicates2.retry;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -104,7 +105,7 @@ public class ElasticStackApiLiveTest extends BaseComputeServiceContextLiveTest {
    @Test
    public void testGetServer() throws Exception {
       for (String serverUUID : client.listServers()) {
-         assert !"".equals(serverUUID);
+         assertThat(!"".equals(serverUUID)).isTrue();
          assertNotNull(client.getServerInfo(serverUUID));
       }
    }
@@ -138,8 +139,8 @@ public class ElasticStackApiLiveTest extends BaseComputeServiceContextLiveTest {
    @Test
    public void testGetDrive() throws Exception {
       for (String driveUUID : client.listDrives()) {
-         assert !"".equals(driveUUID) : driveUUID;
-         assert client.getDriveInfo(driveUUID) != null : driveUUID;
+         assertThat(!"".equals(driveUUID)).as(driveUUID).isTrue();
+         assertThat(client.getDriveInfo(driveUUID) != null).as(driveUUID).isTrue();
       }
    }
 
@@ -233,10 +234,10 @@ public class ElasticStackApiLiveTest extends BaseComputeServiceContextLiveTest {
    public void testConnectivity() throws Exception {
       HostAndPort vncsocket = HostAndPort.fromParts(server.getVnc().getIp(), 5900);
       Logger.getAnonymousLogger().info("awaiting vnc: " + vncsocket);
-      assert socketTester.apply(vncsocket) : server;
+      assertThat(socketTester.apply(vncsocket)).as(String.valueOf(server)).isTrue();
       HostAndPort sshsocket = HostAndPort.fromParts(server.getNics().get(0).getDhcp(), 22);
       Logger.getAnonymousLogger().info("awaiting ssh: " + sshsocket);
-      assert socketTester.apply(sshsocket) : server;
+      assertThat(socketTester.apply(sshsocket)).as(String.valueOf(server)).isTrue();
       doConnectViaSsh(server, getSshCredentials(server));
    }
 
@@ -254,8 +255,8 @@ public class ElasticStackApiLiveTest extends BaseComputeServiceContextLiveTest {
       client.shutdownServer(server.getUuid());
       // behavior on shutdown depends on how your server OS is set up to respond to an ACPI power
       // button signal
-      assert client.getServerInfo(server.getUuid()).getStatus() == ServerStatus.ACTIVE || client.getServerInfo(
-               server.getUuid()).getStatus() == ServerStatus.STOPPED;
+      assertThat(client.getServerInfo(server.getUuid()).getStatus() == ServerStatus.ACTIVE || client.getServerInfo(
+               server.getUuid()).getStatus() == ServerStatus.STOPPED).isTrue();
    }
 
    @Test(dependsOnMethods = "testLifeCycle")
@@ -339,8 +340,8 @@ public class ElasticStackApiLiveTest extends BaseComputeServiceContextLiveTest {
          System.err.println("before image; drive 2" + client.getDriveInfo(drive2.getUuid()));
          System.err.println("before image; drive 3" + client.getDriveInfo(drive3.getUuid()));
          client.imageDrive(drive2.getUuid(), drive3.getUuid());
-         assert driveNotClaimed.apply(drive3) : client.getDriveInfo(drive3.getUuid());
-         assert driveNotClaimed.apply(drive2) : client.getDriveInfo(drive2.getUuid());
+         assertThat(driveNotClaimed.apply(drive3)).as(String.valueOf(client.getDriveInfo(drive3.getUuid()))).isTrue();
+         assertThat(driveNotClaimed.apply(drive2)).as(String.valueOf(client.getDriveInfo(drive2.getUuid()))).isTrue();
          System.err.println("after image; drive 2" + client.getDriveInfo(drive2.getUuid()));
          System.err.println("after image; drive 3" + client.getDriveInfo(drive3.getUuid()));
          assertEquals(Strings2.toStringAndClose(client.readDrive(drive3.getUuid(), 0, 3).openStream()), "foo");
@@ -357,7 +358,7 @@ public class ElasticStackApiLiveTest extends BaseComputeServiceContextLiveTest {
    protected void prepareDrive() {
       System.err.println("before prepare" + client.getDriveInfo(drive.getUuid()));
       client.imageDrive(imageId, drive.getUuid(), ImageConversionType.GUNZIP);
-      assert driveNotClaimed.apply(drive) : client.getDriveInfo(drive.getUuid());
+      assertThat(driveNotClaimed.apply(drive)).as(String.valueOf(client.getDriveInfo(drive.getUuid()))).isTrue();
       System.err.println("after prepare" + client.getDriveInfo(drive.getUuid()));
    }
 

--- a/apis/elasticstack/src/test/java/org/jclouds/elasticstack/compute/ElasticStackComputeServiceLiveTest.java
+++ b/apis/elasticstack/src/test/java/org/jclouds/elasticstack/compute/ElasticStackComputeServiceLiveTest.java
@@ -24,6 +24,8 @@ import org.testng.annotations.Test;
 
 import com.google.inject.Module;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Test(groups = "live", testName = "ElasticStackComputeServiceLiveTest")
 public class ElasticStackComputeServiceLiveTest extends BaseComputeServiceLiveTest {
 
@@ -43,6 +45,6 @@ public class ElasticStackComputeServiceLiveTest extends BaseComputeServiceLiveTe
 
    protected void checkResponseEqualsHostname(ExecResponse execResponse, NodeMetadata node1) {
       // hostname is not predictable based on node metadata
-      assert execResponse.getOutput().trim().equals("ubuntu") : execResponse.getOutput();
+      assertThat(execResponse.getOutput().trim().equals("ubuntu")).as(execResponse.getOutput()).isTrue();
    }
 }

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/predicates/ExtensionPredicatesTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/predicates/ExtensionPredicatesTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.openstack.v2_0.predicates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.openstack.v2_0.predicates.ExtensionPredicates.aliasEquals;
 import static org.jclouds.openstack.v2_0.predicates.ExtensionPredicates.namespaceEquals;
 
@@ -34,27 +35,27 @@ public class ExtensionPredicatesTest {
 
    @Test
    public void testAliasEqualsWhenEqual() {
-      assert aliasEquals("os-keypairs").apply(ref);
+      assertThat(aliasEquals("os-keypairs").apply(ref)).isTrue();
    }
 
    @Test
    public void testAliasEqualsWhenNotEqual() {
-      assert !aliasEquals("foo").apply(ref);
+      assertThat(!aliasEquals("foo").apply(ref)).isTrue();
    }
 
    @Test
    public void testNamespaceEqualsWhenEqual() {
-      assert namespaceEquals(URI.create("http://docs.openstack.org/ext/keypairs/api/v1.1")).apply(ref);
+      assertThat(namespaceEquals(URI.create("http://docs.openstack.org/ext/keypairs/api/v1.1")).apply(ref)).isTrue();
    }
 
    @Test
    public void testNamespaceEqualsWhenEqualEvenOnInputHttps() {
-      assert namespaceEquals(URI.create("http://docs.openstack.org/ext/keypairs/api/v1.1")).apply(
-               ref.toBuilder().namespace(URI.create("https://docs.openstack.org/ext/keypairs/api/v1.1")).build());
+      assertThat(namespaceEquals(URI.create("http://docs.openstack.org/ext/keypairs/api/v1.1")).apply(
+               ref.toBuilder().namespace(URI.create("https://docs.openstack.org/ext/keypairs/api/v1.1")).build())).isTrue();
    }
 
    @Test
    public void testNamespaceEqualsWhenNotEqual() {
-      assert !namespaceEquals(URI.create("foo")).apply(ref);
+      assertThat(!namespaceEquals(URI.create("foo")).apply(ref)).isTrue();
    }
 }

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/predicates/LinkPredicatesTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/predicates/LinkPredicatesTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.openstack.v2_0.predicates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.openstack.v2_0.predicates.LinkPredicates.hrefEquals;
 import static org.jclouds.openstack.v2_0.predicates.LinkPredicates.relationEquals;
 import static org.jclouds.openstack.v2_0.predicates.LinkPredicates.typeEquals;
@@ -33,31 +34,31 @@ public class LinkPredicatesTest {
 
    @Test
    public void testRelationEqualsWhenEqual() {
-      assert relationEquals(Relation.DESCRIBEDBY).apply(ref);
+      assertThat(relationEquals(Relation.DESCRIBEDBY).apply(ref)).isTrue();
    }
 
    @Test
    public void testRelationEqualsWhenNotEqual() {
-      assert !relationEquals(Relation.UNRECOGNIZED).apply(ref);
+      assertThat(!relationEquals(Relation.UNRECOGNIZED).apply(ref)).isTrue();
    }
 
    @Test
    public void testTypeEqualsWhenEqual() {
-      assert typeEquals("application/pdf").apply(ref);
+      assertThat(typeEquals("application/pdf").apply(ref)).isTrue();
    }
 
    @Test
    public void testTypeEqualsWhenNotEqual() {
-      assert !typeEquals("foo").apply(ref);
+      assertThat(!typeEquals("foo").apply(ref)).isTrue();
    }
 
    @Test
    public void testHrefEqualsWhenEqual() {
-      assert hrefEquals(URI.create("http://docs.openstack.org/ext/keypairs/api/v1.1")).apply(ref);
+      assertThat(hrefEquals(URI.create("http://docs.openstack.org/ext/keypairs/api/v1.1")).apply(ref)).isTrue();
    }
 
    @Test
    public void testHrefEqualsWhenNotEqual() {
-      assert !hrefEquals(URI.create("foo")).apply(ref);
+      assertThat(!hrefEquals(URI.create("foo")).apply(ref)).isTrue();
    }
 }

--- a/apis/openstack-nova-ec2/src/test/java/org/jclouds/openstack/nova/ec2/compute/NovaEC2ComputeServiceLiveTest.java
+++ b/apis/openstack-nova-ec2/src/test/java/org/jclouds/openstack/nova/ec2/compute/NovaEC2ComputeServiceLiveTest.java
@@ -21,6 +21,8 @@ import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.ec2.compute.EC2ComputeServiceLiveTest;
 import org.testng.annotations.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Test(groups = "live", singleThreaded = true, testName = "NovaEC2ComputeServiceLiveTest")
 public class NovaEC2ComputeServiceLiveTest extends EC2ComputeServiceLiveTest {
 
@@ -30,6 +32,6 @@ public class NovaEC2ComputeServiceLiveTest extends EC2ComputeServiceLiveTest {
    
    protected void checkResponseEqualsHostname(ExecResponse execResponse, NodeMetadata node1) {
       // hostname is not predictable based on node metadata
-      assert execResponse.getOutput().trim().equals("ubuntu");
+      assertThat(execResponse.getOutput().trim().equals("ubuntu")).isTrue();
    }
 }

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/compute/options/NovaTemplateOptionsTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/compute/options/NovaTemplateOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.openstack.nova.v2_0.compute.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.openstack.nova.v2_0.compute.options.NovaTemplateOptions.Builder.authorizePublicKey;
 import static org.jclouds.openstack.nova.v2_0.compute.options.NovaTemplateOptions.Builder.autoAssignFloatingIp;
 import static org.jclouds.openstack.nova.v2_0.compute.options.NovaTemplateOptions.Builder.blockOnPort;
@@ -94,37 +95,37 @@ public class NovaTemplateOptionsTest {
    @Test
    public void testautoAssignFloatingIpDefault() {
       NovaTemplateOptions options = new NovaTemplateOptions();
-      assert !options.shouldAutoAssignFloatingIp();
+      assertThat(!options.shouldAutoAssignFloatingIp()).isTrue();
    }
 
    @Test
    public void testautoAssignFloatingIp() {
       NovaTemplateOptions options = new NovaTemplateOptions().autoAssignFloatingIp(true);
-      assert options.shouldAutoAssignFloatingIp();
+      assertThat(options.shouldAutoAssignFloatingIp()).isTrue();
    }
 
    @Test
    public void testautoAssignFloatingIpStatic() {
       NovaTemplateOptions options = autoAssignFloatingIp(true);
-      assert options.shouldAutoAssignFloatingIp();
+      assertThat(options.shouldAutoAssignFloatingIp()).isTrue();
    }
 
    @Test
    public void testGenerateKeyPairDefault() {
       NovaTemplateOptions options = new NovaTemplateOptions();
-      assert !options.shouldGenerateKeyPair();
+      assertThat(!options.shouldGenerateKeyPair()).isTrue();
    }
 
    @Test
    public void testGenerateKeyPair() {
       NovaTemplateOptions options = new NovaTemplateOptions().generateKeyPair(true);
-      assert options.shouldGenerateKeyPair();
+      assertThat(options.shouldGenerateKeyPair()).isTrue();
    }
 
    @Test
    public void testGenerateKeyPairStatic() {
       NovaTemplateOptions options = generateKeyPair(true);
-      assert options.shouldGenerateKeyPair();
+      assertThat(options.shouldGenerateKeyPair()).isTrue();
    }
 
    // superclass tests

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/extensions/FloatingIPApiLiveTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/extensions/FloatingIPApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.openstack.nova.v2_0.extensions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -49,7 +50,7 @@ public class FloatingIPApiLiveTest extends BaseNovaApiLiveTest {
             continue;
          FloatingIPApi api = apiOption.get();
          Set<? extends FloatingIP> response = api.list().toSet();
-         assert null != response;
+         assertThat(null != response).isTrue();
          assertTrue(response.size() > 0);
          for (FloatingIP ip : response) {
             FloatingIP newDetails = api.get(ip.getId());

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/predicates/ImagePredicatesTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/predicates/ImagePredicatesTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.openstack.nova.v2_0.predicates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.openstack.nova.v2_0.predicates.ImagePredicates.statusEquals;
 
 import org.jclouds.openstack.nova.v2_0.domain.Image;
@@ -29,12 +30,12 @@ public class ImagePredicatesTest {
 
    @Test
    public void teststatusEqualsWhenEqual() {
-      assert statusEquals(Status.SAVING).apply(ref);
+      assertThat(statusEquals(Status.SAVING).apply(ref)).isTrue();
    }
 
    @Test
    public void teststatusEqualsWhenNotEqual() {
-      assert !statusEquals(Status.DELETED).apply(ref);
+      assertThat(!statusEquals(Status.DELETED).apply(ref)).isTrue();
    }
 
 }

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftBlobIntegrationLiveTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftBlobIntegrationLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.openstack.swift.v1.blobstore.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
 
 import java.util.Properties;
@@ -70,8 +71,8 @@ public class SwiftBlobIntegrationLiveTest extends BaseBlobIntegrationTest {
 
    @Override
    protected void checkContentLanguage(Blob blob, String contentLanguage) {
-      assert blob.getPayload().getContentMetadata().getContentLanguage() == null;
-      assert blob.getMetadata().getContentMetadata().getContentLanguage() == null;
+      assertThat(blob.getPayload().getContentMetadata().getContentLanguage() == null).isTrue();
+      assertThat(blob.getMetadata().getContentMetadata().getContentLanguage() == null).isTrue();
    }
 
    @Override

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/v1/features/LoadBalancerApiLiveTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/v1/features/LoadBalancerApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.rackspace.cloudloadbalancers.v1.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.rackspace.cloudloadbalancers.v1.predicates.LoadBalancerPredicates.awaitAvailable;
 import static org.jclouds.rackspace.cloudloadbalancers.v1.predicates.LoadBalancerPredicates.awaitDeleted;
 import static org.testng.Assert.assertEquals;
@@ -114,17 +115,17 @@ public class LoadBalancerApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
          for (LoadBalancer lb : response) {
             if (!lbs.contains(lb))
                continue;
-            assert lb.getRegion() != null : lb;
-            assert lb.getName() != null : lb;
-            assert lb.getId() != -1 : lb;
-            assert lb.getProtocol() != null : lb;
-            assert lb.getPort() != -1 : lb;
-            assert lb.getStatus() != null : lb;
-            assert lb.getCreated() != null : lb;
-            assert lb.getUpdated() != null : lb;
-            assert !lb.getVirtualIPs().isEmpty() : lb;
+            assertThat(lb.getRegion() != null).as(String.valueOf(lb)).isTrue();
+            assertThat(lb.getName() != null).as(String.valueOf(lb)).isTrue();
+            assertThat(lb.getId() != -1).as(String.valueOf(lb)).isTrue();
+            assertThat(lb.getProtocol() != null).as(String.valueOf(lb)).isTrue();
+            assertThat(lb.getPort() != -1).as(String.valueOf(lb)).isTrue();
+            assertThat(lb.getStatus() != null).as(String.valueOf(lb)).isTrue();
+            assertThat(lb.getCreated() != null).as(String.valueOf(lb)).isTrue();
+            assertThat(lb.getUpdated() != null).as(String.valueOf(lb)).isTrue();
+            assertThat(!lb.getVirtualIPs().isEmpty()).as(String.valueOf(lb)).isTrue();
             // node info not available during list;
-            assert lb.getNodes().size() == 0 : lb;
+            assertThat(lb.getNodes().size() == 0).as(String.valueOf(lb)).isTrue();
 
             LoadBalancer getDetails = api.getLoadBalancerApi(region).get(lb.getId());
 
@@ -139,7 +140,7 @@ public class LoadBalancerApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
                assertEquals(getDetails.getUpdated(), lb.getUpdated());
                assertEquals(getDetails.getVirtualIPs(), lb.getVirtualIPs());
                // node info not available during list;
-               assert !getDetails.getNodes().isEmpty() : lb;
+               assertThat(!getDetails.getNodes().isEmpty()).as(String.valueOf(lb)).isTrue();
             } catch (AssertionError e) {
                throw new AssertionError(String.format("%s\n%s - %s", e.getMessage(), getDetails, lb));
             }

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/v1/features/NodeApiLiveTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/v1/features/NodeApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.rackspace.cloudloadbalancers.v1.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.rackspace.cloudloadbalancers.v1.predicates.LoadBalancerPredicates.awaitAvailable;
 import static org.jclouds.rackspace.cloudloadbalancers.v1.predicates.LoadBalancerPredicates.awaitDeleted;
 import static org.testng.Assert.assertEquals;
@@ -106,16 +107,16 @@ public class NodeApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
    public void testListNodes() throws Exception {
       for (LoadBalancer lb : nodes.keySet()) {
          Set<Node> response = api.getNodeApi(lb.getRegion(), lb.getId()).list().concat().toSet();
-         assert null != response;
+         assertThat(null != response).isTrue();
          assertTrue(response.size() > 0);
          for (Node n : response) {
-            assert n.getId() != -1 : n;
-            assert n.getCondition() != null : n;
-            assert n.getAddress() != null : n;
-            assert n.getPort() != -1 : n;
-            assert n.getStatus() != null : n;
-            assert !Arrays.asList(LoadBalancer.WEIGHTED_ALGORITHMS).contains(lb.getAlgorithm())
-                     || n.getWeight() != null : n;
+            assertThat(n.getId() != -1).as(String.valueOf(n)).isTrue();
+            assertThat(n.getCondition() != null).as(String.valueOf(n)).isTrue();
+            assertThat(n.getAddress() != null).as(String.valueOf(n)).isTrue();
+            assertThat(n.getPort() != -1).as(String.valueOf(n)).isTrue();
+            assertThat(n.getStatus() != null).as(String.valueOf(n)).isTrue();
+            assertThat(!Arrays.asList(LoadBalancer.WEIGHTED_ALGORITHMS).contains(lb.getAlgorithm())
+                     || n.getWeight() != null).as(String.valueOf(n)).isTrue();
 
             Node getDetails = api.getNodeApi(lb.getRegion(), lb.getId()).get(n.getId());
 

--- a/apis/route53/src/test/java/org/jclouds/route53/predicates/HostedZonePredicatesTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/predicates/HostedZonePredicatesTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.route53.predicates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.route53.predicates.HostedZonePredicates.nameEquals;
 
 import org.jclouds.route53.domain.HostedZone;
@@ -27,11 +28,11 @@ public class HostedZonePredicatesTest {
 
    @Test
    public void testNameEqualsWhenEqual() {
-      assert nameEquals("jclouds.org.").apply(zone);
+      assertThat(nameEquals("jclouds.org.").apply(zone)).isTrue();
    }
 
    @Test
    public void testNameEqualsWhenNotEqual() {
-      assert !nameEquals("kclouds.org.").apply(zone);
+      assertThat(!nameEquals("kclouds.org.").apply(zone)).isTrue();
    }
 }

--- a/apis/route53/src/test/java/org/jclouds/route53/predicates/ResourceRecordSetPredicatesTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/predicates/ResourceRecordSetPredicatesTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.route53.predicates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.route53.predicates.ResourceRecordSetPredicates.typeEquals;
 
 import org.jclouds.route53.domain.ResourceRecordSet;
@@ -28,11 +29,11 @@ public class ResourceRecordSetPredicatesTest {
 
    @Test
    public void testTypeEqualsWhenEqual() {
-      assert typeEquals("NS").apply(rrs);
+      assertThat(typeEquals("NS").apply(rrs)).isTrue();
    }
 
    @Test
    public void testTypeEqualsWhenNotEqual() {
-      assert !typeEquals("AAAA").apply(rrs);
+      assertThat(!typeEquals("AAAA").apply(rrs)).isTrue();
    }
 }

--- a/apis/s3/src/test/java/org/jclouds/s3/PathBasedS3ClientExpectTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/PathBasedS3ClientExpectTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.s3;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.s3.reference.S3Constants.PROPERTY_S3_VIRTUAL_HOST_BUCKETS;
 
 import java.util.Properties;
@@ -49,10 +50,10 @@ public class PathBasedS3ClientExpectTest extends BaseS3ClientExpectTest {
                                                .build();
                                     
       S3Client clientWhenBucketExists = requestSendsResponse(bucketFooExists, HttpResponse.builder().statusCode(200).build());
-      assert clientWhenBucketExists.bucketExists("foo");
+      assertThat(clientWhenBucketExists.bucketExists("foo")).isTrue();
       
       S3Client clientWhenBucketDoesntExist = requestSendsResponse(bucketFooExists, HttpResponse.builder().statusCode(404).build());
-      assert !clientWhenBucketDoesntExist.bucketExists("foo");
+      assertThat(!clientWhenBucketDoesntExist.bucketExists("foo")).isTrue();
       
    }
 
@@ -66,7 +67,7 @@ public class PathBasedS3ClientExpectTest extends BaseS3ClientExpectTest {
                                                .build();
                                     
       S3Client clientWhenBucketExists = requestSendsResponse(bucketFooExists, HttpResponse.builder().statusCode(200).build());
-      assert clientWhenBucketExists.putBucketInRegion(null, "foo");
+      assertThat(clientWhenBucketExists.putBucketInRegion(null, "foo")).isTrue();
       
    }
    

--- a/apis/s3/src/test/java/org/jclouds/s3/S3ClientExpectTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/S3ClientExpectTest.java
@@ -18,6 +18,7 @@ package org.jclouds.s3;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.hash.Hashing.md5;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -48,10 +49,10 @@ public class S3ClientExpectTest extends BaseS3ClientExpectTest {
                   .build()).build();
       
       S3Client clientWhenBucketExists = requestSendsResponse(bucketFooExists, HttpResponse.builder().statusCode(200).build());
-      assert clientWhenBucketExists.bucketExists("foo");
+      assertThat(clientWhenBucketExists.bucketExists("foo")).isTrue();
       
       S3Client clientWhenBucketDoesntExist = requestSendsResponse(bucketFooExists, HttpResponse.builder().statusCode(404).build());
-      assert !clientWhenBucketDoesntExist.bucketExists("foo");
+      assertThat(!clientWhenBucketDoesntExist.bucketExists("foo")).isTrue();
       
    }
 

--- a/apis/s3/src/test/java/org/jclouds/s3/S3ClientLiveTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/S3ClientLiveTest.java
@@ -91,7 +91,7 @@ public class S3ClientLiveTest extends BaseBlobStoreIntegrationTest {
     */
    @Test(groups = { "integration", "live" })
    public void deleteContainerIfEmptyNotFound() throws Exception {
-      assert getApi().deleteBucketIfEmpty("dbienf");
+      assertThat(getApi().deleteBucketIfEmpty("dbienf")).isTrue();
    }
 
    @Test(groups = { "integration", "live" })
@@ -99,7 +99,7 @@ public class S3ClientLiveTest extends BaseBlobStoreIntegrationTest {
       String containerName = getContainerName();
       try {
          addBlobToContainer(containerName, "test");
-         assert !getApi().deleteBucketIfEmpty(containerName);
+         assertThat(!getApi().deleteBucketIfEmpty(containerName)).isTrue();
       } finally {
          returnContainer(containerName);
       }
@@ -298,7 +298,7 @@ public class S3ClientLiveTest extends BaseBlobStoreIntegrationTest {
             ExecutionException, TimeoutException, IOException {
       assertConsistencyAwareContainerSize(sourceContainer, 1);
       S3Object newObject = getApi().getObject(sourceContainer, key);
-      assert newObject != null;
+      assertThat(newObject != null).isTrue();
       assertEquals(Strings2.toStringAndClose(newObject.getPayload().openStream()), TEST_STRING);
       return newObject;
    }
@@ -325,15 +325,15 @@ public class S3ClientLiveTest extends BaseBlobStoreIntegrationTest {
    }
 
    protected void assertCacheControl(S3Object newObject, String string) {
-      assert newObject.getMetadata().getCacheControl().indexOf(string) != -1 : newObject.getMetadata()
-               .getCacheControl();
+      assertThat(newObject.getMetadata().getCacheControl().indexOf(string) != -1).as(newObject.getMetadata()
+               .getCacheControl()).isTrue();
    }
 
    protected void assertContentEncoding(S3Object newObject, String string) {
-      assert newObject.getPayload().getContentMetadata().getContentEncoding().indexOf(string) != -1 : newObject
-               .getPayload().getContentMetadata().getContentEncoding();
-      assert newObject.getMetadata().getContentMetadata().getContentEncoding().indexOf(string) != -1 : newObject
-               .getMetadata().getContentMetadata().getContentEncoding();
+      assertThat(newObject.getPayload().getContentMetadata().getContentEncoding().indexOf(string) != -1).as(newObject
+               .getPayload().getContentMetadata().getContentEncoding()).isTrue();
+      assertThat(newObject.getMetadata().getContentMetadata().getContentEncoding().indexOf(string) != -1).as(newObject
+               .getMetadata().getContentMetadata().getContentEncoding()).isTrue();
    }
 
    @Test(groups = { "integration", "live" })
@@ -533,7 +533,7 @@ public class S3ClientLiveTest extends BaseBlobStoreIntegrationTest {
 
          String eTag = getApi().completeMultipartUpload(containerName, key, uploadId, ImmutableMap.of(1, eTagOf1));
 
-         assert !eTagOf1.equals(eTag);
+         assertThat(!eTagOf1.equals(eTag)).isTrue();
 
          object = getApi().getObject(containerName, key);
          assertEquals(ByteStreams2.toByteArrayAndClose(object.getPayload().openStream()), buffer);

--- a/apis/s3/src/test/java/org/jclouds/s3/filters/RequestAuthorizeSignatureTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/filters/RequestAuthorizeSignatureTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.s3.filters;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import static org.jclouds.reflect.Reflection2.method;
 import static org.testng.Assert.assertEquals;
@@ -70,9 +71,9 @@ public class RequestAuthorizeSignatureTest extends BaseS3ClientTest<S3Client> {
          date = request.getFirstHeaderOrNull(HttpHeaders.DATE);
          request = filter.filter(request);
          if (request.getFirstHeaderOrNull(HttpHeaders.DATE).equals(date))
-            assert signature.equals(request.getFirstHeaderOrNull(HttpHeaders.AUTHORIZATION)) : String.format(
+            assertThat(signature.equals(request.getFirstHeaderOrNull(HttpHeaders.AUTHORIZATION))).as(String.format(
                      "sig: %s != %s on attempt %s", signature, request.getFirstHeaderOrNull(HttpHeaders.AUTHORIZATION),
-                     iterations);
+                     iterations)).isTrue();
          else
             iterations++;
 

--- a/apis/s3/src/test/java/org/jclouds/s3/options/CopyObjectOptionsTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/options/CopyObjectOptionsTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.s3.options;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.s3.options.CopyObjectOptions.Builder.ifSourceETagDoesntMatch;
 import static org.jclouds.s3.options.CopyObjectOptions.Builder.ifSourceETagMatches;
 import static org.jclouds.s3.options.CopyObjectOptions.Builder.ifSourceModifiedSince;
@@ -78,8 +79,8 @@ public class CopyObjectOptionsTest {
    }
 
    private void assertGoodMeta(CopyObjectOptions options) {
-      assert options != null;
-      assert options.getMetadata() != null;
+      assertThat(options != null).isTrue();
+      assertThat(options.getMetadata() != null).isTrue();
       Multimap<String, String> headers = options.buildRequestHeaders();
       assertEquals(headers.size(), 2);
       assertEquals(headers.get(METADATA_DIRECTIVE).iterator().next(), "REPLACE");
@@ -272,7 +273,7 @@ public class CopyObjectOptionsTest {
       options.setHeaderTag(DEFAULT_AMAZON_HEADERTAG);
 
       options.setMetadataPrefix(USER_METADATA_PREFIX);
-      assert options.buildRequestHeaders() != null;
+      assertThat(options.buildRequestHeaders() != null).isTrue();
    }
 
    @Test

--- a/apis/s3/src/test/java/org/jclouds/s3/options/ListBucketOptionsTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/options/ListBucketOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.s3.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.s3.options.ListBucketOptions.Builder.afterMarker;
 import static org.jclouds.s3.options.ListBucketOptions.Builder.delimiter;
 import static org.jclouds.s3.options.ListBucketOptions.Builder.maxResults;
@@ -36,8 +37,8 @@ public class ListBucketOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(ListBucketOptions.class);
-      assert !String.class.isAssignableFrom(ListBucketOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(ListBucketOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(ListBucketOptions.class)).isTrue();
    }
 
    @Test

--- a/apis/s3/src/test/java/org/jclouds/s3/services/BucketsLiveTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/services/BucketsLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.s3.services;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.s3.S3ClientLiveTest.TEST_ACL_EMAIL;
 import static org.jclouds.s3.S3ClientLiveTest.TEST_ACL_ID;
 import static org.jclouds.s3.domain.AccessControlList.GroupGranteeURI.ALL_USERS;
@@ -79,7 +80,7 @@ public class BucketsLiveTest extends BaseBlobStoreIntegrationTest {
     */
    @Test(groups = { "integration", "live" })
    public void deleteBucketIfEmptyNotFound() throws Exception {
-      assert getApi().deleteBucketIfEmpty("dbienf");
+      assertThat(getApi().deleteBucketIfEmpty("dbienf")).isTrue();
    }
 
    @Test(groups = { "integration", "live" })
@@ -87,7 +88,7 @@ public class BucketsLiveTest extends BaseBlobStoreIntegrationTest {
       String bucketName = getContainerName();
       try {
          addBlobToContainer(bucketName, "test");
-         assert !getApi().deleteBucketIfEmpty(bucketName);
+         assertThat(!getApi().deleteBucketIfEmpty(bucketName)).isTrue();
       } finally {
          returnContainer(bucketName);
       }
@@ -223,7 +224,7 @@ public class BucketsLiveTest extends BaseBlobStoreIntegrationTest {
             public void run() {
                try {
                   BucketLogging newLogging = getApi().getBucketLogging(bucketName);
-                  assert newLogging != null;
+                  assertThat(newLogging != null).isTrue();
                   AccessControlList acl = new AccessControlList();
                   for (Grant grant : newLogging.getTargetGrants()) { // TODO: add permission
                      // checking features to
@@ -269,7 +270,7 @@ public class BucketsLiveTest extends BaseBlobStoreIntegrationTest {
          Set<BucketMetadata> list = getApi().listOwnedBuckets();
          BucketMetadata firstBucket = Iterables.get(list, 0);
          BucketMetadata toMatch = new BucketMetadata(bucketName, new Date(), firstBucket.getOwner());
-         assert list.contains(toMatch);
+         assertThat(list.contains(toMatch)).isTrue();
       } finally {
          returnContainer(bucketName);
       }
@@ -290,7 +291,7 @@ public class BucketsLiveTest extends BaseBlobStoreIntegrationTest {
          addAlphabetUnderRoot(bucketName);
          ListBucketResponse bucket = getApi().listBucket(bucketName, afterMarker("y"));
          assertEquals(bucket.getMarker(), "y");
-         assert !bucket.isTruncated();
+         assertThat(!bucket.isTruncated()).isTrue();
          assertEquals(bucket.size(), 1);
       } finally {
          returnContainer(bucketName);
@@ -305,7 +306,7 @@ public class BucketsLiveTest extends BaseBlobStoreIntegrationTest {
          add15UnderRoot(bucketName);
          ListBucketResponse bucket = getApi().listBucket(bucketName, delimiter("/"));
          assertEquals(bucket.getDelimiter(), "/");
-         assert !bucket.isTruncated();
+         assertThat(!bucket.isTruncated()).isTrue();
          assertEquals(bucket.size(), 15);
          assertEquals(bucket.getCommonPrefixes().size(), 1);
       } finally {
@@ -322,7 +323,7 @@ public class BucketsLiveTest extends BaseBlobStoreIntegrationTest {
          add15UnderRoot(bucketName);
 
          ListBucketResponse bucket = getApi().listBucket(bucketName, withPrefix("apps/"));
-         assert !bucket.isTruncated();
+         assertThat(!bucket.isTruncated()).isTrue();
          assertEquals(bucket.size(), 10);
          assertEquals(bucket.getPrefix(), "apps/");
       } finally {
@@ -337,7 +338,7 @@ public class BucketsLiveTest extends BaseBlobStoreIntegrationTest {
          addAlphabetUnderRoot(bucketName);
          ListBucketResponse bucket = getApi().listBucket(bucketName, maxResults(5));
          assertEquals(bucket.getMaxKeys(), 5);
-         assert bucket.isTruncated();
+         assertThat(bucket.isTruncated()).isTrue();
          assertEquals(bucket.size(), 5);
       } finally {
          returnContainer(bucketName);

--- a/apis/s3/src/test/java/org/jclouds/s3/xml/CopyObjectHandlerTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/xml/CopyObjectHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.s3.xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -45,7 +46,7 @@ public class CopyObjectHandlerTest extends BaseHandlerTest {
    protected void setUpInjector() {
       super.setUpInjector();
       dateService = injector.getInstance(DateService.class);
-      assert dateService != null;
+      assertThat(dateService != null).isTrue();
    }
 
    public void testApplyInputStream() {

--- a/apis/s3/src/test/java/org/jclouds/s3/xml/ListBucketHandlerTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/xml/ListBucketHandlerTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.s3.xml;
 
 import static com.google.common.io.BaseEncoding.base16;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -122,7 +123,7 @@ public class ListBucketHandlerTest extends BaseHandlerTest {
                Strings2.toInputStream(listBucketWithSlashDelimiterAndCommonPrefixApps));
       assertEquals(bucket.getCommonPrefixes().iterator().next(), "apps/");
       assertEquals(bucket.getDelimiter(), "/");
-      assert bucket.getMarker() == null;
+      assertThat(bucket.getMarker() == null).isTrue();
    }
 
    @Test
@@ -131,7 +132,7 @@ public class ListBucketHandlerTest extends BaseHandlerTest {
       ListBucketResponse bucket = createParser().parse(Strings2.toInputStream(listBucketWithPrefixAppsSlash));
       assertEquals(bucket.getPrefix(), "apps/");
       assertEquals(bucket.getMaxKeys(), 1000);
-      assert bucket.getMarker() == null;
+      assertThat(bucket.getMarker() == null).isTrue();
    }
 
    /**

--- a/apis/s3/src/test/java/org/jclouds/s3/xml/S3ParserTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/xml/S3ParserTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.s3.xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
@@ -60,7 +61,7 @@ public class S3ParserTest extends PerformanceTest {
    protected void setUpInjector() {
       injector = Guice.createInjector(new SaxParserModule());
       factory = injector.getInstance(ParseSax.Factory.class);
-      assert factory != null;
+      assertThat(factory != null).isTrue();
    }
 
    @AfterTest
@@ -92,46 +93,46 @@ public class S3ParserTest extends PerformanceTest {
             }
          });
       for (int i = 0; i < LOOP_COUNT; i++)
-         assert completer.take().get() != null;
+         assertThat(completer.take().get() != null).isTrue();
    }
 
    @Test
    public void testCanParseListAllMyBuckets() throws HttpException {
       Set<BucketMetadata> s3Buckets = runParseListAllMyBuckets();
       BucketMetadata container1 = Iterables.get(s3Buckets, 0);
-      assert container1.getName().equals("adrianjbosstest");
+      assertThat(container1.getName().equals("adrianjbosstest")).isTrue();
       Date expectedDate1 = new SimpleDateFormatDateService().iso8601DateParse("2009-03-12T02:00:07.000Z");
       Date date1 = container1.getCreationDate();
-      assert date1.equals(expectedDate1);
+      assertThat(date1.equals(expectedDate1)).isTrue();
       BucketMetadata container2 = (BucketMetadata) s3Buckets.toArray()[1];
-      assert container2.getName().equals("adrianjbosstest2");
+      assertThat(container2.getName().equals("adrianjbosstest2")).isTrue();
       Date expectedDate2 = new SimpleDateFormatDateService().iso8601DateParse("2009-03-12T02:00:09.000Z");
       Date date2 = container2.getCreationDate();
-      assert date2.equals(expectedDate2);
-      assert s3Buckets.size() == 2;
+      assertThat(date2.equals(expectedDate2)).isTrue();
+      assertThat(s3Buckets.size() == 2).isTrue();
       CanonicalUser owner = new CanonicalUser("e1a5f66a480ca99a4fdfe8e318c3020446c9989d7004e7778029fbcc5d990fa0");
-      assert container1.getOwner().equals(owner);
-      assert container2.getOwner().equals(owner);
+      assertThat(container1.getOwner().equals(owner)).isTrue();
+      assertThat(container2.getOwner().equals(owner)).isTrue();
    }
 
    public static final String listContainerResult = "<ListContainerHandler xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>adrianjbosstest</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Contents><Key>3366</Key><LastModified>2009-03-12T02:00:13.000Z</LastModified><ETag>&quot;9d7bb64e8e18ee34eec06dd2cf37b766&quot;</ETag><Size>136</Size><Owner><ID>e1a5f66a480ca99a4fdfe8e318c3020446c9989d7004e7778029fbcc5d990fa0</ID><DisplayName>ferncam</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListContainerHandler>";
 
    public void testCanParseListContainerResult() throws HttpException {
       ListBucketResponse container = runParseListContainerResult();
-      assert !container.isTruncated();
-      assert container.getName().equals("adrianjbosstest");
-      assert container.size() == 1;
+      assertThat(!container.isTruncated()).isTrue();
+      assertThat(container.getName().equals("adrianjbosstest")).isTrue();
+      assertThat(container.size() == 1).isTrue();
       ObjectMetadata object = container.iterator().next();
-      assert object.getKey().equals("3366");
+      assertThat(object.getKey().equals("3366")).isTrue();
       Date expected = new SimpleDateFormatDateService().iso8601DateParse("2009-03-12T02:00:13.000Z");
-      assert object.getLastModified().equals(expected) : String.format("expected %1$s, but got %1$s", expected, object
-               .getLastModified());
+      assertThat(object.getLastModified().equals(expected)).as(String.format("expected %1$s, but got %1$s", expected, object
+               .getLastModified())).isTrue();
       assertEquals(object.getETag(), "\"9d7bb64e8e18ee34eec06dd2cf37b766\"");
-      assert object.getContentMetadata().getContentLength() == 136;
+      assertThat(object.getContentMetadata().getContentLength() == 136).isTrue();
       CanonicalUser owner = new CanonicalUser("e1a5f66a480ca99a4fdfe8e318c3020446c9989d7004e7778029fbcc5d990fa0");
       owner.setDisplayName("ferncam");
-      assert object.getOwner().equals(owner);
-      assert object.getStorageClass().equals(StorageClass.STANDARD);
+      assertThat(object.getOwner().equals(owner)).isTrue();
+      assertThat(object.getStorageClass().equals(StorageClass.STANDARD)).isTrue();
    }
 
    private ListBucketResponse runParseListContainerResult() throws HttpException {
@@ -170,7 +171,7 @@ public class S3ParserTest extends PerformanceTest {
             }
          });
       for (int i = 0; i < LOOP_COUNT; i++)
-         assert completer.take().get() != null;
+         assertThat(completer.take().get() != null).isTrue();
    }
 
 }

--- a/apis/sqs/src/test/java/org/jclouds/sqs/internal/BaseSQSApiLiveTest.java
+++ b/apis/sqs/src/test/java/org/jclouds/sqs/internal/BaseSQSApiLiveTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.sqs.internal;
 
 import static com.google.common.collect.Iterables.get;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -103,7 +104,7 @@ public class BaseSQSApiLiveTest extends BaseApiLiveTest<SQSApi> {
          public void run() {
             FluentIterable<URI> result = api.getQueueApiForRegion(region).list();
             assertNotNull(result);
-            assert result.size() >= 1 : result;
+            assertThat(result.size() >= 1).as(String.valueOf(result)).isTrue();
             assertTrue(result.contains(finalQ), finalQ + " not in " + result);
          }
       });

--- a/apis/sqs/src/test/java/org/jclouds/sqs/options/ListQueuesOptionsTest.java
+++ b/apis/sqs/src/test/java/org/jclouds/sqs/options/ListQueuesOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.sqs.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.sqs.options.ListQueuesOptions.Builder.queuePrefix;
 import static org.testng.Assert.assertEquals;
 
@@ -31,8 +32,8 @@ public class ListQueuesOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(ListQueuesOptions.class);
-      assert !String.class.isAssignableFrom(ListQueuesOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(ListQueuesOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(ListQueuesOptions.class)).isTrue();
    }
 
    @Test

--- a/apis/sts/src/test/java/org/jclouds/aws/handlers/AWSClientErrorRetryHandlerTest.java
+++ b/apis/sts/src/test/java/org/jclouds/aws/handlers/AWSClientErrorRetryHandlerTest.java
@@ -18,6 +18,7 @@ package org.jclouds.aws.handlers;
 import static javax.ws.rs.HttpMethod.PUT;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -52,7 +53,7 @@ public class AWSClientErrorRetryHandlerTest {
       AWSClientErrorRetryHandler retry = new AWSClientErrorRetryHandler(utils, backoffLimitedRetryHandler,
             ImmutableSet.<String> of());
 
-      assert !retry.shouldRetryRequest(command, HttpResponse.builder().statusCode(UNAUTHORIZED.getStatusCode()).build());
+      assertThat(!retry.shouldRetryRequest(command, HttpResponse.builder().statusCode(UNAUTHORIZED.getStatusCode()).build())).isTrue();
 
       verify(utils, backoffLimitedRetryHandler, command);
 
@@ -90,7 +91,7 @@ public class AWSClientErrorRetryHandlerTest {
       AWSClientErrorRetryHandler retry = new AWSClientErrorRetryHandler(utils, backoffLimitedRetryHandler,
             ImmutableSet.<String> of("RequestTimeout", "OperationAborted", "SignatureDoesNotMatch"));
 
-      assert retry.shouldRetryRequest(command, operationAborted);
+      assertThat(retry.shouldRetryRequest(command, operationAborted)).isTrue();
 
       verify(utils, backoffLimitedRetryHandler, command);
 

--- a/apis/sts/src/test/java/org/jclouds/aws/handlers/AWSServerErrorRetryHandlerTest.java
+++ b/apis/sts/src/test/java/org/jclouds/aws/handlers/AWSServerErrorRetryHandlerTest.java
@@ -18,6 +18,7 @@ package org.jclouds.aws.handlers;
 import static javax.ws.rs.HttpMethod.PUT;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -108,7 +109,7 @@ public class AWSServerErrorRetryHandlerTest {
       AWSServerErrorRetryHandler retry = new AWSServerErrorRetryHandler(utils,
             ImmutableSet.of("RequestLimitExceeded", "InternalError"));
 
-      assert retry.shouldRetryRequest(command, response);
+      assertThat(retry.shouldRetryRequest(command, response)).isTrue();
 
       verify(utils, command);
 

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/CommonSwiftClientLiveTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/CommonSwiftClientLiveTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.openstack.swift;
 
 import static com.google.common.io.BaseEncoding.base16;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.openstack.swift.options.ListContainerOptions.Builder.underPath;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -170,9 +171,9 @@ public abstract class CommonSwiftClientLiveTest<C extends CommonSwiftClient> ext
          assertEquals(Iterables.get(response, 0).getName(), containerName + ".hello");
 
          String containerName2 = containerName + "?should-be-illegal-question-char";
-         assert getApi().createContainer(containerName2);
+         assertThat(getApi().createContainer(containerName2)).isTrue();
 
-         assert getApi().createContainer(containerName + "/illegal-slash-char");
+         assertThat(getApi().createContainer(containerName + "/illegal-slash-char")).isTrue();
 
          assertTrue(getApi().deleteContainerIfEmpty(containerName1));
          assertTrue(getApi().deleteContainerIfEmpty(containerName2));
@@ -191,11 +192,11 @@ public abstract class CommonSwiftClientLiveTest<C extends CommonSwiftClient> ext
          getApi().putObject(containerName, newSwiftObject(data, "path/bar"));
 
          PageSet<ObjectInfo> container = getApi().listObjects(containerName, underPath(""));
-         assert container.getNextMarker() == null;
+         assertThat(container.getNextMarker() == null).isTrue();
          assertEquals(container.size(), 1);
          assertEquals(Iterables.get(container, 0).getName(), "foo");
          container = getApi().listObjects(containerName, underPath("path"));
-         assert container.getNextMarker() == null;
+         assertThat(container.getNextMarker() == null).isTrue();
          assertEquals(container.size(), 1);
          assertEquals(Iterables.get(container, 0).getName(), "path/bar");
       } finally {
@@ -214,20 +215,20 @@ public abstract class CommonSwiftClientLiveTest<C extends CommonSwiftClient> ext
          SwiftObject object = newSwiftObject(data, key);
          byte[] md5 = object.getPayload().getContentMetadata().getContentMD5();
          String newEtag = getApi().putObject(containerName, object);
-         assert newEtag != null;
+         assertThat(newEtag != null).isTrue();
 
          assertEquals(base16().lowerCase().encode(md5), base16().lowerCase().encode(object.getPayload().getContentMetadata()
                   .getContentMD5()));
 
          // Test HEAD of missing object
-         assert getApi().getObjectInfo(containerName, "non-existent-object") == null;
+         assertThat(getApi().getObjectInfo(containerName, "non-existent-object") == null).isTrue();
 
          // Test HEAD of object
          MutableObjectInfoWithMetadata metadata = getApi().getObjectInfo(containerName, object.getInfo().getName());
          assertEquals(metadata.getName(), object.getInfo().getName());
 
          assertEquals(metadata.getBytes(), Long.valueOf(data.length()));
-         assert metadata.getContentType().startsWith("text/plain") : metadata.getContentType();
+         assertThat(metadata.getContentType().startsWith("text/plain")).as(metadata.getContentType()).isTrue();
 
          assertEquals(base16().lowerCase().encode(md5), base16().lowerCase().encode(metadata.getHash()));
          assertEquals(metadata.getHash(), base16().lowerCase().decode(newEtag));
@@ -241,7 +242,7 @@ public abstract class CommonSwiftClientLiveTest<C extends CommonSwiftClient> ext
          assertTrue(getApi().setObjectInfo(containerName, object.getInfo().getName(), userMetadata));
 
          // Test GET of missing object
-         assert getApi().getObject(containerName, "non-existent-object") == null;
+         assertThat(getApi().getObject(containerName, "non-existent-object") == null).isTrue();
          // Test GET of object (including updated metadata)
          SwiftObject getBlob = getApi().getObject(containerName, object.getInfo().getName());
          assertEquals(Strings2.toStringAndClose(getBlob.getPayload().openStream()), data);
@@ -356,7 +357,7 @@ public abstract class CommonSwiftClientLiveTest<C extends CommonSwiftClient> ext
    
    protected void testGetObjectContentType(SwiftObject getBlob) {
        String contentType = getBlob.getPayload().getContentMetadata().getContentType();
-       assert contentType.startsWith("text/plain") || "application/x-www-form-urlencoded".equals(contentType) : contentType;
+       assertThat(contentType.startsWith("text/plain") || "application/x-www-form-urlencoded".equals(contentType)).as(contentType).isTrue();
    }
 
    protected SwiftObject newSwiftObject(String data, String key) throws IOException {

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/blobstore/integration/SwiftBlobIntegrationLiveTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/blobstore/integration/SwiftBlobIntegrationLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.openstack.swift.blobstore.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
@@ -99,8 +100,8 @@ public class SwiftBlobIntegrationLiveTest extends BaseBlobIntegrationTest {
    // not supported in swift
    @Override
    protected void checkContentLanguage(Blob blob, String contentLanguage) {
-      assert blob.getPayload().getContentMetadata().getContentLanguage() == null;
-      assert blob.getMetadata().getContentMetadata().getContentLanguage() == null;
+      assertThat(blob.getPayload().getContentMetadata().getContentLanguage() == null).isTrue();
+      assertThat(blob.getMetadata().getContentMetadata().getContentLanguage() == null).isTrue();
    }
 
    // swift doesn't support quotes

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/options/ListContainerOptionsTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/options/ListContainerOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.openstack.swift.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.openstack.swift.options.ListContainerOptions.Builder.afterMarker;
 import static org.jclouds.openstack.swift.options.ListContainerOptions.Builder.maxResults;
 import static org.jclouds.openstack.swift.options.ListContainerOptions.Builder.underPath;
@@ -36,8 +37,8 @@ public class ListContainerOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(ListContainerOptions.class);
-      assert !String.class.isAssignableFrom(ListContainerOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(ListContainerOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(ListContainerOptions.class)).isTrue();
    }
 
    @Test

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
@@ -152,7 +152,7 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
          }
          Map<Integer, Exception> exceptions = awaitCompletion(responses, exec, 30000l, Logger.CONSOLE,
                   "putFileParallel");
-         assert exceptions.size() == 0 : exceptions;
+         assertThat(exceptions.size() == 0).as(String.valueOf(exceptions)).isTrue();
 
       } finally {
          payloadFile.delete();
@@ -482,7 +482,7 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
       String container = getContainerName();
       String name = "test";
       try {
-         assert !view.getBlobStore().blobExists(container, name);
+         assertThat(!view.getBlobStore().blobExists(container, name)).isTrue();
       } finally {
          returnContainer(container);
       }
@@ -583,7 +583,7 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
          String returnedString = getContentAsStringOrNullAndClose(blob);
          assertEquals(returnedString, realObject);
          PageSet<? extends StorageMetadata> set = view.getBlobStore().list(container);
-         assert set.size() == 1 : set;
+         assertThat(set.size() == 1).as(String.valueOf(set)).isTrue();
       } finally {
          returnContainer(container);
       }
@@ -609,7 +609,7 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
          validateMetadata(blob.getMetadata(), container, blob.getMetadata().getName());
          checkContentMetadata(blob);
          PageSet<? extends StorageMetadata> set = view.getBlobStore().list(container);
-         assert set.size() == 1 : set;
+         assertThat(set.size() == 1).as(String.valueOf(set)).isTrue();
       } finally {
          returnContainer(container);
       }
@@ -732,32 +732,32 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
    }
 
    protected void checkContentType(Blob blob, String contentType) {
-      assert blob.getPayload().getContentMetadata().getContentType().startsWith(contentType) : blob.getPayload()
-               .getContentMetadata().getContentType();
-      assert blob.getMetadata().getContentMetadata().getContentType().startsWith(contentType) : blob.getMetadata()
-               .getContentMetadata().getContentType();
+      assertThat(blob.getPayload().getContentMetadata().getContentType().startsWith(contentType)).as(blob.getPayload()
+               .getContentMetadata().getContentType()).isTrue();
+      assertThat(blob.getMetadata().getContentMetadata().getContentType().startsWith(contentType)).as(blob.getMetadata()
+               .getContentMetadata().getContentType()).isTrue();
    }
 
    protected void checkContentDisposition(Blob blob, String contentDisposition) {
-      assert blob.getPayload().getContentMetadata().getContentDisposition().startsWith(contentDisposition) : blob
-               .getPayload().getContentMetadata().getContentDisposition();
-      assert blob.getMetadata().getContentMetadata().getContentDisposition().startsWith(contentDisposition) : blob
-               .getMetadata().getContentMetadata().getContentDisposition();
+      assertThat(blob.getPayload().getContentMetadata().getContentDisposition().startsWith(contentDisposition)).as(blob
+               .getPayload().getContentMetadata().getContentDisposition()).isTrue();
+      assertThat(blob.getMetadata().getContentMetadata().getContentDisposition().startsWith(contentDisposition)).as(blob
+               .getMetadata().getContentMetadata().getContentDisposition()).isTrue();
 
    }
 
    protected void checkContentEncoding(Blob blob, String contentEncoding) {
-      assert blob.getPayload().getContentMetadata().getContentEncoding().indexOf(contentEncoding) != -1 : blob
-               .getPayload().getContentMetadata().getContentEncoding();
-      assert blob.getMetadata().getContentMetadata().getContentEncoding().indexOf(contentEncoding) != -1 : blob
-               .getMetadata().getContentMetadata().getContentEncoding();
+      assertThat(blob.getPayload().getContentMetadata().getContentEncoding().indexOf(contentEncoding) != -1).as(blob
+               .getPayload().getContentMetadata().getContentEncoding()).isTrue();
+      assertThat(blob.getMetadata().getContentMetadata().getContentEncoding().indexOf(contentEncoding) != -1).as(blob
+               .getMetadata().getContentMetadata().getContentEncoding()).isTrue();
    }
 
    protected void checkContentLanguage(Blob blob, String contentLanguage) {
-      assert blob.getPayload().getContentMetadata().getContentLanguage().startsWith(contentLanguage) : blob
-               .getPayload().getContentMetadata().getContentLanguage();
-      assert blob.getMetadata().getContentMetadata().getContentLanguage().startsWith(contentLanguage) : blob
-               .getMetadata().getContentMetadata().getContentLanguage();
+      assertThat(blob.getPayload().getContentMetadata().getContentLanguage().startsWith(contentLanguage)).as(blob
+               .getPayload().getContentMetadata().getContentLanguage()).isTrue();
+      assertThat(blob.getMetadata().getContentMetadata().getContentLanguage().startsWith(contentLanguage)).as(blob
+               .getMetadata().getContentMetadata().getContentLanguage()).isTrue();
    }
 
    protected static volatile Crypto crypto;
@@ -1008,8 +1008,8 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
    }
 
    protected void validateMetadata(BlobMetadata metadata) throws IOException {
-      assert metadata.getContentMetadata().getContentType().startsWith("text/plain") : metadata.getContentMetadata()
-               .getContentType();
+      assertThat(metadata.getContentMetadata().getContentType().startsWith("text/plain")).as(metadata.getContentMetadata()
+               .getContentType()).isTrue();
       assertEquals(metadata.getContentMetadata().getContentLength(), Long.valueOf(TEST_STRING.length()));
       assertEquals(metadata.getUserMetadata().get("adrian"), "powderpuff");
       checkMD5(metadata);

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobSignerLiveTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobSignerLiveTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.blobstore.integration.internal;
 
 import static com.google.common.net.HttpHeaders.EXPECT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.blobstore.options.GetOptions.Builder.range;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
@@ -175,7 +176,7 @@ public class BaseBlobSignerLiveTest extends BaseBlobStoreIntegrationTest {
          HttpRequest request = view.getSigner().signRemoveBlob(container, name);
          assertEquals(request.getFilters().size(), 0);
          view.utils().http().invoke(request);
-         assert !view.getBlobStore().blobExists(container, name);
+         assertThat(!view.getBlobStore().blobExists(container, name)).isTrue();
       } finally {
          returnContainer(container);
       }

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobStoreIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobStoreIntegrationTest.java
@@ -18,6 +18,7 @@ package org.jclouds.blobstore.integration.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Throwables.propagateIfPossible;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.reflect.Reflection2.typeToken;
 import static org.testng.Assert.assertEquals;
 
@@ -297,7 +298,7 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
    protected Blob validateContent(String container, String name) throws InterruptedException {
       assertConsistencyAwareContainerSize(container, 1);
       Blob newObject = view.getBlobStore().getBlob(container, name);
-      assert newObject != null;
+      assertThat(newObject != null).isTrue();
       validateMetadata(newObject.getMetadata(), container, name);
       try {
          assertEquals(getContentAsStringOrNullAndClose(newObject), TEST_STRING);
@@ -312,7 +313,7 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
       assertConsistencyAware(new Runnable() {
          public void run() {
             try {
-               assert view.getBlobStore().countBlobs(containerName) == count : String.format(
+               assertThat(view.getBlobStore().countBlobs(containerName) == count).as(String.format(
                      "expected only %d values in %s: %s", count, containerName, ImmutableSet.copyOf(Iterables
                            .transform(view.getBlobStore().list(containerName),
                                  new Function<StorageMetadata, String>() {
@@ -321,7 +322,7 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
                                        return from.getName();
                                     }
 
-                                 })));
+                                 })))).isTrue();
             } catch (Exception e) {
                Throwables.propagateIfPossible(e);
             }
@@ -334,7 +335,7 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
       assertConsistencyAware(new Runnable() {
          public void run() {
             try {
-               assert view.getBlobStore().blobExists(containerName, name) : String.format(
+               assertThat(view.getBlobStore().blobExists(containerName, name)).as(String.format(
                      "could not find %s in %s: %s", name, containerName, ImmutableSet.copyOf(Iterables.transform(
                            view.getBlobStore().list(containerName), new Function<StorageMetadata, String>() {
 
@@ -342,7 +343,7 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
                                  return from.getName();
                               }
 
-                           })));
+                           })))).isTrue();
             } catch (Exception e) {
                Throwables.propagateIfPossible(e);
             }
@@ -355,8 +356,8 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
       assertConsistencyAware(new Runnable() {
          public void run() {
             try {
-               assert !view.getBlobStore().blobExists(containerName, name) : String.format("found %s in %s", name,
-                     containerName);
+               assertThat(!view.getBlobStore().blobExists(containerName, name)).as(String.format("found %s in %s", name,
+                     containerName)).isTrue();
             } catch (Exception e) {
                Throwables.propagateIfPossible(e);
             }
@@ -368,7 +369,7 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
       assertConsistencyAware(new Runnable() {
          public void run() {
             try {
-               assert view.getBlobStore().containerExists(containerName) : String.format("container %s doesn't exist", containerName);
+               assertThat(view.getBlobStore().containerExists(containerName)).as(String.format("container %s doesn't exist", containerName)).isTrue();
             } catch (Exception e) {
                Throwables.propagate(e);
             }
@@ -391,8 +392,8 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
                });
                Location actualLoc = container.getLocation();
 
-               assert loc.equals(actualLoc) : String.format("blob %s, in location %s instead of %s", containerName,
-                        actualLoc, loc);
+               assertThat(loc.equals(actualLoc)).as(String.format("blob %s, in location %s instead of %s", containerName,
+                        actualLoc, loc)).isTrue();
             } catch (Exception e) {
                Throwables.propagate(e);
             }
@@ -407,8 +408,8 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
             try {
                Blob blob = view.getBlobStore().getBlob(containerName, blobName);
                Date actualExpires = blob.getPayload().getContentMetadata().getExpires();
-               assert expectedExpires.equals(actualExpires) : "expires=" + actualExpires + "; expected="
-                        + expectedExpires;
+               assertThat(expectedExpires.equals(actualExpires)).as("expires=" + actualExpires + "; expected="
+                        + expectedExpires).isTrue();
             } catch (Exception e) {
                Throwables.propagateIfPossible(e);
             }
@@ -423,8 +424,8 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
             try {
                Location actualLoc = view.getBlobStore().getBlob(containerName, blobName).getMetadata().getLocation();
 
-               assert loc.equals(actualLoc) : String.format(
-                     "blob %s in %s, in location %s instead of %s", blobName, containerName, actualLoc, loc);
+               assertThat(loc.equals(actualLoc)).as(String.format(
+                     "blob %s in %s, in location %s instead of %s", blobName, containerName, actualLoc, loc)).isTrue();
             } catch (Exception e) {
                Throwables.propagate(e);
             }
@@ -434,7 +435,7 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
 
    public String getContainerName() throws InterruptedException {
       String containerName = containerNames.poll(30, TimeUnit.SECONDS);
-      assert containerName != null : "unable to get a container for the test";
+      assertThat(containerName != null).as("unable to get a container for the test").isTrue();
       createContainerAndEnsureEmpty(containerName);
       return containerName;
    }
@@ -477,8 +478,8 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
       assertConsistencyAware(new Runnable() {
          public void run() {
             try {
-               assert !view.getBlobStore().containerExists(containerName) : "container " + containerName
-                     + " still exists";
+               assertThat(!view.getBlobStore().containerExists(containerName)).as("container " + containerName
+                     + " still exists").isTrue();
             } catch (Exception e) {
                propagateIfPossible(e);
             }

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
@@ -58,8 +58,8 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
 
    @Test(groups = { "integration", "live" })
    public void containerDoesntExist() {
-      assert !view.getBlobStore().containerExists("forgetaboutit");
-      assert !view.getBlobStore().containerExists("cloudcachestorefunctionalintegrationtest-first");
+      assertThat(!view.getBlobStore().containerExists("forgetaboutit")).isTrue();
+      assertThat(!view.getBlobStore().containerExists("cloudcachestorefunctionalintegrationtest-first")).isTrue();
    }
 
    @Test(groups = { "integration", "live" })
@@ -143,8 +143,8 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
 
          BlobMetadata metadata = BlobMetadata.class.cast(get(container, 0));
 
-         assert metadata.getContentMetadata().getContentType().startsWith("text/plain") : metadata.getContentMetadata()
-               .getContentType();
+         assertThat(metadata.getContentMetadata().getContentType().startsWith("text/plain")).as(metadata.getContentMetadata()
+               .getContentType()).isTrue();
          assertEquals(metadata.getContentMetadata().getContentLength(), Long.valueOf(TEST_STRING.length()));
          assertEquals(metadata.getUserMetadata().get("adrian"), "powderpuff");
          checkMD5(metadata);
@@ -177,15 +177,15 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
 
          PageSet<? extends StorageMetadata> container = view.getBlobStore().list(containerName, maxResults(1));
 
-         assert container.getNextMarker() != null;
+         assertThat(container.getNextMarker() != null).isTrue();
          assertEquals(container.size(), 1);
          String marker = container.getNextMarker();
 
          container = view.getBlobStore().list(containerName, afterMarker(marker));
          assertEquals(container.getNextMarker(), null);
-         assert container.size() == 25 : String.format("size should have been 25, but was %d: %s", container.size(),
-               container);
-         assert container.getNextMarker() == null;
+         assertThat(container.size() == 25).as(String.format("size should have been 25, but was %d: %s", container.size(),
+               container)).isTrue();
+         assertThat(container.getNextMarker() == null).isTrue();
       } finally {
          returnContainer(containerName);
       }
@@ -200,7 +200,7 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
          add15UnderRoot(containerName);
          awaitConsistency();
          PageSet<? extends StorageMetadata> container = view.getBlobStore().list(containerName);
-         assert container.getNextMarker() == null;
+         assertThat(container.getNextMarker() == null).isTrue();
          assertEquals(container.size(), 16);
       } finally {
          returnContainer(containerName);
@@ -214,21 +214,21 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
       try {
          String directory = "directory";
 
-         assert !view.getBlobStore().directoryExists(containerName, directory);
+         assertThat(!view.getBlobStore().directoryExists(containerName, directory)).isTrue();
 
          view.getBlobStore().createDirectory(containerName, directory);
 
-         assert view.getBlobStore().directoryExists(containerName, directory);
+         assertThat(view.getBlobStore().directoryExists(containerName, directory)).isTrue();
          PageSet<? extends StorageMetadata> container = view.getBlobStore().list(containerName);
          // we should have only the directory under root
-         assert container.getNextMarker() == null;
-         assert container.size() == 1 : container;
+         assertThat(container.getNextMarker() == null).isTrue();
+         assertThat(container.size() == 1).as(String.valueOf(container)).isTrue();
 
          container = view.getBlobStore().list(containerName, inDirectory(directory));
 
          // we should have nothing in the directory
-         assert container.getNextMarker() == null;
-         assert container.size() == 0 : container;
+         assertThat(container.getNextMarker() == null).isTrue();
+         assertThat(container.size() == 0).as(String.valueOf(container)).isTrue();
 
          addTenObjectsUnderPrefix(containerName, directory);
 
@@ -236,58 +236,58 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
 
          container = view.getBlobStore().list(containerName);
          // we should get back the subdir entry and the directory marker
-         assert container.getNextMarker() == null;
+         assertThat(container.getNextMarker() == null).isTrue();
          assertThat(container).hasSize(2);
 
          container = view.getBlobStore().list(containerName, inDirectory(directory));
          // we should have only the 10 items under the directory
-         assert container.getNextMarker() == null;
-         assert container.size() == 10 : container;
+         assertThat(container.getNextMarker() == null).isTrue();
+         assertThat(container.size() == 10).as(String.valueOf(container)).isTrue();
 
          // try 2 level deep directory
-         assert !view.getBlobStore().directoryExists(containerName, directory + "/" + directory);
+         assertThat(!view.getBlobStore().directoryExists(containerName, directory + "/" + directory)).isTrue();
          view.getBlobStore().createDirectory(containerName, directory + "/" + directory);
 
          awaitConsistency();
 
-         assert view.getBlobStore().directoryExists(containerName, directory + "/" + directory);
+         assertThat(view.getBlobStore().directoryExists(containerName, directory + "/" + directory)).isTrue();
 
          view.getBlobStore().clearContainer(containerName, inDirectory(directory));
          awaitConsistency();
 
-         assert view.getBlobStore().directoryExists(containerName, directory);
-         assert view.getBlobStore().directoryExists(containerName, directory + "/" + directory);
+         assertThat(view.getBlobStore().directoryExists(containerName, directory)).isTrue();
+         assertThat(view.getBlobStore().directoryExists(containerName, directory + "/" + directory)).isTrue();
 
          // should have only the 2 level-deep directory above
          container = view.getBlobStore().list(containerName, inDirectory(directory));
-         assert container.getNextMarker() == null;
-         assert container.size() == 1 : container;
+         assertThat(container.getNextMarker() == null).isTrue();
+         assertThat(container.size() == 1).as(String.valueOf(container)).isTrue();
 
          view.getBlobStore().createDirectory(containerName, directory + "/" + directory);
 
          awaitConsistency();
 
          container = view.getBlobStore().list(containerName, inDirectory(directory).recursive());
-         assert container.getNextMarker() == null;
-         assert container.size() == 1 : container;
+         assertThat(container.getNextMarker() == null).isTrue();
+         assertThat(container.size() == 1).as(String.valueOf(container)).isTrue();
 
          view.getBlobStore().clearContainer(containerName, inDirectory(directory).recursive());
 
          // should no longer have the 2 level-deep directory above
          container = view.getBlobStore().list(containerName, inDirectory(directory));
-         assert container.getNextMarker() == null;
-         assert container.size() == 0 : container;
+         assertThat(container.getNextMarker() == null).isTrue();
+         assertThat(container.size() == 0).as(String.valueOf(container)).isTrue();
 
          container = view.getBlobStore().list(containerName);
          // should only have the directory
-         assert container.getNextMarker() == null;
-         assert container.size() == 1 : container;
+         assertThat(container.getNextMarker() == null).isTrue();
+         assertThat(container.size() == 1).as(String.valueOf(container)).isTrue();
          view.getBlobStore().deleteDirectory(containerName, directory);
 
          container = view.getBlobStore().list(containerName);
          // now should be completely empty
-         assert container.getNextMarker() == null;
-         assert container.size() == 0 : container;
+         assertThat(container.getNextMarker() == null).isTrue();
+         assertThat(container.size() == 0).as(String.valueOf(container)).isTrue();
       } finally {
          returnContainer(containerName);
       }
@@ -303,7 +303,7 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
          add15UnderRoot(containerName);
          awaitConsistency();
          PageSet<? extends StorageMetadata> container = view.getBlobStore().list(containerName, inDirectory(prefix));
-         assert container.getNextMarker() == null;
+         assertThat(container.getNextMarker() == null).isTrue();
          assertEquals(container.size(), 10);
       } finally {
          returnContainer(containerName);
@@ -401,7 +401,7 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
    public void containerExists() throws InterruptedException {
       String containerName = getContainerName();
       try {
-         assert view.getBlobStore().containerExists(containerName);
+         assertThat(view.getBlobStore().containerExists(containerName)).isTrue();
       } finally {
          returnContainer(containerName);
       }

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseServiceIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseServiceIntegrationTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.blobstore.integration.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -37,7 +38,7 @@ public class BaseServiceIntegrationTest extends BaseBlobStoreIntegrationTest {
    @Test(groups = { "integration", "live" })
    void containerDoesntExist() {
       Set<? extends StorageMetadata> list = view.getBlobStore().list();
-      assert !list.contains(new MutableStorageMetadataImpl());
+      assertThat(!list.contains(new MutableStorageMetadataImpl())).isTrue();
    }
 
    @Test(groups = { "integration", "live" })
@@ -54,11 +55,11 @@ public class BaseServiceIntegrationTest extends BaseBlobStoreIntegrationTest {
                @Override
                public void run() {
                   PageSet<? extends StorageMetadata> list = view.getBlobStore().list();
-                  assert Iterables.any(list, new Predicate<StorageMetadata>() {
+                  assertThat(Iterables.any(list, new Predicate<StorageMetadata>() {
                      public boolean apply(StorageMetadata md) {
                         return containerName.equals(md.getName()) && locationEquals(location, md.getLocation());
                      }
-                  }) : String.format("container %s/%s not found in list %s", location, containerName, list);
+                  })).as(String.format("container %s/%s not found in list %s", location, containerName, list)).isTrue();
                   assertTrue(view.getBlobStore().containerExists(containerName), containerName);
                }
 
@@ -79,18 +80,18 @@ public class BaseServiceIntegrationTest extends BaseBlobStoreIntegrationTest {
          assertProvider(Location.class.cast(view.unwrap()));
       for (Location location : view.getBlobStore().listAssignableLocations()) {
          System.err.printf("location %s%n", location);
-         assert location.getId() != null : location;
-         assert location != location.getParent() : location;
-         assert location.getScope() != null : location;
+         assertThat(location.getId() != null).as(String.valueOf(location)).isTrue();
+         assertThat(location != location.getParent()).as(String.valueOf(location)).isTrue();
+         assertThat(location.getScope() != null).as(String.valueOf(location)).isTrue();
          switch (location.getScope()) {
             case PROVIDER:
                assertProvider(location);
                break;
             case REGION:
                assertProvider(location.getParent());
-               assert location.getIso3166Codes().size() == 0
-                        || location.getParent().getIso3166Codes().containsAll(location.getIso3166Codes()) : location
-                        + " ||" + location.getParent();
+               assertThat(location.getIso3166Codes().size() == 0
+                        || location.getParent().getIso3166Codes().containsAll(location.getIso3166Codes())).as(location
+                        + " ||" + location.getParent()).isTrue();
                break;
             case ZONE:
                Location provider = location.getParent().getParent();
@@ -98,9 +99,9 @@ public class BaseServiceIntegrationTest extends BaseBlobStoreIntegrationTest {
                if (provider == null)
                   provider = location.getParent();
                assertProvider(provider);
-               assert location.getIso3166Codes().size() == 0
-                        || location.getParent().getIso3166Codes().containsAll(location.getIso3166Codes()) : location
-                        + " ||" + location.getParent();
+               assertThat(location.getIso3166Codes().size() == 0
+                        || location.getParent().getIso3166Codes().containsAll(location.getIso3166Codes())).as(location
+                        + " ||" + location.getParent()).isTrue();
                break;
             case HOST:
                Location provider2 = location.getParent().getParent().getParent();

--- a/common/openstack/src/test/java/org/jclouds/openstack/predicates/LinkPredicatesTest.java
+++ b/common/openstack/src/test/java/org/jclouds/openstack/predicates/LinkPredicatesTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.openstack.predicates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.openstack.predicates.LinkPredicates.hrefEquals;
 import static org.jclouds.openstack.predicates.LinkPredicates.relationEquals;
 import static org.jclouds.openstack.predicates.LinkPredicates.typeEquals;
@@ -33,31 +34,31 @@ public class LinkPredicatesTest {
 
    @Test
    public void testRelationEqualsWhenEqual() {
-      assert relationEquals(Relation.DESCRIBEDBY).apply(ref);
+      assertThat(relationEquals(Relation.DESCRIBEDBY).apply(ref)).isTrue();
    }
 
    @Test
    public void testRelationEqualsWhenNotEqual() {
-      assert !relationEquals(Relation.UNRECOGNIZED).apply(ref);
+      assertThat(!relationEquals(Relation.UNRECOGNIZED).apply(ref)).isTrue();
    }
 
    @Test
    public void testTypeEqualsWhenEqual() {
-      assert typeEquals("application/pdf").apply(ref);
+      assertThat(typeEquals("application/pdf").apply(ref)).isTrue();
    }
 
    @Test
    public void testTypeEqualsWhenNotEqual() {
-      assert !typeEquals("foo").apply(ref);
+      assertThat(!typeEquals("foo").apply(ref)).isTrue();
    }
 
    @Test
    public void testHrefEqualsWhenEqual() {
-      assert hrefEquals(URI.create("http://docs.openstack.org/ext/keypairs/api/v1.1")).apply(ref);
+      assertThat(hrefEquals(URI.create("http://docs.openstack.org/ext/keypairs/api/v1.1")).apply(ref)).isTrue();
    }
 
    @Test
    public void testHrefEqualsWhenNotEqual() {
-      assert !hrefEquals(URI.create("foo")).apply(ref);
+      assertThat(!hrefEquals(URI.create("foo")).apply(ref)).isTrue();
    }
 }

--- a/compute/src/test/java/org/jclouds/compute/ComputeTestUtils.java
+++ b/compute/src/test/java/org/jclouds/compute/ComputeTestUtils.java
@@ -19,6 +19,7 @@ package org.jclouds.compute;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.emptyToNull;
 import static com.google.common.collect.Iterables.get;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.File;
@@ -57,7 +58,7 @@ public class ComputeTestUtils {
       }
       try {
          String secret = Files.toString(new File(secretKeyFile), Charsets.UTF_8);
-         assert secret.startsWith("-----BEGIN RSA PRIVATE KEY-----") : "invalid key:\n" + secret;
+         assertThat(secret.startsWith("-----BEGIN RSA PRIVATE KEY-----")).as("invalid key:\n" + secret).isTrue();
          return ImmutableMap.<String, String> of("private", secret, "public", Files.toString(new File(secretKeyFile
                   + ".pub"), Charsets.UTF_8));
       } catch (IOException e) {
@@ -75,7 +76,7 @@ public class ComputeTestUtils {
    public static void checkHttpGet(HttpClient client, NodeMetadata node, int port) {
       for (int i = 0; i < 5; i++)
          try {
-            assert client.get(URI.create(String.format("http://%s:%d", get(node.getPublicAddresses(), 0), port))) != null;
+            assertThat(client.get(URI.create(String.format("http://%s:%d", get(node.getPublicAddresses(), 0), port))) != null).isTrue();
             break;
          } catch (UndeclaredThrowableException e) {
             assertEquals(e.getCause().getClass(), TimeoutException.class);

--- a/compute/src/test/java/org/jclouds/compute/callables/InitScriptConfigurationForTasksTest.java
+++ b/compute/src/test/java/org/jclouds/compute/callables/InitScriptConfigurationForTasksTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.compute.callables;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.File;
@@ -62,11 +63,11 @@ public class InitScriptConfigurationForTasksTest {
    public void testCurrentTimeSupplier() throws InterruptedException {
       InitScriptConfigurationForTasks config = InitScriptConfigurationForTasks.create();
       long time1 = Long.parseLong(config.getAnonymousTaskSuffixSupplier().get());
-      assert time1 <= System.currentTimeMillis();
+      assertThat(time1 <= System.currentTimeMillis()).isTrue();
       Thread.sleep(10);
       long time2 = Long.parseLong(config.getAnonymousTaskSuffixSupplier().get());
-      assert time2 <= System.currentTimeMillis();
-      assert time2 > time1;
+      assertThat(time2 <= System.currentTimeMillis()).isTrue();
+      assertThat(time2 > time1).isTrue();
    }
 
    public void testIncrementingTimeSupplier() throws InterruptedException {

--- a/compute/src/test/java/org/jclouds/compute/domain/internal/TemplateBuilderImplTest.java
+++ b/compute/src/test/java/org/jclouds/compute/domain/internal/TemplateBuilderImplTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.compute.domain.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
@@ -141,7 +142,7 @@ public class TemplateBuilderImplTest {
 
       TemplateBuilderImpl template = createTemplateBuilder(null, locations, images, hardwares, region,
                optionsProvider, templateBuilderProvider, getImageStrategy);
-      assert template.locationPredicate.apply(hardware);
+      assertThat(template.locationPredicate.apply(hardware)).isTrue();
 
       verify(defaultTemplate, optionsProvider, templateBuilderProvider, getImageStrategy);
    }

--- a/compute/src/test/java/org/jclouds/compute/internal/BaseTemplateBuilderLiveTest.java
+++ b/compute/src/test/java/org/jclouds/compute/internal/BaseTemplateBuilderLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.compute.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.compute.util.ComputeServiceUtils.getCores;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -53,14 +54,14 @@ public abstract class BaseTemplateBuilderLiveTest extends BaseComputeServiceCont
 
       assertEquals(defaultSize, smallest);
 
-      assert getCores(smallest) <= getCores(fastest) : String.format("%s ! <= %s", smallest, fastest);
-      assert getCores(biggest) <= getCores(fastest) : String.format("%s ! <= %s", biggest, fastest);
+      assertThat(getCores(smallest) <= getCores(fastest)).as(String.format("%s ! <= %s", smallest, fastest)).isTrue();
+      assertThat(getCores(biggest) <= getCores(fastest)).as(String.format("%s ! <= %s", biggest, fastest)).isTrue();
 
-      assert biggest.getRam() >= fastest.getRam() : String.format("%s ! >= %s", biggest, fastest);
-      assert biggest.getRam() >= smallest.getRam() : String.format("%s ! >= %s", biggest, smallest);
+      assertThat(biggest.getRam() >= fastest.getRam()).as(String.format("%s ! >= %s", biggest, fastest)).isTrue();
+      assertThat(biggest.getRam() >= smallest.getRam()).as(String.format("%s ! >= %s", biggest, smallest)).isTrue();
 
-      assert getCores(fastest) >= getCores(biggest) : String.format("%s ! >= %s", fastest, biggest);
-      assert getCores(fastest) >= getCores(smallest) : String.format("%s ! >= %s", fastest, smallest);
+      assertThat(getCores(fastest) >= getCores(biggest)).as(String.format("%s ! >= %s", fastest, biggest)).isTrue();
+      assertThat(getCores(fastest) >= getCores(smallest)).as(String.format("%s ! >= %s", fastest, smallest)).isTrue();
    }
 
    public void testFromTemplate() {
@@ -96,18 +97,18 @@ public abstract class BaseTemplateBuilderLiveTest extends BaseComputeServiceCont
    public void testGetAssignableLocations() throws Exception {
       assertProvider(view.unwrap());
       for (Location location : view.getComputeService().listAssignableLocations()) {
-         assert location.getId() != null : location;
-         assert location != location.getParent() : location;
-         assert location.getScope() != null : location;
+         assertThat(location.getId() != null).as(String.valueOf(location)).isTrue();
+         assertThat(location != location.getParent()).as(String.valueOf(location)).isTrue();
+         assertThat(location.getScope() != null).as(String.valueOf(location)).isTrue();
          switch (location.getScope()) {
          case PROVIDER:
             assertProvider(location);
             break;
          case REGION:
             assertProvider(location.getParent());
-            assert location.getIso3166Codes().size() == 0
-                  || location.getParent().getIso3166Codes().containsAll(location.getIso3166Codes()) : location + " ||"
-                  + location.getParent();
+            assertThat(location.getIso3166Codes().size() == 0
+                  || location.getParent().getIso3166Codes().containsAll(location.getIso3166Codes())).as(location + " ||"
+                  + location.getParent()).isTrue();
             break;
          case ZONE:
             Location provider = location.getParent().getParent();
@@ -115,9 +116,9 @@ public abstract class BaseTemplateBuilderLiveTest extends BaseComputeServiceCont
             if (provider == null)
                provider = location.getParent();
             assertProvider(provider);
-            assert location.getIso3166Codes().size() == 0
-                  || location.getParent().getIso3166Codes().containsAll(location.getIso3166Codes()) : location + " ||"
-                  + location.getParent();
+            assertThat(location.getIso3166Codes().size() == 0
+                  || location.getParent().getIso3166Codes().containsAll(location.getIso3166Codes())).as(location + " ||"
+                  + location.getParent()).isTrue();
             break;
          case SYSTEM:
             Location systemParent = location.getParent();

--- a/compute/src/test/java/org/jclouds/compute/predicates/HardwarePredicatesTest.java
+++ b/compute/src/test/java/org/jclouds/compute/predicates/HardwarePredicatesTest.java
@@ -24,15 +24,17 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Test
 public class HardwarePredicatesTest {
    ComputeService computeService = ContextBuilder.newBuilder("stub").build(ComputeServiceContext.class).getComputeService();
 
    public void testHardwareId() {
       Hardware first = Iterables.get(computeService.listHardwareProfiles(), 0);
-      assert HardwarePredicates.idEquals(first.getId()).apply(first);
+      assertThat(HardwarePredicates.idEquals(first.getId()).apply(first)).isTrue();
       Hardware second = Iterables.get(computeService.listHardwareProfiles(), 1);
-      assert !HardwarePredicates.idEquals(first.getId()).apply(second);
+      assertThat(!HardwarePredicates.idEquals(first.getId()).apply(second)).isTrue();
    }
 
 }

--- a/compute/src/test/java/org/jclouds/compute/predicates/ImagePredicatesTest.java
+++ b/compute/src/test/java/org/jclouds/compute/predicates/ImagePredicatesTest.java
@@ -26,24 +26,26 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Test
 public class ImagePredicatesTest {
    ComputeService computeService = ContextBuilder.newBuilder("stub").build(ComputeServiceContext.class).getComputeService();
 
    public void testImageId() {
       Image first = Iterables.get(computeService.listImages(), 0);
-      assert ImagePredicates.idEquals(first.getId()).apply(first);
+      assertThat(ImagePredicates.idEquals(first.getId()).apply(first)).isTrue();
       Image second = Iterables.get(computeService.listImages(), 1);
-      assert !ImagePredicates.idEquals(first.getId()).apply(second);
+      assertThat(!ImagePredicates.idEquals(first.getId()).apply(second)).isTrue();
    }
 
    public void testUserMetadataContains() {
       Image first = Iterables.get(computeService.listImages(), 0);
       first = ImageBuilder.fromImage(first).userMetadata(ImmutableMap.of("foo", "bar")).build();
-      assert ImagePredicates.userMetadataContains("foo", "bar").apply(first);
+      assertThat(ImagePredicates.userMetadataContains("foo", "bar").apply(first)).isTrue();
       Image second = Iterables.get(computeService.listImages(), 1);
       second = ImageBuilder.fromImage(second).userMetadata(ImmutableMap.of("foo", "baz")).build();
-      assert !ImagePredicates.userMetadataContains("foo", "bar").apply(second);
+      assertThat(!ImagePredicates.userMetadataContains("foo", "bar").apply(second)).isTrue();
    }
 
 }

--- a/compute/src/test/java/org/jclouds/compute/predicates/OperatingSystemPredicatesTest.java
+++ b/compute/src/test/java/org/jclouds/compute/predicates/OperatingSystemPredicatesTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.compute.predicates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.compute.predicates.OperatingSystemPredicates.supportsApt;
 import static org.jclouds.compute.predicates.OperatingSystemPredicates.supportsYum;
 import static org.jclouds.compute.predicates.OperatingSystemPredicates.supportsZypper;
@@ -33,106 +34,106 @@ import org.testng.annotations.Test;
 public class OperatingSystemPredicatesTest {
 
    public void testCIMCENTOSDoesntSupportApt() {
-      assert !supportsApt().apply(new CIMOperatingSystem(OSType.CENTOS, "", null, "description"));
-      assert !supportsApt().apply(new CIMOperatingSystem(OSType.CENTOS_64, "", null, "description"));
+      assertThat(!supportsApt().apply(new CIMOperatingSystem(OSType.CENTOS, "", null, "description"))).isTrue();
+      assertThat(!supportsApt().apply(new CIMOperatingSystem(OSType.CENTOS_64, "", null, "description"))).isTrue();
    }
 
    public void testCIMRHELDoesntSupportApt() {
-      assert !supportsApt().apply(new CIMOperatingSystem(OSType.RHEL, "", null, "description"));
-      assert !supportsApt().apply(new CIMOperatingSystem(OSType.RHEL_64, "", null, "description"));
+      assertThat(!supportsApt().apply(new CIMOperatingSystem(OSType.RHEL, "", null, "description"))).isTrue();
+      assertThat(!supportsApt().apply(new CIMOperatingSystem(OSType.RHEL_64, "", null, "description"))).isTrue();
    }
 
    public void testCIMDEBIANSupportsApt() {
-      assert supportsApt().apply(new CIMOperatingSystem(OSType.DEBIAN, "", null, "description"));
-      assert supportsApt().apply(new CIMOperatingSystem(OSType.DEBIAN_64, "", null, "description"));
+      assertThat(supportsApt().apply(new CIMOperatingSystem(OSType.DEBIAN, "", null, "description"))).isTrue();
+      assertThat(supportsApt().apply(new CIMOperatingSystem(OSType.DEBIAN_64, "", null, "description"))).isTrue();
    }
 
    public void testCIMUBUNTUSupportsApt() {
-      assert supportsApt().apply(new CIMOperatingSystem(OSType.UBUNTU, "", null, "description"));
-      assert supportsApt().apply(new CIMOperatingSystem(OSType.UBUNTU_64, "", null, "description"));
+      assertThat(supportsApt().apply(new CIMOperatingSystem(OSType.UBUNTU, "", null, "description"))).isTrue();
+      assertThat(supportsApt().apply(new CIMOperatingSystem(OSType.UBUNTU_64, "", null, "description"))).isTrue();
    }
 
    public void testUbuntuNameSupportsApt() {
-      assert supportsApt().apply(new OperatingSystem(null, "Ubuntu", "", null, "description", false));
+      assertThat(supportsApt().apply(new OperatingSystem(null, "Ubuntu", "", null, "description", false))).isTrue();
    }
 
    public void testCIMCENTOSSupportsYum() {
-      assert supportsYum().apply(new CIMOperatingSystem(OSType.CENTOS, "", null, "description"));
-      assert supportsYum().apply(new CIMOperatingSystem(OSType.CENTOS_64, "", null, "description"));
+      assertThat(supportsYum().apply(new CIMOperatingSystem(OSType.CENTOS, "", null, "description"))).isTrue();
+      assertThat(supportsYum().apply(new CIMOperatingSystem(OSType.CENTOS_64, "", null, "description"))).isTrue();
    }
 
    public void testCIMRHELSupportsYum() {
-      assert supportsYum().apply(new CIMOperatingSystem(OSType.RHEL, "", null, "description"));
-      assert supportsYum().apply(new CIMOperatingSystem(OSType.RHEL_64, "", null, "description"));
+      assertThat(supportsYum().apply(new CIMOperatingSystem(OSType.RHEL, "", null, "description"))).isTrue();
+      assertThat(supportsYum().apply(new CIMOperatingSystem(OSType.RHEL_64, "", null, "description"))).isTrue();
    }
 
    public void testCIMDEBIANDoesntSupportYum() {
-      assert !supportsYum().apply(new CIMOperatingSystem(OSType.DEBIAN, "", null, "description"));
-      assert !supportsYum().apply(new CIMOperatingSystem(OSType.DEBIAN_64, "", null, "description"));
+      assertThat(!supportsYum().apply(new CIMOperatingSystem(OSType.DEBIAN, "", null, "description"))).isTrue();
+      assertThat(!supportsYum().apply(new CIMOperatingSystem(OSType.DEBIAN_64, "", null, "description"))).isTrue();
    }
 
    public void testCIMUBUNTUDoesntSupportYum() {
-      assert !supportsYum().apply(new CIMOperatingSystem(OSType.UBUNTU, "", null, "description"));
-      assert !supportsYum().apply(new CIMOperatingSystem(OSType.UBUNTU_64, "", null, "description"));
+      assertThat(!supportsYum().apply(new CIMOperatingSystem(OSType.UBUNTU, "", null, "description"))).isTrue();
+      assertThat(!supportsYum().apply(new CIMOperatingSystem(OSType.UBUNTU_64, "", null, "description"))).isTrue();
    }
 
    public void testSuseTypeSupportsZypper() {
-      assert supportsZypper().apply(new OperatingSystem(OsFamily.SUSE, null, "", null, "description", false));
+      assertThat(supportsZypper().apply(new OperatingSystem(OsFamily.SUSE, null, "", null, "description", false))).isTrue();
    }
 
    public void testSuseDescriptionSupportsZypper() {
-      assert supportsZypper().apply(new OperatingSystem(null, "", null, null, "Suse", false));
+      assertThat(supportsZypper().apply(new OperatingSystem(null, "", null, null, "Suse", false))).isTrue();
    }
 
    public void testSuseNameSupportsZypper() {
-      assert supportsZypper().apply(new OperatingSystem(null, "Suse", "", null, "description", false));
+      assertThat(supportsZypper().apply(new OperatingSystem(null, "Suse", "", null, "description", false))).isTrue();
    }
 
    public void testCentosTypeSupportsYum() {
-      assert supportsYum().apply(new OperatingSystem(OsFamily.CENTOS, null, "", null, "description", false));
+      assertThat(supportsYum().apply(new OperatingSystem(OsFamily.CENTOS, null, "", null, "description", false))).isTrue();
    }
 
    public void testAmzTypeSupportsYum() {
-      assert supportsYum().apply(new OperatingSystem(OsFamily.AMZN_LINUX, null, "", null, "description", false));
+      assertThat(supportsYum().apply(new OperatingSystem(OsFamily.AMZN_LINUX, null, "", null, "description", false))).isTrue();
    }
 
    public void testRhelTypeSupportsYum() {
-      assert supportsYum().apply(new OperatingSystem(OsFamily.RHEL, null, "", null, "description", false));
+      assertThat(supportsYum().apply(new OperatingSystem(OsFamily.RHEL, null, "", null, "description", false))).isTrue();
    }
 
    public void testFedoraTypeSupportsYum() {
-      assert supportsYum().apply(new OperatingSystem(OsFamily.FEDORA, null, "", null, "description", false));
+      assertThat(supportsYum().apply(new OperatingSystem(OsFamily.FEDORA, null, "", null, "description", false))).isTrue();
    }
 
    public void testCentosNameSupportsYum() {
-      assert supportsYum().apply(new OperatingSystem(null, "Centos", "", null, "description", false));
+      assertThat(supportsYum().apply(new OperatingSystem(null, "Centos", "", null, "description", false))).isTrue();
    }
 
    public void testRhelNameSupportsYum() {
-      assert supportsYum().apply(new OperatingSystem(null, "RHEL", "", null, "description", false));
+      assertThat(supportsYum().apply(new OperatingSystem(null, "RHEL", "", null, "description", false))).isTrue();
    }
 
    public void testFedoraNameSupportsYum() {
-      assert supportsYum().apply(new OperatingSystem(null, "Fedora", "", null, "description", false));
+      assertThat(supportsYum().apply(new OperatingSystem(null, "Fedora", "", null, "description", false))).isTrue();
    }
 
    public void testRedHatEnterpriseLinuxNameSupportsYum() {
-      assert supportsYum().apply(new OperatingSystem(null, "Red Hat Enterprise Linux", "", null, "description", false));
+      assertThat(supportsYum().apply(new OperatingSystem(null, "Red Hat Enterprise Linux", "", null, "description", false))).isTrue();
    }
 
    public void testCentosDescriptionSupportsYum() {
-      assert supportsYum().apply(new OperatingSystem(null, "", null, null, "Centos", false));
+      assertThat(supportsYum().apply(new OperatingSystem(null, "", null, null, "Centos", false))).isTrue();
    }
 
    public void testRhelDescriptionSupportsYum() {
-      assert supportsYum().apply(new OperatingSystem(null, "", null, null, "RHEL", false));
+      assertThat(supportsYum().apply(new OperatingSystem(null, "", null, null, "RHEL", false))).isTrue();
    }
 
    public void testFedoraDescriptionSupportsYum() {
-      assert supportsYum().apply(new OperatingSystem(null, "", null, null, "Fedora", false));
+      assertThat(supportsYum().apply(new OperatingSystem(null, "", null, null, "Fedora", false))).isTrue();
    }
 
    public void testRedHatEnterpriseLinuxDescriptionSupportsYum() {
-      assert supportsYum().apply(new OperatingSystem(null, "", null, null, "Red Hat Enterprise Linux", false));
+      assertThat(supportsYum().apply(new OperatingSystem(null, "", null, null, "Red Hat Enterprise Linux", false))).isTrue();
    }
 }

--- a/compute/src/test/java/org/jclouds/ssh/SshKeysTest.java
+++ b/compute/src/test/java/org/jclouds/ssh/SshKeysTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ssh;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.ssh.SshKeys.fingerprint;
 import static org.jclouds.ssh.SshKeys.generate;
 import static org.jclouds.ssh.SshKeys.privateKeyHasFingerprint;
@@ -65,26 +66,26 @@ public class SshKeysTest {
    public void testPrivateKeyMatchesFingerprintTyped() throws IOException {
       String privKey = Strings2.toStringAndClose(getClass().getResourceAsStream("/test"));
       RSAPrivateCrtKeySpec privateKey = (RSAPrivateCrtKeySpec) Pems.privateKeySpec(privKey);
-      assert privateKeyHasFingerprint(privateKey, expectedFingerprint);
+      assertThat(privateKeyHasFingerprint(privateKey, expectedFingerprint)).isTrue();
    }
 
    @Test
    public void testPrivateKeyMatchesFingerprintString() throws IOException {
       String privKey = Strings2.toStringAndClose(getClass().getResourceAsStream("/test"));
-      assert privateKeyHasFingerprint(privKey, expectedFingerprint);
+      assertThat(privateKeyHasFingerprint(privKey, expectedFingerprint)).isTrue();
    }
 
    @Test
    public void testPrivateKeyMatchesSha1Typed() throws IOException {
       String privKey = Strings2.toStringAndClose(getClass().getResourceAsStream("/test"));
       RSAPrivateCrtKeySpec privateKey = (RSAPrivateCrtKeySpec) Pems.privateKeySpec(privKey);
-      assert privateKeyHasSha1(privateKey, expectedSha1);
+      assertThat(privateKeyHasSha1(privateKey, expectedSha1)).isTrue();
    }
 
    @Test
    public void testPrivateKeyMatchesSha1String() throws IOException {
       String privKey = Strings2.toStringAndClose(getClass().getResourceAsStream("/test"));
-      assert privateKeyHasSha1(privKey, expectedSha1);
+      assertThat(privateKeyHasSha1(privKey, expectedSha1)).isTrue();
    }
 
    @Test
@@ -93,22 +94,22 @@ public class SshKeysTest {
       RSAPrivateCrtKeySpec privateKey = (RSAPrivateCrtKeySpec) Pems.privateKeySpec(privKey);
       String pubKey = Strings2.toStringAndClose(getClass().getResourceAsStream("/test.pub"));
       RSAPublicKeySpec publicKey = publicKeySpecFromOpenSSH(pubKey);
-      assert privateKeyMatchesPublicKey(privateKey, publicKey);
+      assertThat(privateKeyMatchesPublicKey(privateKey, publicKey)).isTrue();
    }
 
    @Test
    public void testPrivateKeyMatchesPublicKeyString() throws IOException {
       String privKey = Strings2.toStringAndClose(getClass().getResourceAsStream("/test"));
       String pubKey = Strings2.toStringAndClose(getClass().getResourceAsStream("/test.pub"));
-      assert privateKeyMatchesPublicKey(privKey, pubKey);
+      assertThat(privateKeyMatchesPublicKey(privKey, pubKey)).isTrue();
    }
 
    @Test
    public void testCanGenerate() {
       Map<String, String> map = generate();
-      assert map.get("public").startsWith("ssh-rsa ") : map;
-      assert map.get("private").startsWith("-----BEGIN RSA PRIVATE KEY-----") : map;
-      assert privateKeyMatchesPublicKey(map.get("private"), map.get("public")) : map;
+      assertThat(map.get("public").startsWith("ssh-rsa ")).as(String.valueOf(map)).isTrue();
+      assertThat(map.get("private").startsWith("-----BEGIN RSA PRIVATE KEY-----")).as(String.valueOf(map)).isTrue();
+      assertThat(privateKeyMatchesPublicKey(map.get("private"), map.get("public"))).as(String.valueOf(map)).isTrue();
 
    }
 

--- a/core/src/test/java/org/jclouds/ContextBuilderTest.java
+++ b/core/src/test/java/org/jclouds/ContextBuilderTest.java
@@ -17,6 +17,7 @@
 package org.jclouds;
 
 import static com.google.common.base.Suppliers.ofInstance;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.providers.AnonymousProviderMetadata.forApiOnEndpoint;
 import static org.testng.Assert.assertEquals;
 
@@ -221,8 +222,8 @@ public class ContextBuilderTest {
       ContextBuilder.addHttpModuleIfNeededAndNotPresent(modules);
       ContextBuilder.addLoggingModuleIfNotPresent(modules);
       assertEquals(modules.size(), 2);
-      assert modules.remove(0) instanceof JavaUrlHttpCommandExecutorServiceModule;
-      assert modules.remove(0) instanceof JDKLoggingModule;
+      assertThat(modules.remove(0) instanceof JavaUrlHttpCommandExecutorServiceModule).isTrue();
+      assertThat(modules.remove(0) instanceof JDKLoggingModule).isTrue();
    }
 
    @Test
@@ -231,8 +232,8 @@ public class ContextBuilderTest {
       ContextBuilder.addHttpModuleIfNeededAndNotPresent(modules);
       ContextBuilder.addLoggingModuleIfNotPresent(modules);
       assertEquals(modules.size(), 2);
-      assert modules.remove(0) instanceof JavaUrlHttpCommandExecutorServiceModule;
-      assert modules.remove(0) instanceof JDKLoggingModule;
+      assertThat(modules.remove(0) instanceof JavaUrlHttpCommandExecutorServiceModule).isTrue();
+      assertThat(modules.remove(0) instanceof JDKLoggingModule).isTrue();
    }
 
    public void testBuilder() {

--- a/core/src/test/java/org/jclouds/apis/internal/BaseApiMetadataTest.java
+++ b/core/src/test/java/org/jclouds/apis/internal/BaseApiMetadataTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.apis.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Set;
@@ -51,15 +52,15 @@ public abstract class BaseApiMetadataTest {
    public void testTransformableToContains() {
       for (TypeToken<? extends View> view : views) {
          ImmutableSet<ApiMetadata> ofType = ImmutableSet.copyOf(Apis.viewableAs(view));
-         assert ofType.contains(toTest) : String.format("%s not found in %s for %s", toTest, ofType,
-                  view);
+         assertThat(ofType.contains(toTest)).as(String.format("%s not found in %s for %s", toTest, ofType,
+                  view)).isTrue();
       }
    }
 
    @Test
    public void testAllContains() {
       ImmutableSet<ApiMetadata> all = ImmutableSet.copyOf(Apis.all());
-      assert all.contains(toTest) : String.format("%s not found in %s", toTest, all);
+      assertThat(all.contains(toTest)).as(String.format("%s not found in %s", toTest, all)).isTrue();
    }
 
 }

--- a/core/src/test/java/org/jclouds/domain/JsonBallTest.java
+++ b/core/src/test/java/org/jclouds/domain/JsonBallTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
@@ -40,47 +41,47 @@ public class JsonBallTest {
 
    public void testJSON_STRING_PATTERN1() {
       Matcher matcher = JsonBall.JSON_STRING_PATTERN.matcher("hello");
-      assert matcher.find();
+      assertThat(matcher.find()).isTrue();
    }
 
    public void testJSON_STRING_PATTERN2() {
       Matcher matcher = JsonBall.JSON_STRING_PATTERN.matcher("hello world!");
-      assert matcher.find();
+      assertThat(matcher.find()).isTrue();
    }
 
    public void testJSON_STRING_PATTERN3() {
       Matcher matcher = JsonBall.JSON_STRING_PATTERN.matcher("\"hello world!\"");
-      assert !matcher.find();
+      assertThat(!matcher.find()).isTrue();
    }
 
    public void testJSON_STRING_PATTERN4() {
       Matcher matcher = JsonBall.JSON_STRING_PATTERN.matcher("[hello world!]");
-      assert !matcher.find();
+      assertThat(!matcher.find()).isTrue();
    }
 
    public void testJSON_STRING_PATTERN5() {
       Matcher matcher = JsonBall.JSON_STRING_PATTERN.matcher("{hello world!}");
-      assert !matcher.find();
+      assertThat(!matcher.find()).isTrue();
    }
 
    public void testJSON_NUMBER_PATTERN1() {
       Matcher matcher = JsonBall.JSON_NUMBER_PATTERN.matcher("1");
-      assert matcher.find();
+      assertThat(matcher.find()).isTrue();
    }
 
    public void testJSON_NUMBER_PATTERN2() {
       Matcher matcher = JsonBall.JSON_NUMBER_PATTERN.matcher("1.1");
-      assert matcher.find();
+      assertThat(matcher.find()).isTrue();
    }
 
    public void testJSON_NUMBER_PATTERN3() {
       Matcher matcher = JsonBall.JSON_NUMBER_PATTERN.matcher("\"1.1\"");
-      assert !matcher.find();
+      assertThat(!matcher.find()).isTrue();
    }
 
    public void testJSON_NUMBER_PATTERN4() {
       Matcher matcher = JsonBall.JSON_NUMBER_PATTERN.matcher("\"1\"");
-      assert !matcher.find();
+      assertThat(!matcher.find()).isTrue();
    }
 
    private ParseJson<Map<String, JsonBall>> handler;

--- a/core/src/test/java/org/jclouds/http/BaseJettyTest.java
+++ b/core/src/test/java/org/jclouds/http/BaseJettyTest.java
@@ -25,6 +25,7 @@ import static com.google.common.net.HttpHeaders.CONTENT_LANGUAGE;
 import static com.google.common.net.HttpHeaders.CONTENT_LENGTH;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.Constants.PROPERTY_RELAX_HOSTNAME;
 import static org.jclouds.Constants.PROPERTY_TRUST_ALL_CERTS;
 import static org.jclouds.providers.AnonymousProviderMetadata.forApiOnEndpoint;
@@ -162,9 +163,9 @@ public abstract class BaseJettyTest {
       Properties properties = new Properties();
       addConnectionProperties(properties);
       client = newBuilder(testPort, properties, createConnectionModule()).buildApi(IntegrationTestClient.class);
-      assert client != null;
+      assertThat(client != null).isTrue();
 
-      assert client.newStringBuilder() != null;
+      assertThat(client.newStringBuilder() != null).isTrue();
    }
 
    private static void handlePost(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/core/src/test/java/org/jclouds/http/HttpRequestTest.java
+++ b/core/src/test/java/org/jclouds/http/HttpRequestTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.http;
 
 import static com.google.common.net.MediaType.FORM_DATA;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.net.URI;
@@ -35,7 +36,7 @@ public class HttpRequestTest {
    @Test(expectedExceptions = IllegalArgumentException.class)
    public void testConstructorHostNull() throws Exception {
       URI uri = URI.create("http://adriancole.compute1138eu.s3-external-3.amazonaws.com:-1");
-      assert uri.getHost() == null : "test requires something to produce a uri with a null hostname";
+      assertThat(uri.getHost() == null).as("test requires something to produce a uri with a null hostname").isTrue();
       HttpRequest.builder().method("GET").endpoint(uri).build();
    }
 

--- a/core/src/test/java/org/jclouds/http/functions/BaseHandlerTest.java
+++ b/core/src/test/java/org/jclouds/http/functions/BaseHandlerTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.http.functions;
 
 import static com.google.common.base.Throwables.propagate;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.reflect.Reflection2.method;
 
 import java.util.List;
@@ -42,7 +43,7 @@ public class BaseHandlerTest {
    protected void setUpInjector() {
       injector = Guice.createInjector(new SaxParserModule());
       factory = injector.getInstance(ParseSax.Factory.class);
-      assert factory != null;
+      assertThat(factory != null).isTrue();
    }
 
    @BeforeTest

--- a/core/src/test/java/org/jclouds/http/functions/ParseURIFromListOrLocationHeaderIf20xTest.java
+++ b/core/src/test/java/org/jclouds/http/functions/ParseURIFromListOrLocationHeaderIf20xTest.java
@@ -18,6 +18,7 @@ package org.jclouds.http.functions;
 
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.HttpHeaders.LOCATION;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -54,7 +55,7 @@ public class ParseURIFromListOrLocationHeaderIf20xTest {
       try {
          function.apply(response);
       } catch (Exception e) {
-         assert e.getMessage().equals("no content");
+         assertThat(e.getMessage().equals("no content")).isTrue();
       }
       verify(payload);
       verify(response);
@@ -78,7 +79,7 @@ public class ParseURIFromListOrLocationHeaderIf20xTest {
       try {
          function.apply(response);
       } catch (Exception e) {
-         assert e.equals(exception);
+         assertThat(e.equals(exception)).isTrue();
       }
       verify(payload);
       verify(response);

--- a/core/src/test/java/org/jclouds/http/functions/ReturnStringIf200Test.java
+++ b/core/src/test/java/org/jclouds/http/functions/ReturnStringIf200Test.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.http.functions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -47,7 +48,7 @@ public class ReturnStringIf200Test {
 
       replay(payload);
       replay(response);
-      assert function.apply(response) == null;
+      assertThat(function.apply(response) == null).isTrue();
 
       verify(payload);
       verify(response);
@@ -71,7 +72,7 @@ public class ReturnStringIf200Test {
       try {
          function.apply(response);
       } catch (Exception e) {
-         assert e.equals(exception);
+         assertThat(e.equals(exception)).isTrue();
       }
       verify(payload);
       verify(response);

--- a/core/src/test/java/org/jclouds/http/handlers/BackoffLimitedRetryHandlerTest.java
+++ b/core/src/test/java/org/jclouds/http/handlers/BackoffLimitedRetryHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.http.handlers;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.reflect.Reflection2.method;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -52,31 +53,31 @@ public class BackoffLimitedRetryHandlerTest {
       long startTime = System.nanoTime();
       handler.imposeBackoffExponentialDelay(period, 2, 1, 5, "TEST FAILURE: 1");
       long elapsedTime = (System.nanoTime() - startTime) / 1000000;
-      assert elapsedTime >= period - 1 : elapsedTime;
+      assertThat(elapsedTime >= period - 1).as(String.valueOf(elapsedTime)).isTrue();
       assertTrue(elapsedTime < period + acceptableDelay);
 
       startTime = System.nanoTime();
       handler.imposeBackoffExponentialDelay(period, 2, 2, 5, "TEST FAILURE: 2");
       elapsedTime = (System.nanoTime() - startTime) / 1000000;
-      assert elapsedTime >= period * 4 - 1 : elapsedTime;
+      assertThat(elapsedTime >= period * 4 - 1).as(String.valueOf(elapsedTime)).isTrue();
       assertTrue(elapsedTime < period * 9);
 
       startTime = System.nanoTime();
       handler.imposeBackoffExponentialDelay(period, 2, 3, 5, "TEST FAILURE: 3");
       elapsedTime = (System.nanoTime() - startTime) / 1000000;
-      assert elapsedTime >= period * 9 - 1 : elapsedTime;
+      assertThat(elapsedTime >= period * 9 - 1).as(String.valueOf(elapsedTime)).isTrue();
       assertTrue(elapsedTime < period * 10);
 
       startTime = System.nanoTime();
       handler.imposeBackoffExponentialDelay(period, 2, 4, 5, "TEST FAILURE: 4");
       elapsedTime = (System.nanoTime() - startTime) / 1000000;
-      assert elapsedTime >= period * 10 - 1 : elapsedTime;
+      assertThat(elapsedTime >= period * 10 - 1).as(String.valueOf(elapsedTime)).isTrue();
       assertTrue(elapsedTime < period * 11);
 
       startTime = System.nanoTime();
       handler.imposeBackoffExponentialDelay(period, 2, 5, 5, "TEST FAILURE: 5");
       elapsedTime = (System.nanoTime() - startTime) / 1000000;
-      assert elapsedTime >= period * 10 - 1 : elapsedTime;
+      assertThat(elapsedTime >= period * 10 - 1).as(String.valueOf(elapsedTime)).isTrue();
       assertTrue(elapsedTime < period * 11);
 
    }
@@ -89,7 +90,7 @@ public class BackoffLimitedRetryHandlerTest {
       long startTime = System.nanoTime();
       handler.imposeBackoffExponentialDelay(period, 2, 1, 5, "TEST FAILURE: 1");
       long elapsedTime = (System.nanoTime() - startTime) / 1000000;
-      assert elapsedTime >= period - 1 : elapsedTime;
+      assertThat(elapsedTime >= period - 1).as(String.valueOf(elapsedTime)).isTrue();
       assertTrue(elapsedTime < period + acceptableDelay);
    }
 
@@ -101,7 +102,7 @@ public class BackoffLimitedRetryHandlerTest {
       long startTime = System.nanoTime();
       handler.imposeBackoffExponentialDelay(period, 2, 1, 5, "TEST FAILURE: 1");
       long elapsedTime = (System.nanoTime() - startTime) / 1000000;
-      assert elapsedTime >= period - 1 : elapsedTime;
+      assertThat(elapsedTime >= period - 1).as(String.valueOf(elapsedTime)).isTrue();
       assertTrue(elapsedTime < period + acceptableDelay);
    }
 
@@ -113,7 +114,7 @@ public class BackoffLimitedRetryHandlerTest {
       long startTime = System.nanoTime();
       handler.imposeBackoffExponentialDelay(period, 2, 1, 5, "TEST FAILURE: 1");
       long elapsedTime = (System.nanoTime() - startTime) / 1000000;
-      assert elapsedTime >= period - 1 : elapsedTime;
+      assertThat(elapsedTime >= period - 1).as(String.valueOf(elapsedTime)).isTrue();
       assertTrue(elapsedTime < period + acceptableDelay);
    }
 

--- a/core/src/test/java/org/jclouds/http/handlers/RedirectionRetryHandlerTest.java
+++ b/core/src/test/java/org/jclouds/http/handlers/RedirectionRetryHandlerTest.java
@@ -18,6 +18,7 @@ package org.jclouds.http.handlers;
 
 import static com.google.common.net.HttpHeaders.HOST;
 import static com.google.common.net.HttpHeaders.LOCATION;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -59,7 +60,7 @@ public class RedirectionRetryHandlerTest {
 
       RedirectionRetryHandler retry = injector.getInstance(RedirectionRetryHandler.class);
 
-      assert !retry.shouldRetryRequest(command, response);
+      assertThat(!retry.shouldRetryRequest(command, response)).isTrue();
 
       verify(command);
 
@@ -81,7 +82,7 @@ public class RedirectionRetryHandlerTest {
 
       RedirectionRetryHandler retry = injector.getInstance(RedirectionRetryHandler.class);
 
-      assert !retry.shouldRetryRequest(command, response);
+      assertThat(!retry.shouldRetryRequest(command, response)).isTrue();
 
       verify(command);
 
@@ -178,7 +179,7 @@ public class RedirectionRetryHandlerTest {
 
       RedirectionRetryHandler retry = injector.getInstance(RedirectionRetryHandler.class);
 
-      assert retry.shouldRetryRequest(command, response);
+      assertThat(retry.shouldRetryRequest(command, response)).isTrue();
       verify(command);
    }
 }

--- a/core/src/test/java/org/jclouds/http/utils/QueriesTest.java
+++ b/core/src/test/java/org/jclouds/http/utils/QueriesTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.http.utils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.http.utils.Queries.queryParser;
 import static org.testng.Assert.assertEquals;
 
@@ -49,22 +50,22 @@ public class QueriesTest {
    @Test
    public void testParseQueryToMapSingleParam() {
       Multimap<String, String> parsedMap = queryParser().apply("v=1.3");
-      assert parsedMap.keySet().size() == 1 : "Expected 1 key, found: " + parsedMap.keySet().size();
-      assert parsedMap.keySet().contains("v") : "Expected v to be a part of the keys";
+      assertThat(parsedMap.keySet().size() == 1).as("Expected 1 key, found: " + parsedMap.keySet().size()).isTrue();
+      assertThat(parsedMap.keySet().contains("v")).as("Expected v to be a part of the keys").isTrue();
       String valueForV = Iterables.getOnlyElement(parsedMap.get("v"));
-      assert valueForV.equals("1.3") : "Expected the value for 'v' to be '1.3', found: " + valueForV;
+      assertThat(valueForV.equals("1.3")).as("Expected the value for 'v' to be '1.3', found: " + valueForV).isTrue();
    }
 
    @Test
    public void testParseQueryToMapMultiParam() {
       Multimap<String, String> parsedMap = queryParser().apply("v=1.3&sig=123");
-      assert parsedMap.keySet().size() == 2 : "Expected 2 keys, found: " + parsedMap.keySet().size();
-      assert parsedMap.keySet().contains("v") : "Expected v to be a part of the keys";
-      assert parsedMap.keySet().contains("sig") : "Expected sig to be a part of the keys";
+      assertThat(parsedMap.keySet().size() == 2).as("Expected 2 keys, found: " + parsedMap.keySet().size()).isTrue();
+      assertThat(parsedMap.keySet().contains("v")).as("Expected v to be a part of the keys").isTrue();
+      assertThat(parsedMap.keySet().contains("sig")).as("Expected sig to be a part of the keys").isTrue();
       String valueForV = Iterables.getOnlyElement(parsedMap.get("v"));
-      assert valueForV.equals("1.3") : "Expected the value for 'v' to be '1.3', found: " + valueForV;
+      assertThat(valueForV.equals("1.3")).as("Expected the value for 'v' to be '1.3', found: " + valueForV).isTrue();
       String valueForSig = Iterables.getOnlyElement(parsedMap.get("sig"));
-      assert valueForSig.equals("123") : "Expected the value for 'v' to be '123', found: " + valueForSig;
+      assertThat(valueForSig.equals("123")).as("Expected the value for 'v' to be '123', found: " + valueForSig).isTrue();
    }
 
    @Test

--- a/core/src/test/java/org/jclouds/io/payloads/MultipartFormTest.java
+++ b/core/src/test/java/org/jclouds/io/payloads/MultipartFormTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.io.payloads;
 
 import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -111,7 +112,7 @@ public class MultipartFormTest {
       assertEquals(Strings2.toStringAndClose(multipartForm.openStream()), expects);
 
       // test repeatable
-      assert multipartForm.isRepeatable();
+      assertThat(multipartForm.isRepeatable()).isTrue();
       assertEquals(Strings2.toStringAndClose(multipartForm.openStream()), expects);
       assertEquals(multipartForm.getContentMetadata().getContentLength(), Long.valueOf(352));
    }

--- a/core/src/test/java/org/jclouds/lifecycle/config/LifeCycleModuleTest.java
+++ b/core/src/test/java/org/jclouds/lifecycle/config/LifeCycleModuleTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.lifecycle.config;
 
 import static com.google.inject.name.Names.named;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.Constants.PROPERTY_USER_THREADS;
 
 import java.io.Closeable;
@@ -46,7 +47,7 @@ public class LifeCycleModuleTest {
    @Test
    void testBindsExecutor() {
       Injector i = createInjector();
-      assert i.getInstance(Key.get(ListeningExecutorService.class, named(PROPERTY_USER_THREADS))) != null;
+      assertThat(i.getInstance(Key.get(ListeningExecutorService.class, named(PROPERTY_USER_THREADS))) != null).isTrue();
    }
 
    private Injector createInjector() {
@@ -64,8 +65,8 @@ public class LifeCycleModuleTest {
    @Test
    void testBindsCloser() {
       Injector i = createInjector();
-      assert i.getInstance(Closer.class) != null;
-      assert i.getInstance(Closer.class).getState() == Closer.State.AVAILABLE;
+      assertThat(i.getInstance(Closer.class) != null).isTrue();
+      assertThat(i.getInstance(Closer.class).getState() == Closer.State.AVAILABLE).isTrue();
    }
 
    @Test
@@ -73,12 +74,12 @@ public class LifeCycleModuleTest {
       Injector i = createInjector();
       ListeningExecutorService executor = i.getInstance(Key.get(ListeningExecutorService.class,
             named(PROPERTY_USER_THREADS)));
-      assert !executor.isShutdown();
+      assertThat(!executor.isShutdown()).isTrue();
       Closer closer = i.getInstance(Closer.class);
-      assert closer.getState() == Closer.State.AVAILABLE;
+      assertThat(closer.getState() == Closer.State.AVAILABLE).isTrue();
       closer.close();
-      assert executor.isShutdown();
-      assert closer.getState() == Closer.State.DONE;
+      assertThat(executor.isShutdown()).isTrue();
+      assertThat(closer.getState() == Closer.State.DONE).isTrue();
    }
 
    @Test
@@ -86,12 +87,12 @@ public class LifeCycleModuleTest {
       Injector i = createInjector();
       ListeningExecutorService userExecutor = i.getInstance(Key.get(ListeningExecutorService.class,
             named(PROPERTY_USER_THREADS)));
-      assert !userExecutor.isShutdown();
+      assertThat(!userExecutor.isShutdown()).isTrue();
       Closer closer = i.getInstance(Closer.class);
-      assert closer.getState() == Closer.State.AVAILABLE;
+      assertThat(closer.getState() == Closer.State.AVAILABLE).isTrue();
       closer.close();
-      assert userExecutor.isShutdown();
-      assert closer.getState() == Closer.State.DONE;
+      assertThat(userExecutor.isShutdown()).isTrue();
+      assertThat(closer.getState() == Closer.State.DONE).isTrue();
    }
 
    static class PostConstructable {
@@ -111,7 +112,7 @@ public class LifeCycleModuleTest {
          }
       });
       PostConstructable postConstructable = i.getInstance(PostConstructable.class);
-      assert postConstructable.isStarted;
+      assertThat(postConstructable.isStarted).isTrue();
    }
 
    @Test
@@ -127,10 +128,10 @@ public class LifeCycleModuleTest {
          public void close() throws IOException {
              try {
                  closeStart.countDown();
-                 assert closer.getState() == Closer.State.PROCESSING;
+                 assertThat(closer.getState() == Closer.State.PROCESSING).isTrue();
                  closeDone.await();
              } catch (InterruptedException e) {
-                 assert false : e.getMessage();
+                 assertThat(false).as(e.getMessage()).isTrue();
              }
          }
       });
@@ -141,7 +142,7 @@ public class LifeCycleModuleTest {
             try {
                closer.close();
             } catch (IOException e) {
-               assert false : e.getMessage();
+               assertThat(false).as(e.getMessage()).isTrue();
             }
          }
       });
@@ -150,13 +151,13 @@ public class LifeCycleModuleTest {
 
       closeStart.await();
 
-      assert closer.getState() == Closer.State.PROCESSING;
+      assertThat(closer.getState() == Closer.State.PROCESSING).isTrue();
 
       closeDone.countDown();
 
       thread.join();
 
-      assert closer.getState() == Closer.State.DONE;
+      assertThat(closer.getState() == Closer.State.DONE).isTrue();
    }
 
    @Test
@@ -180,7 +181,7 @@ public class LifeCycleModuleTest {
             try {
                closer.close();
             } catch (IOException e) {
-               assert false : e.getMessage();
+               assertThat(false).as(e.getMessage()).isTrue();
             }
          }
       };
@@ -196,6 +197,6 @@ public class LifeCycleModuleTest {
 
       verify(closeable);
 
-      assert closer.getState() == Closer.State.DONE;
+      assertThat(closer.getState() == Closer.State.DONE).isTrue();
    }
 }

--- a/core/src/test/java/org/jclouds/logging/config/BindLoggersAnnotatedWithResourceTest.java
+++ b/core/src/test/java/org/jclouds/logging/config/BindLoggersAnnotatedWithResourceTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.logging.config;
 
 import static com.google.inject.matcher.Matchers.any;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.createMock;
 import static org.testng.Assert.assertEquals;
 
@@ -85,14 +86,14 @@ public class BindLoggersAnnotatedWithResourceTest {
       Field field = A.class.getDeclaredField("logger");
       AssignLoggerToField<A> assigner = new AssignLoggerToField<A>(logger, field);
       assigner.afterInjection(a);
-      assert field.get(a).equals(logger);
+      assertThat(field.get(a).equals(logger)).isTrue();
    }
 
    @Test
    public void testLoggerFieldsAnnotatedWithResource() throws SecurityException,
             NoSuchFieldException {
       LoggerFieldsAnnotatedWithResource predicate = new LoggerFieldsAnnotatedWithResource();
-      assert predicate.apply(A.class.getDeclaredField("logger"));
+      assertThat(predicate.apply(A.class.getDeclaredField("logger"))).isTrue();
    }
 
    public static class C {
@@ -104,7 +105,7 @@ public class BindLoggersAnnotatedWithResourceTest {
    public void testLoggerFieldsAnnotatedWithInjectReturnsNull() throws SecurityException,
             NoSuchFieldException {
       LoggerFieldsAnnotatedWithResource predicate = new LoggerFieldsAnnotatedWithResource();
-      assert !predicate.apply(C.class.getDeclaredField("logger"));
+      assertThat(!predicate.apply(C.class.getDeclaredField("logger"))).isTrue();
    }
 
    public static class D {

--- a/core/src/test/java/org/jclouds/providers/internal/BaseProviderMetadataTest.java
+++ b/core/src/test/java/org/jclouds/providers/internal/BaseProviderMetadataTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.providers.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.reflect.Reflection2.typeToken;
 import static org.testng.Assert.assertEquals;
 
@@ -50,7 +51,7 @@ public abstract class BaseProviderMetadataTest {
       ProviderMetadata providerMetadata = Providers.withId(toTest.getId());
 
       assertEquals(toTest, providerMetadata);
-      assert providerMetadata.getLinkedServices().contains(toTest.getId());
+      assertThat(providerMetadata.getLinkedServices().contains(toTest.getId())).isTrue();
    }
 
    @Test
@@ -58,22 +59,22 @@ public abstract class BaseProviderMetadataTest {
       if (expectedApi == null)
          Logger.getAnonymousLogger().warning("please update your test class");
       ImmutableSet<ProviderMetadata> ofApi = ImmutableSet.copyOf(Providers.apiMetadataAssignableFrom(typeToken(expectedApi.getClass())));
-      assert ofApi.contains(toTest) : String.format("%s not found in %s", toTest, ofApi);
+      assertThat(ofApi.contains(toTest)).as(String.format("%s not found in %s", toTest, ofApi)).isTrue();
    }
 
    @Test
    public void testTransformableToContains() {
       for (TypeToken<? extends View> view : views) {
          ImmutableSet<ProviderMetadata> ofType = ImmutableSet.copyOf(Providers.viewableAs(view));
-         assert ofType.contains(toTest) : String.format("%s not found in %s for %s", toTest, ofType,
-                  view);
+         assertThat(ofType.contains(toTest)).as(String.format("%s not found in %s for %s", toTest, ofType,
+                  view)).isTrue();
       }
    }
 
    @Test
    public void testAllContains() {
       ImmutableSet<ProviderMetadata> all = ImmutableSet.copyOf(Providers.all());
-      assert all.contains(toTest) : String.format("%s not found in %s", toTest, all);
+      assertThat(all.contains(toTest)).as(String.format("%s not found in %s", toTest, all)).isTrue();
    }
 
 }

--- a/core/src/test/java/org/jclouds/rest/internal/BaseHttpApiMetadataTest.java
+++ b/core/src/test/java/org/jclouds/rest/internal/BaseHttpApiMetadataTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 package org.jclouds.rest.internal;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.reflect.Reflection2.typeToken;
 
 import java.util.Set;
@@ -40,7 +41,7 @@ public abstract class BaseHttpApiMetadataTest extends BaseApiMetadataTest {
    @Test
    public void testContextAssignableFromRestContext() {
       Set<ApiMetadata> all = ImmutableSet.copyOf(Apis.contextAssignableFrom(typeToken(ApiContext.class)));
-      assert all.contains(toTest) : String.format("%s not found in %s", toTest, all);
+      assertThat(all.contains(toTest)).as(String.format("%s not found in %s", toTest, all)).isTrue();
    }
 
 }

--- a/core/src/test/java/org/jclouds/rest/internal/BaseRestApiTest.java
+++ b/core/src/test/java/org/jclouds/rest/internal/BaseRestApiTest.java
@@ -20,6 +20,7 @@ import static com.google.common.hash.Hashing.md5;
 import static com.google.common.net.HttpHeaders.TRANSFER_ENCODING;
 import static com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor;
 import static com.google.inject.name.Names.named;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.createMock;
 import static org.jclouds.Constants.PROPERTY_USER_THREADS;
 import static org.testng.Assert.assertEquals;
@@ -128,7 +129,7 @@ public abstract class BaseRestApiTest {
          assertEquals(md.getContentLength(), length);
       } else {
          assertEquals(request.getFirstHeaderOrNull(TRANSFER_ENCODING), "chunked");
-         assert md.getContentLength() == null || md.getContentLength().equals(length);
+         assertThat(md.getContentLength() == null || md.getContentLength().equals(length)).isTrue();
       }
       assertEquals(md.getContentType(), contentType);
       assertEquals(md.getContentDisposition(), contentDispositon);

--- a/core/src/test/java/org/jclouds/rest/internal/RestAnnotationProcessorTest.java
+++ b/core/src/test/java/org/jclouds/rest/internal/RestAnnotationProcessorTest.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.io.Payloads.newInputStreamPayload;
 import static org.jclouds.io.Payloads.newStringPayload;
 import static org.jclouds.providers.AnonymousProviderMetadata.forApiOnEndpoint;
@@ -2269,8 +2270,8 @@ public class RestAnnotationProcessorTest extends BaseRestApiTest {
             ImmutableList.<Object> of("robot", "egg"))).getHeaders();
       assertEquals(headers.size(), 2);
       Collection<String> values = headers.get("header");
-      assert values.contains("robot");
-      assert values.contains("egg");
+      assertThat(values.contains("robot")).isTrue();
+      assertThat(values.contains("egg")).isTrue();
    }
 
    interface TestEndpointParams {

--- a/core/src/test/java/org/jclouds/util/InetAddresses2Test.java
+++ b/core/src/test/java/org/jclouds/util/InetAddresses2Test.java
@@ -18,18 +18,20 @@ package org.jclouds.util;
 
 import org.testng.annotations.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Test(groups = "unit")
 public class InetAddresses2Test {
 
    @Test
    public void testPrivateIPAddress() {
-      assert InetAddresses2.isPrivateIPAddress("10.0.0.0");
-      assert !InetAddresses2.isPrivateIPAddress("11.0.0.0");
-      assert InetAddresses2.isPrivateIPAddress("172.16.0.0");
-      assert !InetAddresses2.isPrivateIPAddress("172.32.0.0");
-      assert InetAddresses2.isPrivateIPAddress("172.16.0.0");
-      assert !InetAddresses2.isPrivateIPAddress("192.169.0.0");
-      assert InetAddresses2.isPrivateIPAddress("192.168.0.0");
+      assertThat(InetAddresses2.isPrivateIPAddress("10.0.0.0")).isTrue();
+      assertThat(!InetAddresses2.isPrivateIPAddress("11.0.0.0")).isTrue();
+      assertThat(InetAddresses2.isPrivateIPAddress("172.16.0.0")).isTrue();
+      assertThat(!InetAddresses2.isPrivateIPAddress("172.32.0.0")).isTrue();
+      assertThat(InetAddresses2.isPrivateIPAddress("172.16.0.0")).isTrue();
+      assertThat(!InetAddresses2.isPrivateIPAddress("192.169.0.0")).isTrue();
+      assertThat(InetAddresses2.isPrivateIPAddress("192.168.0.0")).isTrue();
    }
 
 }

--- a/core/src/test/java/org/jclouds/util/Strings2Test.java
+++ b/core/src/test/java/org/jclouds/util/Strings2Test.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.util.Strings2.urlDecode;
 import static org.jclouds.util.Strings2.urlEncode;
 import static org.testng.Assert.assertEquals;
@@ -28,8 +29,8 @@ import com.google.common.collect.ImmutableMap;
 public class Strings2Test {
 
    public void testIsEncoded() {
-      assert Strings2.isUrlEncoded("/read-tests/%73%6f%6d%65%20%66%69%6c%65");
-      assert !Strings2.isUrlEncoded("/read-tests/ tep");
+      assertThat(Strings2.isUrlEncoded("/read-tests/%73%6f%6d%65%20%66%69%6c%65")).isTrue();
+      assertThat(!Strings2.isUrlEncoded("/read-tests/ tep")).isTrue();
    }
 
    public void testNoDoubleEncode() {
@@ -56,11 +57,11 @@ public class Strings2Test {
    }
 
    public void testIsCidrFormat() {
-      assert Strings2.isCidrFormat("1.2.3.4/5");
-      assert Strings2.isCidrFormat("0.0.0.0/0");
-      assert !Strings2.isCidrFormat("banana");
-      assert !Strings2.isCidrFormat("1.2.3.4");
-      assert !Strings2.isCidrFormat("500.500.500.500/2423");
+      assertThat(Strings2.isCidrFormat("1.2.3.4/5")).isTrue();
+      assertThat(Strings2.isCidrFormat("0.0.0.0/0")).isTrue();
+      assertThat(!Strings2.isCidrFormat("banana")).isTrue();
+      assertThat(!Strings2.isCidrFormat("1.2.3.4")).isTrue();
+      assertThat(!Strings2.isCidrFormat("500.500.500.500/2423")).isTrue();
    }
       
 }

--- a/drivers/bouncycastle/src/test/java/org/jclouds/encryption/bouncycastle/BouncyCastleCryptoTest.java
+++ b/drivers/bouncycastle/src/test/java/org/jclouds/encryption/bouncycastle/BouncyCastleCryptoTest.java
@@ -24,6 +24,8 @@ import org.testng.annotations.Test;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Test(groups = "unit")
 public class BouncyCastleCryptoTest  {
 
@@ -31,6 +33,6 @@ public class BouncyCastleCryptoTest  {
    protected void createCrypto() {
       Injector i = Guice.createInjector(new BouncyCastleCryptoModule());
       Crypto crypto = i.getInstance(Crypto.class);
-      assert crypto instanceof BouncyCastleCrypto;
+      assertThat(crypto instanceof BouncyCastleCrypto).isTrue();
    }
 }

--- a/drivers/gae/src/test/java/org/jclouds/gae/ConvertToGaeRequestTest.java
+++ b/drivers/gae/src/test/java/org/jclouds/gae/ConvertToGaeRequestTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.gae;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.File;
@@ -81,7 +82,7 @@ public class ConvertToGaeRequestTest {
    void testConvertRequestSetsFetchOptions() throws IOException {
       HttpRequest request = HttpRequest.builder().method(HttpMethod.GET).endpoint(endPoint).build();
       HTTPRequest gaeRequest = req.apply(request);
-      assert gaeRequest.getFetchOptions() != null;
+      assertThat(gaeRequest.getFetchOptions() != null).isTrue();
    }
 
    @Test
@@ -99,7 +100,7 @@ public class ConvertToGaeRequestTest {
    void testConvertRequestNoContent() throws IOException {
       HttpRequest request = HttpRequest.builder().method(HttpMethod.GET).endpoint(endPoint).build();
       HTTPRequest gaeRequest = req.apply(request);
-      assert gaeRequest.getPayload() == null;
+      assertThat(gaeRequest.getPayload() == null).isTrue();
       assertEquals(gaeRequest.getHeaders().size(), 1);  // user agent
       assertEquals(gaeRequest.getHeaders().get(0).getName(), HttpHeaders.USER_AGENT);
       assertEquals(gaeRequest.getHeaders().get(0).getValue(), "jclouds/1.0 urlfetch/1.4.3");

--- a/drivers/joda/src/test/java/org/jclouds/date/joda/JodaDateServiceTest.java
+++ b/drivers/joda/src/test/java/org/jclouds/date/joda/JodaDateServiceTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.date.joda;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Date;
@@ -45,7 +46,7 @@ public class JodaDateServiceTest extends DateServiceTest {
    protected void createDateService() {
       Injector i = Guice.createInjector(new JodaDateServiceModule());
       dateService = i.getInstance(DateService.class);
-      assert dateService instanceof JodaDateService;
+      assertThat(dateService instanceof JodaDateService).isTrue();
    }
 
    @Override

--- a/drivers/jsch/src/test/java/org/jclouds/ssh/jsch/JschSshClientLiveTest.java
+++ b/drivers/jsch/src/test/java/org/jclouds/ssh/jsch/JschSshClientLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.ssh.jsch;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
@@ -173,7 +174,7 @@ public class JschSshClientLiveTest {
    public void testGetEtcPassword() throws IOException {
       Payload input = setupClient().get("/etc/passwd");
       String contents = Strings2.toStringAndClose(input.openStream());
-      assert contents.indexOf("root") >= 0 : "no root in " + contents;
+      assertThat(contents.indexOf("root") >= 0).as("no root in " + contents).isTrue();
    }
 
    @Test

--- a/drivers/jsch/src/test/java/org/jclouds/ssh/jsch/JschSshClientTest.java
+++ b/drivers/jsch/src/test/java/org/jclouds/ssh/jsch/JschSshClientTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.ssh.jsch;
 
 import static com.google.inject.name.Names.bindProperties;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.ConnectException;
@@ -77,48 +78,48 @@ public class JschSshClientTest {
    }
 
    public void testExceptionClassesRetry() {
-      assert ssh.shouldRetry(new JSchException("io error", new IOException("socket closed")));
-      assert ssh.shouldRetry(new JSchException("connect error", new ConnectException("problem")));
-      assert ssh.shouldRetry(new IOException("channel %s is not open", new NullPointerException()));
-      assert ssh.shouldRetry(new IOException("channel %s is not open", new NullPointerException(null)));
+      assertThat(ssh.shouldRetry(new JSchException("io error", new IOException("socket closed")))).isTrue();
+      assertThat(ssh.shouldRetry(new JSchException("connect error", new ConnectException("problem")))).isTrue();
+      assertThat(ssh.shouldRetry(new IOException("channel %s is not open", new NullPointerException()))).isTrue();
+      assertThat(ssh.shouldRetry(new IOException("channel %s is not open", new NullPointerException(null)))).isTrue();
    }
 
    public void testOnlyRetryAuthWhenSet() throws UnknownHostException {
       JschSshClient ssh1 = createClient();
-      assert !ssh1.shouldRetry(new AuthorizationException("problem", null));
+      assertThat(!ssh1.shouldRetry(new AuthorizationException("problem", null))).isTrue();
       ssh1.retryAuth = true;
-      assert ssh1.shouldRetry(new AuthorizationException("problem", null));
+      assertThat(ssh1.shouldRetry(new AuthorizationException("problem", null))).isTrue();
    }
 
    public void testOnlyRetryAuthWhenSetViaProperties() throws UnknownHostException {
       Properties props = new Properties();
       props.setProperty("jclouds.ssh.retry-auth", "true");
       JschSshClient ssh1 = createClient(props);
-      assert ssh1.shouldRetry(new AuthorizationException("problem", null));
+      assertThat(ssh1.shouldRetry(new AuthorizationException("problem", null))).isTrue();
    }
 
    public void testExceptionMessagesRetry() {
-      assert !ssh.shouldRetry(new NullPointerException(""));
-      assert !ssh.shouldRetry(new NullPointerException((String) null));
-      assert ssh.shouldRetry(new JSchException("Session.connect: java.io.IOException: End of IO Stream Read"));
-      assert ssh.shouldRetry(new JSchException("Session.connect: invalid data"));
-      assert ssh.shouldRetry(new JSchException("Session.connect: java.net.SocketException: Connection reset"));
+      assertThat(!ssh.shouldRetry(new NullPointerException(""))).isTrue();
+      assertThat(!ssh.shouldRetry(new NullPointerException((String) null))).isTrue();
+      assertThat(ssh.shouldRetry(new JSchException("Session.connect: java.io.IOException: End of IO Stream Read"))).isTrue();
+      assertThat(ssh.shouldRetry(new JSchException("Session.connect: invalid data"))).isTrue();
+      assertThat(ssh.shouldRetry(new JSchException("Session.connect: java.net.SocketException: Connection reset"))).isTrue();
    }
 
    public void testDoNotRetryOnGeneralSftpError() {
       // http://sourceforge.net/mailarchive/forum.php?thread_name=CAARMrHVhASeku48xoAgWEb-nEpUuYkMA03PoA5TvvFdk%3DjGKMA%40mail.gmail.com&forum_name=jsch-users
-      assert !ssh.shouldRetry(new SftpException(ChannelSftp.SSH_FX_FAILURE, new NullPointerException().toString()));
+      assertThat(!ssh.shouldRetry(new SftpException(ChannelSftp.SSH_FX_FAILURE, new NullPointerException().toString()))).isTrue();
    }
 
    public void testCausalChainHasMessageContaining() {
-      assert ssh.causalChainHasMessageContaining(
+      assertThat(ssh.causalChainHasMessageContaining(
             new JSchException("Session.connect: java.io.IOException: End of IO Stream Read")).apply(
-            " End of IO Stream Read");
-      assert ssh.causalChainHasMessageContaining(new JSchException("Session.connect: invalid data")).apply(
-            " invalid data");
-      assert ssh.causalChainHasMessageContaining(
-            new JSchException("Session.connect: java.net.SocketException: Connection reset")).apply("java.net.Socket");
-      assert !ssh.causalChainHasMessageContaining(new NullPointerException()).apply(" End of IO Stream Read");
+            " End of IO Stream Read")).isTrue();
+      assertThat(ssh.causalChainHasMessageContaining(new JSchException("Session.connect: invalid data")).apply(
+            " invalid data")).isTrue();
+      assertThat(ssh.causalChainHasMessageContaining(
+            new JSchException("Session.connect: java.net.SocketException: Connection reset")).apply("java.net.Socket")).isTrue();
+      assertThat(!ssh.causalChainHasMessageContaining(new NullPointerException()).apply(" End of IO Stream Read")).isTrue();
    }
 
    public void testRetryOnToStringNpe() throws UnknownHostException {
@@ -127,7 +128,7 @@ public class JschSshClientTest {
       // ensure we test toString on the exception independently
       props.setProperty("jclouds.ssh.retryable-messages", nex.toString());
       JschSshClient ssh1 = createClient(props);
-      assert ssh1.shouldRetry(new RuntimeException(nex));
+      assertThat(ssh1.shouldRetry(new RuntimeException(nex))).isTrue();
    }
 
    private static class ExceptionWithStrangeToString extends RuntimeException {
@@ -140,7 +141,7 @@ public class JschSshClientTest {
       Properties props = new Properties();
       props.setProperty("jclouds.ssh.retryable-messages", "foo-bar");
       JschSshClient ssh1 = createClient(props);
-      assert ssh1.shouldRetry(new RuntimeException(nex));
+      assertThat(ssh1.shouldRetry(new RuntimeException(nex))).isTrue();
    }
 
    public void testRetryNotOnToStringCustomMismatch() throws UnknownHostException {
@@ -148,7 +149,7 @@ public class JschSshClientTest {
       Properties props = new Properties();
       props.setProperty("jclouds.ssh.retryable-messages", "foo-baR");
       JschSshClient ssh1 = createClient(props);
-      assert !ssh1.shouldRetry(new RuntimeException(nex));
+      assertThat(!ssh1.shouldRetry(new RuntimeException(nex))).isTrue();
    }
 
 }

--- a/drivers/jsch/src/test/java/org/jclouds/ssh/jsch/config/JschSshClientModuleTest.java
+++ b/drivers/jsch/src/test/java/org/jclouds/ssh/jsch/config/JschSshClientModuleTest.java
@@ -28,6 +28,8 @@ import com.google.common.net.HostAndPort;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Tests the ability to configure a {@link JschSshClient}
  */
@@ -40,6 +42,6 @@ public class JschSshClientModuleTest {
       SshClient.Factory factory = i.getInstance(SshClient.Factory.class);
       SshClient connection = factory.create(HostAndPort.fromParts("localhost", 22), LoginCredentials.builder().user("username")
             .password("password").build());
-      assert connection instanceof JschSshClient;
+      assertThat(connection instanceof JschSshClient).isTrue();
    }
 }

--- a/drivers/sshj/src/test/java/org/jclouds/sshj/SshjSshClientLiveTest.java
+++ b/drivers/sshj/src/test/java/org/jclouds/sshj/SshjSshClientLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.sshj;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
@@ -159,7 +160,7 @@ public class SshjSshClientLiveTest {
    public void testGetEtcPassword() throws IOException {
       Payload input = setupClient().get("/etc/passwd");
       String contents = Strings2.toStringAndClose(input.openStream());
-      assert contents.indexOf("root") >= 0 : "no root in " + contents;
+      assertThat(contents.indexOf("root") >= 0).as("no root in " + contents).isTrue();
    }
 
    public void testExecHostname() throws IOException, InterruptedException {

--- a/drivers/sshj/src/test/java/org/jclouds/sshj/SshjSshClientTest.java
+++ b/drivers/sshj/src/test/java/org/jclouds/sshj/SshjSshClientTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.sshj;
 
 import static com.google.inject.name.Names.bindProperties;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
@@ -92,45 +93,45 @@ public class SshjSshClientTest {
    }
 
    public void testExceptionClassesRetry() {
-      assert ssh.shouldRetry(new ConnectionException("Read timed out", new SSHException("Read timed out",
-            new SocketTimeoutException("Read timed out"))));
-      assert ssh.shouldRetry(new SFTPException("Failure!"));
-      assert ssh.shouldRetry(new SocketTimeoutException("connect timed out"));
-      assert ssh.shouldRetry(new TransportException("socket closed"));
-      assert ssh.shouldRetry(new ConnectionException("problem"));
-      assert ssh.shouldRetry(new ConnectException("Connection refused"));
-      assert !ssh.shouldRetry(new IOException("channel %s is not open", new NullPointerException()));
+      assertThat(ssh.shouldRetry(new ConnectionException("Read timed out", new SSHException("Read timed out",
+            new SocketTimeoutException("Read timed out"))))).isTrue();
+      assertThat(ssh.shouldRetry(new SFTPException("Failure!"))).isTrue();
+      assertThat(ssh.shouldRetry(new SocketTimeoutException("connect timed out"))).isTrue();
+      assertThat(ssh.shouldRetry(new TransportException("socket closed"))).isTrue();
+      assertThat(ssh.shouldRetry(new ConnectionException("problem"))).isTrue();
+      assertThat(ssh.shouldRetry(new ConnectException("Connection refused"))).isTrue();
+      assertThat(!ssh.shouldRetry(new IOException("channel %s is not open", new NullPointerException()))).isTrue();
    }
 
    public void testOnlyRetryAuthWhenSet() {
       SshjSshClient ssh1 = createClient();
-      assert !ssh1.shouldRetry(new AuthorizationException("problem", null));
-      assert !ssh1.shouldRetry(new UserAuthException("problem", null));
+      assertThat(!ssh1.shouldRetry(new AuthorizationException("problem", null))).isTrue();
+      assertThat(!ssh1.shouldRetry(new UserAuthException("problem", null))).isTrue();
       ssh1.retryAuth = true;
-      assert ssh1.shouldRetry(new AuthorizationException("problem", null));
-      assert ssh1.shouldRetry(new UserAuthException("problem", null));
+      assertThat(ssh1.shouldRetry(new AuthorizationException("problem", null))).isTrue();
+      assertThat(ssh1.shouldRetry(new UserAuthException("problem", null))).isTrue();
    }
 
    public void testOnlyRetryAuthWhenSetViaProperties() {
       Properties props = new Properties();
       props.setProperty("jclouds.ssh.retry-auth", "true");
       SshjSshClient ssh1 = createClient(props);
-      assert ssh1.shouldRetry(new AuthorizationException("problem", null));
-      assert ssh1.shouldRetry(new UserAuthException("problem", null));
+      assertThat(ssh1.shouldRetry(new AuthorizationException("problem", null))).isTrue();
+      assertThat(ssh1.shouldRetry(new UserAuthException("problem", null))).isTrue();
    }
 
    public void testExceptionMessagesRetry() {
-      assert !ssh.shouldRetry(new SSHException(""));
-      assert !ssh.shouldRetry(new NullPointerException((String) null));
+      assertThat(!ssh.shouldRetry(new SSHException(""))).isTrue();
+      assertThat(!ssh.shouldRetry(new NullPointerException((String) null))).isTrue();
    }
 
    public void testCausalChainHasMessageContaining() {
-      assert ssh.causalChainHasMessageContaining(
+      assertThat(ssh.causalChainHasMessageContaining(
             new SSHException("Session.connect: java.io.IOException: End of IO Stream Read")).apply(
-            " End of IO Stream Read");
-      assert ssh.causalChainHasMessageContaining(
-            new SSHException("Session.connect: java.net.SocketException: Connection reset")).apply("java.net.Socket");
-      assert !ssh.causalChainHasMessageContaining(new NullPointerException()).apply(" End of IO Stream Read");
+            " End of IO Stream Read")).isTrue();
+      assertThat(ssh.causalChainHasMessageContaining(
+            new SSHException("Session.connect: java.net.SocketException: Connection reset")).apply("java.net.Socket")).isTrue();
+      assertThat(!ssh.causalChainHasMessageContaining(new NullPointerException()).apply(" End of IO Stream Read")).isTrue();
    }
 
    public void testRetryOnToStringNpe() {
@@ -139,7 +140,7 @@ public class SshjSshClientTest {
       // ensure we test toString on the exception independently
       props.setProperty("jclouds.ssh.retryable-messages", nex.toString());
       SshjSshClient ssh1 = createClient(props);
-      assert ssh1.shouldRetry(new RuntimeException(nex));
+      assertThat(ssh1.shouldRetry(new RuntimeException(nex))).isTrue();
    }
 
    private static class ExceptionWithStrangeToString extends RuntimeException {
@@ -155,7 +156,7 @@ public class SshjSshClientTest {
       Properties props = new Properties();
       props.setProperty("jclouds.ssh.retryable-messages", "foo-bar");
       SshjSshClient ssh1 = createClient(props);
-      assert ssh1.shouldRetry(new RuntimeException(nex));
+      assertThat(ssh1.shouldRetry(new RuntimeException(nex))).isTrue();
    }
 
    public void testDontThrowIOExceptionOnClear() throws Exception {
@@ -175,7 +176,7 @@ public class SshjSshClientTest {
       Properties props = new Properties();
       props.setProperty("jclouds.ssh.retryable-messages", "foo-baR");
       SshjSshClient ssh1 = createClient(props);
-      assert !ssh1.shouldRetry(new RuntimeException(nex));
+      assertThat(!ssh1.shouldRetry(new RuntimeException(nex))).isTrue();
    }
 
    public void testRetriesLoggedAtInfoWithCount() throws Exception {

--- a/drivers/sshj/src/test/java/org/jclouds/sshj/config/SshjSshClientModuleTest.java
+++ b/drivers/sshj/src/test/java/org/jclouds/sshj/config/SshjSshClientModuleTest.java
@@ -26,6 +26,8 @@ import com.google.common.net.HostAndPort;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Tests the ability to configure a {@link SshjSshClient}
  */
@@ -38,6 +40,6 @@ public class SshjSshClientModuleTest {
       SshClient.Factory factory = i.getInstance(SshClient.Factory.class);
       SshClient connection = factory.create(HostAndPort.fromParts("localhost", 22), LoginCredentials.builder().user("username")
             .password("password").build());
-      assert connection instanceof SshjSshClient;
+      assertThat(connection instanceof SshjSshClient).isTrue();
    }
 }

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/AWSEC2ComputeServiceLiveTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/AWSEC2ComputeServiceLiveTest.java
@@ -18,6 +18,7 @@ package org.jclouds.aws.ec2.compute;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Sets.newTreeSet;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.compute.domain.OsFamily.AMZN_LINUX;
 import static org.jclouds.compute.options.RunScriptOptions.Builder.runAsRoot;
 import static org.jclouds.compute.util.ComputeServiceUtils.getCores;
@@ -115,7 +116,7 @@ public class AWSEC2ComputeServiceLiveTest extends EC2ComputeServiceLiveTest {
          template.getOptions().as(AWSEC2TemplateOptions.class).keyPair(result.getKeyName());
 
          // pass in the private key, so that we can run a script with it
-         assert result.getKeyMaterial() != null : result;
+         assertThat(result.getKeyMaterial() != null).as(String.valueOf(result)).isTrue();
          template.getOptions().overrideLoginPrivateKey(result.getKeyMaterial());
 
          Set<? extends NodeMetadata> nodes = client.createNodesInGroup(group, 1, template);
@@ -124,8 +125,8 @@ public class AWSEC2ComputeServiceLiveTest extends EC2ComputeServiceLiveTest {
          checkUserMetadataContains(first, userMetadata);
          checkTagsInNodeEquals(first, tags);
 
-         assert first.getCredentials() != null : first;
-         assert first.getCredentials().identity != null : first;
+         assertThat(first.getCredentials() != null).as(String.valueOf(first)).isTrue();
+         assertThat(first.getCredentials().identity != null).as(String.valueOf(first)).isTrue();
 
          startedId = first.getProviderId();
 
@@ -133,7 +134,7 @@ public class AWSEC2ComputeServiceLiveTest extends EC2ComputeServiceLiveTest {
                   .describeInstancesInRegion(region, startedId))));
 
          assertEquals(instance.getKeyName(), group);
-         assert instance.getSpotInstanceRequestId() != null;
+         assertThat(instance.getSpotInstanceRequestId() != null).isTrue();
          assertEquals(instance.getMonitoringState(), MonitoringState.ENABLED);
 
          // generate some load
@@ -163,7 +164,7 @@ public class AWSEC2ComputeServiceLiveTest extends EC2ComputeServiceLiveTest {
                                                              .period(60)
                                                              .statistic(Statistics.AVERAGE)
                                                              .build());
-            assert !datapoints.isEmpty() : instance;
+            assertThat(!datapoints.isEmpty()).as(String.valueOf(instance)).isTrue();
          } finally {
             monitoringApi.close();
          }
@@ -175,7 +176,7 @@ public class AWSEC2ComputeServiceLiveTest extends EC2ComputeServiceLiveTest {
          SecurityGroup secgroup = getOnlyElement(securityGroupApi.describeSecurityGroupsInRegion(instance
                   .getRegion(), "jclouds#" + group));
 
-         assert secgroup.size() == 0 : secgroup;
+         assertThat(secgroup.size() == 0).as(String.valueOf(secgroup)).isTrue();
 
          // try to run a script with the original keyPair
          runScriptWithCreds(group, first.getOperatingSystem(), LoginCredentials.builder().user(
@@ -202,14 +203,14 @@ public class AWSEC2ComputeServiceLiveTest extends EC2ComputeServiceLiveTest {
 
       assertEquals(defaultSize, smallest);
 
-      assert getCores(smallest) <= getCores(fastest) : String.format("%s ! <= %s", smallest, fastest);
+      assertThat(getCores(smallest) <= getCores(fastest)).as(String.format("%s ! <= %s", smallest, fastest)).isTrue();
       // m4.10xlarge is slower but has more cores than c4.8xlarge
       // assert getCores(biggest) <= getCores(fastest) : String.format("%s ! <= %s", biggest, fastest);
       // assert getCores(fastest) >= getCores(biggest) : String.format("%s ! >= %s", fastest, biggest);
 
-      assert biggest.getRam() >= fastest.getRam() : String.format("%s ! >= %s", biggest, fastest);
-      assert biggest.getRam() >= smallest.getRam() : String.format("%s ! >= %s", biggest, smallest);
+      assertThat(biggest.getRam() >= fastest.getRam()).as(String.format("%s ! >= %s", biggest, fastest)).isTrue();
+      assertThat(biggest.getRam() >= smallest.getRam()).as(String.format("%s ! >= %s", biggest, smallest)).isTrue();
 
-      assert getCores(fastest) >= getCores(smallest) : String.format("%s ! >= %s", fastest, smallest);
+      assertThat(getCores(fastest) >= getCores(smallest)).as(String.format("%s ! >= %s", fastest, smallest)).isTrue();
    }
 }

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/AWSEC2TemplateBuilderLiveTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/AWSEC2TemplateBuilderLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.aws.ec2.compute;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.compute.domain.OsFamily.AMZN_LINUX;
 import static org.jclouds.compute.util.ComputeServiceUtils.getCores;
 import static org.jclouds.http.internal.TrackingJavaUrlHttpCommandExecutorService.getInvokerOfRequestAtIndex;
@@ -79,9 +80,9 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
             // http://www.regular-expressions.info/lookaround.html
             .imageDescriptionMatches("^(?!.*(daily|testing)).*ubuntu-images.*$").osFamily(OsFamily.UBUNTU).build();
 
-      assert template.getImage().getProviderId().startsWith("ami-") : template;
-      assert template.getImage().getDescription().indexOf("test") == -1 : template;
-      assert template.getImage().getDescription().indexOf("daily") == -1 : template;
+      assertThat(template.getImage().getProviderId().startsWith("ami-")).as(String.valueOf(template)).isTrue();
+      assertThat(template.getImage().getDescription().indexOf("test") == -1).as(String.valueOf(template)).isTrue();
+      assertThat(template.getImage().getDescription().indexOf("daily") == -1).as(String.valueOf(template)).isTrue();
       assertEquals(template.getImage().getVersion(), "20100224");
       assertEquals(template.getImage().getOperatingSystem().getVersion(), "10.04");
       assertEquals(template.getImage().getOperatingSystem().is64Bit(), false);
@@ -106,9 +107,9 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
             // http://www.regular-expressions.info/lookaround.html
             .imageDescriptionMatches("^(?!.*(daily|testing)).*ubuntu-images.*$").osFamily(OsFamily.UBUNTU).build();
 
-      assert template.getImage().getProviderId().startsWith("ami-") : template;
-      assert template.getImage().getDescription().indexOf("test") == -1 : template;
-      assert template.getImage().getDescription().indexOf("daily") == -1 : template;
+      assertThat(template.getImage().getProviderId().startsWith("ami-")).as(String.valueOf(template)).isTrue();
+      assertThat(template.getImage().getDescription().indexOf("test") == -1).as(String.valueOf(template)).isTrue();
+      assertThat(template.getImage().getDescription().indexOf("daily") == -1).as(String.valueOf(template)).isTrue();
       assertEquals(template.getImage().getOperatingSystem().getVersion(), "10.04");
       assertEquals(template.getImage().getOperatingSystem().is64Bit(), false);
       assertEquals(template.getImage().getOperatingSystem().getFamily(), OsFamily.UBUNTU);
@@ -125,7 +126,7 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
       Template template = view.getComputeService().templateBuilder().imageId("us-east-1/ami-ccb35ea5")
             .hardwareId(InstanceType.M2_2XLARGE).locationId("us-east-1b").build();
 
-      assert template.getImage().getProviderId().startsWith("ami-") : template;
+      assertThat(template.getImage().getProviderId().startsWith("ami-")).as(String.valueOf(template)).isTrue();
       assertEquals(template.getImage().getOperatingSystem().getVersion(), "5.4");
       assertEquals(template.getImage().getOperatingSystem().is64Bit(), true);
       assertEquals(template.getImage().getOperatingSystem().getFamily(), OsFamily.CENTOS);
@@ -141,7 +142,7 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
    @Test
    public void testDefaultTemplateBuilder() throws IOException {
       Template defaultTemplate = view.getComputeService().templateBuilder().build();
-      assert defaultTemplate.getImage().getProviderId().startsWith("ami-") : defaultTemplate;
+      assertThat(defaultTemplate.getImage().getProviderId().startsWith("ami-")).as(String.valueOf(defaultTemplate)).isTrue();
       assertTrue(defaultTemplate.getImage().getOperatingSystem().getVersion().contains("201"),
               "Default template version should include '201' but is "
                       + defaultTemplate.getImage().getOperatingSystem().getVersion());
@@ -158,7 +159,7 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
 
       Template defaultTemplate = view.getComputeService().templateBuilder().osFamily(AMZN_LINUX)
             .imageMatches(EC2ImagePredicates.rootDeviceType(RootDeviceType.INSTANCE_STORE)).build();
-      assert defaultTemplate.getImage().getProviderId().startsWith("ami-") : defaultTemplate;
+      assertThat(defaultTemplate.getImage().getProviderId().startsWith("ami-")).as(String.valueOf(defaultTemplate)).isTrue();
       assertEquals(defaultTemplate.getImage().getOperatingSystem().getVersion(), "pv-2015.03.rc-1");
       assertEquals(defaultTemplate.getImage().getOperatingSystem().is64Bit(), true);
       assertEquals(defaultTemplate.getImage().getOperatingSystem().getFamily(), AMZN_LINUX);
@@ -171,7 +172,7 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
    @Test
    public void testFastestTemplateBuilder() throws IOException {
       Template fastestTemplate = view.getComputeService().templateBuilder().fastest().osFamily(AMZN_LINUX).build();
-      assert fastestTemplate.getImage().getProviderId().startsWith("ami-") : fastestTemplate;
+      assertThat(fastestTemplate.getImage().getProviderId().startsWith("ami-")).as(String.valueOf(fastestTemplate)).isTrue();
       assertEquals(fastestTemplate.getHardware().getProviderId(), InstanceType.C4_8XLARGE);
       assertEquals(fastestTemplate.getImage().getOperatingSystem().getVersion(), "2011.09.2");
       assertEquals(fastestTemplate.getImage().getOperatingSystem().is64Bit(), true);
@@ -188,7 +189,7 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
       Template microTemplate = view.getComputeService().templateBuilder().hardwareId(InstanceType.T1_MICRO)
             .osFamily(OsFamily.UBUNTU).osVersionMatches("10.10").os64Bit(true).build();
 
-      assert microTemplate.getImage().getProviderId().startsWith("ami-") : microTemplate;
+      assertThat(microTemplate.getImage().getProviderId().startsWith("ami-")).as(String.valueOf(microTemplate)).isTrue();
       assertEquals(microTemplate.getImage().getOperatingSystem().getVersion(), "10.10");
       assertEquals(microTemplate.getImage().getOperatingSystem().is64Bit(), true);
       assertEquals(microTemplate.getImage().getOperatingSystem().getFamily(), OsFamily.UBUNTU);
@@ -212,7 +213,7 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
          assertEquals(context.getComputeService().listImages().size(), 0);
 
          Template template = context.getComputeService().templateBuilder().imageId("us-east-1/ami-ccb35ea5").build();
-         assert template.getImage().getProviderId().startsWith("ami-") : template;
+         assertThat(template.getImage().getProviderId().startsWith("ami-")).as(String.valueOf(template)).isTrue();
          assertEquals(template.getImage().getOperatingSystem().getVersion(), "5.4");
          assertEquals(template.getImage().getOperatingSystem().is64Bit(), true);
          assertEquals(template.getImage().getOperatingSystem().getFamily(), OsFamily.CENTOS);
@@ -245,7 +246,7 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
          assertEquals(context.getComputeService().listImages().size(), 0);
 
          Template template = context.getComputeService().templateBuilder().imageId("us-east-1/ami-ccb35ea5").build();
-         assert template.getImage().getProviderId().startsWith("ami-") : template;
+         assertThat(template.getImage().getProviderId().startsWith("ami-")).as(String.valueOf(template)).isTrue();
          assertEquals(template.getImage().getOperatingSystem().getVersion(), "5.4");
          assertEquals(template.getImage().getOperatingSystem().is64Bit(), true);
          assertEquals(template.getImage().getOperatingSystem().getFamily(), OsFamily.CENTOS);
@@ -282,15 +283,15 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
                ImmutableSet.<Module> of(new Log4JLoggingModule(),
                      TrackingJavaUrlHttpCommandExecutorService.newTrackingModule(commandsInvoked)));
 
-         assert context.getComputeService().listAssignableLocations().size() < this.view.getComputeService()
-               .listAssignableLocations().size();
+         assertThat(context.getComputeService().listAssignableLocations().size() < this.view.getComputeService()
+               .listAssignableLocations().size()).isTrue();
 
          assertOnlyOneRegionQueriedForAvailabilityZone(commandsInvoked);
 
-         assert context.getComputeService().listImages().size() < this.view.getComputeService().listImages().size();
+         assertThat(context.getComputeService().listImages().size() < this.view.getComputeService().listImages().size()).isTrue();
 
          Template template = context.getComputeService().templateBuilder().imageId("eu-west-1/ami-a33b06d7").build();
-         assert template.getImage().getProviderId().startsWith("ami-") : template;
+         assertThat(template.getImage().getProviderId().startsWith("ami-")).as(String.valueOf(template)).isTrue();
          assertEquals(template.getImage().getOperatingSystem().getVersion(), "2011.09.2");
          assertEquals(template.getImage().getOperatingSystem().is64Bit(), true);
          assertEquals(template.getImage().getOperatingSystem().getFamily(), AMZN_LINUX);
@@ -308,7 +309,7 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
 
    private static void assertOnlyOneRegionQueriedForAvailabilityZone(List<HttpCommand> commandsInvoked)
          throws NoSuchMethodException {
-      assert commandsInvoked.size() == 2 : commandsInvoked;
+      assertThat(commandsInvoked.size() == 2).as(String.valueOf(commandsInvoked)).isTrue();
       assertInvokedCommand(getInvokerOfRequestAtIndex(commandsInvoked, 0), Invokable.from(
             AvailabilityZoneAndRegionApi.class.getMethod("describeRegions", DescribeRegionsOptions[].class)));
       assertInvokedCommand(getInvokerOfRequestAtIndex(commandsInvoked, 1), Invokable.from(
@@ -323,7 +324,7 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
       String imageId = "us-east-1/ami-44d02f2d";
       Template defaultTemplate = view.getComputeService().templateBuilder().imageId(imageId)
             .imageMatches(EC2ImagePredicates.rootDeviceType(RootDeviceType.INSTANCE_STORE)).build();
-      assert defaultTemplate.getImage().getProviderId().startsWith("ami-") : defaultTemplate;
+      assertThat(defaultTemplate.getImage().getProviderId().startsWith("ami-")).as(String.valueOf(defaultTemplate)).isTrue();
       assertEquals(defaultTemplate.getImage().getId(), imageId);
    }
    
@@ -337,15 +338,15 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
 
       assertEquals(defaultSize, smallest);
 
-      assert getCores(smallest) <= getCores(fastest) : String.format("%s ! <= %s", smallest, fastest);
+      assertThat(getCores(smallest) <= getCores(fastest)).as(String.format("%s ! <= %s", smallest, fastest)).isTrue();
       // m4.10xlarge is slower but has more cores than c4.8xlarge
       // assert getCores(biggest) <= getCores(fastest) : String.format("%s ! <= %s", biggest, fastest);
       // assert getCores(fastest) >= getCores(biggest) : String.format("%s ! >= %s", fastest, biggest);
 
-      assert biggest.getRam() >= fastest.getRam() : String.format("%s ! >= %s", biggest, fastest);
-      assert biggest.getRam() >= smallest.getRam() : String.format("%s ! >= %s", biggest, smallest);
+      assertThat(biggest.getRam() >= fastest.getRam()).as(String.format("%s ! >= %s", biggest, fastest)).isTrue();
+      assertThat(biggest.getRam() >= smallest.getRam()).as(String.format("%s ! >= %s", biggest, smallest)).isTrue();
 
-      assert getCores(fastest) >= getCores(smallest) : String.format("%s ! >= %s", fastest, smallest);
+      assertThat(getCores(fastest) >= getCores(smallest)).as(String.format("%s ! >= %s", fastest, smallest)).isTrue();
    }
    
    @Test

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/functions/AWSRunningInstanceToNodeMetadataTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/functions/AWSRunningInstanceToNodeMetadataTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.aws.ec2.compute.functions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Map;
@@ -69,7 +70,7 @@ public class AWSRunningInstanceToNodeMetadataTest {
    @BeforeTest
    protected void setUpInjector() {
       dateService = Guice.createInjector().getInstance(DateService.class);
-      assert dateService != null;
+      assertThat(dateService != null).isTrue();
    }
 
    @Test

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/options/AWSEC2TemplateOptionsTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/options/AWSEC2TemplateOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.aws.ec2.compute.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.authorizePublicKey;
 import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.blockOnPort;
 import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.enableMonitoring;
@@ -212,41 +213,41 @@ public class AWSEC2TemplateOptionsTest {
       AWSEC2TemplateOptions options = new AWSEC2TemplateOptions();
       options.noKeyPair();
       assertEquals(options.getKeyPair(), null);
-      assert !options.shouldAutomaticallyCreateKeyPair();
+      assertThat(!options.shouldAutomaticallyCreateKeyPair()).isTrue();
    }
 
    @Test
    public void testFalsenoKeyPair() {
       AWSEC2TemplateOptions options = new AWSEC2TemplateOptions();
       assertEquals(options.getKeyPair(), null);
-      assert options.shouldAutomaticallyCreateKeyPair();
+      assertThat(options.shouldAutomaticallyCreateKeyPair()).isTrue();
    }
 
    @Test
    public void testnoKeyPairStatic() {
       AWSEC2TemplateOptions options = noKeyPair();
       assertEquals(options.getKeyPair(), null);
-      assert !options.shouldAutomaticallyCreateKeyPair();
+      assertThat(!options.shouldAutomaticallyCreateKeyPair()).isTrue();
    }
 
    @Test
    public void testMonitoringEnabledDefault() {
       AWSEC2TemplateOptions options = new AWSEC2TemplateOptions();
-      assert !options.isMonitoringEnabled();
+      assertThat(!options.isMonitoringEnabled()).isTrue();
    }
 
    @Test
    public void testMonitoringEnabled() {
       AWSEC2TemplateOptions options = new AWSEC2TemplateOptions();
       options.enableMonitoring();
-      assert options.isMonitoringEnabled();
+      assertThat(options.isMonitoringEnabled()).isTrue();
    }
 
    @Test
    public void testEnableMonitoringStatic() {
       AWSEC2TemplateOptions options = enableMonitoring();
       assertEquals(options.getKeyPair(), null);
-      assert options.isMonitoringEnabled();
+      assertThat(options.isMonitoringEnabled()).isTrue();
    }
 
    // superclass tests

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/AWSAMIApiLiveTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/AWSAMIApiLiveTest.java
@@ -19,6 +19,7 @@ package org.jclouds.aws.ec2.features;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.aws.ec2.options.AWSDescribeImagesOptions.Builder.filters;
 import static org.jclouds.ec2.options.RegisterImageBackedByEbsOptions.Builder.addNewBlockDevice;
 import static org.jclouds.ec2.options.RunInstancesOptions.Builder.withBlockDeviceMappings;
@@ -78,7 +79,7 @@ public class AWSAMIApiLiveTest extends AMIApiLiveTest {
                   .put("root-device-type", "ebs")//
                   .build()).ownedBy("137112412989", "099720109477"));
       assertNotNull(ccResults);
-      assert ccResults.size() >= 34 : ccResults;
+      assertThat(ccResults.size() >= 34).as(String.valueOf(ccResults)).isTrue();
    }
 
    protected RegisterImageBackedByEbsOptions newBlockDeviceOption() {
@@ -118,7 +119,7 @@ public class AWSAMIApiLiveTest extends AMIApiLiveTest {
                  device.getVolumeId());
          snapshotsToDelete.add(snapshot.getId());
          Predicate<Snapshot> snapshotted = retry(new SnapshotCompleted(ec2Api.getElasticBlockStoreApi().get()), 600, 10, SECONDS);
-         assert snapshotted.apply(snapshot);
+         assertThat(snapshotted.apply(snapshot)).isTrue();
          return snapshot;
       } finally {
          if (instanceId != null)

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/AWSInstanceApiLiveTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/AWSInstanceApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.aws.ec2.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertNotNull;
 
 import java.util.Set;
@@ -52,7 +53,7 @@ public class AWSInstanceApiLiveTest extends BaseComputeServiceContextLiveTest {
       for (String region : view.unwrapApi(AWSEC2Api.class).getAvailabilityZoneAndRegionApi().get().describeRegions().keySet()) {
          Set<? extends Reservation<? extends RunningInstance>> allResults = client.describeInstancesInRegion(region);
          assertNotNull(allResults);
-         assert allResults.size() > 0 : allResults.size();
+         assertThat(allResults.size() > 0).as(String.valueOf(allResults.size())).isTrue();
       }
    }
 }

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/AWSKeyPairApiLiveTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/AWSKeyPairApiLiveTest.java
@@ -19,6 +19,7 @@ package org.jclouds.aws.ec2.features;
 import static com.google.common.collect.Iterables.get;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Sets.newTreeSet;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.compute.options.TemplateOptions.Builder.overrideLoginCredentials;
 import static org.jclouds.compute.predicates.NodePredicates.inGroup;
 import static org.jclouds.compute.predicates.NodePredicates.runningInGroup;
@@ -91,11 +92,11 @@ public class AWSKeyPairApiLiveTest extends BaseComputeServiceContextLiveTest {
          Set<? extends NodeMetadata> nodes = noSshContext.getComputeService().createNodesInGroup(group, 1, options);
 
          NodeMetadata first = get(nodes, 0);
-         assert first.getCredentials() != null : first;
-         assert first.getCredentials().identity != null : first;
+         assertThat(first.getCredentials() != null).as(String.valueOf(first)).isTrue();
+         assertThat(first.getCredentials().identity != null).as(String.valueOf(first)).isTrue();
          // credentials should not be present as the import public key call doesn't have access to
          // the related private key
-         assert first.getCredentials().credential == null : first;
+         assertThat(first.getCredentials().credential == null).as(String.valueOf(first)).isTrue();
 
          AWSRunningInstance instance = getInstance(instanceApi, first.getProviderId());
 

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/PlacementGroupApiLiveTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/PlacementGroupApiLiveTest.java
@@ -19,6 +19,7 @@ package org.jclouds.aws.ec2.features;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Sets.newTreeSet;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.util.Predicates2.retry;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -154,7 +155,7 @@ public class PlacementGroupApiLiveTest extends BaseComputeServiceContextLiveTest
    }
 
    private void verifyPlacementGroup(String region, String groupName) {
-      assert availableTester.apply(new PlacementGroup(region, groupName, "cluster", State.PENDING)) : group;
+      assertThat(availableTester.apply(new PlacementGroup(region, groupName, "cluster", State.PENDING))).as(String.valueOf(group)).isTrue();
       Set<PlacementGroup> oneResult = client.getPlacementGroupApi().get().describePlacementGroupsInRegion(region,
                groupName);
       assertNotNull(oneResult);
@@ -162,14 +163,14 @@ public class PlacementGroupApiLiveTest extends BaseComputeServiceContextLiveTest
       group = oneResult.iterator().next();
       assertEquals(group.getName(), groupName);
       assertEquals(group.getStrategy(), "cluster");
-      assert availableTester.apply(group) : group;
+      assertThat(availableTester.apply(group)).as(String.valueOf(group)).isTrue();
    }
 
    public void testStartHS1Instance() throws Exception {
 
       Template template = view.getComputeService().templateBuilder()
                .fromHardware(EC2HardwareBuilder.hs1_8xlarge().build()).osFamily(OsFamily.AMZN_LINUX).build();
-      assert template != null : "The returned template was null, but it should have a value.";
+      assertThat(template != null).as("The returned template was null, but it should have a value.").isTrue();
       assertEquals(template.getHardware().getProviderId(), InstanceType.HS1_8XLARGE);
       assertEquals(template.getImage().getUserMetadata().get("virtualizationType"), "hvm");
       assertEquals(template.getImage().getUserMetadata().get("hypervisor"), "xen");
@@ -203,7 +204,7 @@ public class PlacementGroupApiLiveTest extends BaseComputeServiceContextLiveTest
    protected void tearDownContext() {
       if (group != null) {
          client.getPlacementGroupApi().get().deletePlacementGroupInRegion(group.getRegion(), group.getName());
-         assert deletedTester.apply(group) : group;
+         assertThat(deletedTester.apply(group)).as(String.valueOf(group)).isTrue();
       }
       super.tearDownContext();
    }

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/SpotInstanceApiLiveTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/SpotInstanceApiLiveTest.java
@@ -19,6 +19,7 @@ package org.jclouds.aws.ec2.features;
 import static com.google.common.base.Predicates.in;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.aws.ec2.options.DescribeSpotPriceHistoryOptions.Builder.from;
 import static org.jclouds.aws.ec2.options.RequestSpotInstancesOptions.Builder.launchGroup;
 import static org.jclouds.util.Predicates2.retry;
@@ -134,19 +135,18 @@ public class SpotInstanceApiLiveTest  extends BaseComputeServiceContextLiveTest 
       for (String region : Region.DEFAULT_REGIONS) {
          Set<Spot> spots = client.getSpotInstanceApi().get().describeSpotPriceHistoryInRegion(region, from(new Date()));
          assertNotNull(spots);
-         assert !spots.isEmpty();
+         assertThat(!spots.isEmpty()).isTrue();
          for (Spot spot : spots) {
-            assert spot.getSpotPrice() > 0 : spots;
+            assertThat(spot.getSpotPrice() > 0).as(String.valueOf(spots)).isTrue();
             assertEquals(spot.getRegion(), region);
-            assert in(
+            assertThat(in(
                     ImmutableSet.of("Linux/UNIX", "Linux/UNIX (Amazon VPC)", "SUSE Linux", "SUSE Linux (Amazon VPC)",
-                              "Windows", "Windows (Amazon VPC)")).apply(spot.getProductDescription()) : spot;
-            assert // sometimes get D2 type, which we don't yet enumerate
-                    spot.getInstanceType().startsWith("d2.") ||
+                              "Windows", "Windows (Amazon VPC)")).apply(spot.getProductDescription())).as(String.valueOf(spot)).isTrue();
+            assertThat(spot.getInstanceType().startsWith("d2.") ||
                     in(ImmutableSet.of("c1.medium", "c1.xlarge", "cc1.4xlarge", "cg1.4xlarge", "cc2.8xlarge", "m1.large",
                               "m1.small", "m1.medium", "m1.xlarge", "m2.2xlarge", "m2.4xlarge", "m2.xlarge", "m3.xlarge",
                               "m3.2xlarge", "t1.micro", "cr1.8xlarge", "c4.large", "c4.xlarge", "c4.2xlarge", "c4.4xlarge",
-                              "c4.8xlarge")).apply(spot.getInstanceType()) : spot;
+                              "c4.8xlarge")).apply(spot.getInstanceType())).as(String.valueOf(spot)).isTrue();
          }
       }
 
@@ -181,10 +181,10 @@ public class SpotInstanceApiLiveTest  extends BaseComputeServiceContextLiveTest 
       SpotInstanceRequest spot = refresh(request);
       assertNotNull(spot);
       assertEquals(spot, request);
-      assert activeTester.apply(request) : refresh(request);
+      assertThat(activeTester.apply(request)).as(String.valueOf(refresh(request))).isTrue();
       System.out.println(System.currentTimeMillis() - start);
       spot = refresh(request);
-      assert spot.getInstanceId() != null : spot;
+      assertThat(spot.getInstanceId() != null).as(String.valueOf(spot)).isTrue();
       instance = getOnlyElement(getOnlyElement(client.getInstanceApi().get().describeInstancesInRegion(spot.getRegion(),
                spot.getInstanceId())));
       assertEquals(instance.getSpotInstanceRequestId(), spot.getId());

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/options/AWSDescribeImagesOptionsTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/options/AWSDescribeImagesOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.aws.ec2.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.aws.ec2.options.AWSDescribeImagesOptions.Builder.executableBy;
 import static org.jclouds.aws.ec2.options.AWSDescribeImagesOptions.Builder.filters;
 import static org.jclouds.aws.ec2.options.AWSDescribeImagesOptions.Builder.imageIds;
@@ -36,8 +37,8 @@ public class AWSDescribeImagesOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(AWSDescribeImagesOptions.class);
-      assert !String.class.isAssignableFrom(AWSDescribeImagesOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(AWSDescribeImagesOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(AWSDescribeImagesOptions.class)).isTrue();
    }
 
    @Test

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/options/AWSRunInstancesOptionsTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/options/AWSRunInstancesOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.aws.ec2.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.asType;
 import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.enableMonitoring;
 import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withBlockDeviceMappings;
@@ -46,8 +47,8 @@ public class AWSRunInstancesOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(AWSRunInstancesOptions.class);
-      assert !String.class.isAssignableFrom(AWSRunInstancesOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(AWSRunInstancesOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(AWSRunInstancesOptions.class)).isTrue();
    }
 
    @Test

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/options/DescribeSpotPriceHistoryOptionsTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/options/DescribeSpotPriceHistoryOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.aws.ec2.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.aws.ec2.options.DescribeSpotPriceHistoryOptions.Builder.from;
 import static org.jclouds.aws.ec2.options.DescribeSpotPriceHistoryOptions.Builder.instanceType;
 import static org.jclouds.aws.ec2.options.DescribeSpotPriceHistoryOptions.Builder.productDescription;
@@ -36,8 +37,8 @@ public class DescribeSpotPriceHistoryOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(DescribeSpotPriceHistoryOptions.class);
-      assert !String.class.isAssignableFrom(DescribeSpotPriceHistoryOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(DescribeSpotPriceHistoryOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(DescribeSpotPriceHistoryOptions.class)).isTrue();
    }
 
    @Test

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/options/RequestSpotInstancesOptionsTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/options/RequestSpotInstancesOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.aws.ec2.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.aws.ec2.options.RequestSpotInstancesOptions.Builder.availabilityZoneGroup;
 import static org.jclouds.aws.ec2.options.RequestSpotInstancesOptions.Builder.launchGroup;
 import static org.jclouds.aws.ec2.options.RequestSpotInstancesOptions.Builder.type;
@@ -38,8 +39,8 @@ public class RequestSpotInstancesOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(RequestSpotInstancesOptions.class);
-      assert !String.class.isAssignableFrom(RequestSpotInstancesOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(RequestSpotInstancesOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(RequestSpotInstancesOptions.class)).isTrue();
    }
 
    @Test

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/parse/DescribeInstancesResponseTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/parse/DescribeInstancesResponseTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.aws.ec2.parse;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -53,7 +54,7 @@ public class DescribeInstancesResponseTest extends BaseEC2HandlerTest {
    protected void setUpInjector() {
       super.setUpInjector();
       dateService = injector.getInstance(DateService.class);
-      assert dateService != null;
+      assertThat(dateService != null).isTrue();
    }
 
    public void test() {

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/xml/AWSDescribeInstancesResponseHandlerTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/xml/AWSDescribeInstancesResponseHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.aws.ec2.xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -63,7 +64,7 @@ public class AWSDescribeInstancesResponseHandlerTest extends BaseEC2HandlerTest 
    protected void setUpInjector() {
       super.setUpInjector();
       dateService = injector.getInstance(DateService.class);
-      assert dateService != null;
+      assertThat(dateService != null).isTrue();
    }
 
 

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/xml/AWSRunInstancesResponseHandlerTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/xml/AWSRunInstancesResponseHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.aws.ec2.xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -65,7 +66,7 @@ public class AWSRunInstancesResponseHandlerTest extends BaseEC2HandlerTest {
       });
       factory = injector.getInstance(ParseSax.Factory.class);
       dateService = injector.getInstance(DateService.class);
-      assert dateService != null;
+      assertThat(dateService != null).isTrue();
    }
 
    public void testApplyInputStream() {

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/xml/SpotInstanceHandlerTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/xml/SpotInstanceHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.aws.ec2.xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -62,7 +63,7 @@ public class SpotInstanceHandlerTest extends BaseEC2HandlerTest {
       });
       factory = injector.getInstance(ParseSax.Factory.class);
       dateService = injector.getInstance(DateService.class);
-      assert dateService != null;
+      assertThat(dateService != null).isTrue();
    }
 
    public void testApplyInputStream() {

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/xml/SpotInstancesHandlerTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/xml/SpotInstancesHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.aws.ec2.xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -63,7 +64,7 @@ public class SpotInstancesHandlerTest extends BaseEC2HandlerTest {
       });
       factory = injector.getInstance(ParseSax.Factory.class);
       dateService = injector.getInstance(DateService.class);
-      assert dateService != null;
+      assertThat(dateService != null).isTrue();
    }
 
    public void testDescribe() {

--- a/providers/aws-s3/src/test/java/org/jclouds/aws/s3/services/AWSBucketsLiveTest.java
+++ b/providers/aws-s3/src/test/java/org/jclouds/aws/s3/services/AWSBucketsLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.aws.s3.services;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.s3.options.PutBucketOptions.Builder.withBucketAcl;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -41,7 +42,7 @@ public class AWSBucketsLiveTest extends BucketsLiveTest {
       String bucketName = getContainerName();
       try {
          String location = getApi().getBucketLocation(bucketName);
-         assert location.equals(Region.US_STANDARD) : "bucket: " + bucketName + " location: " + location;
+         assertThat(location.equals(Region.US_STANDARD)).as("bucket: " + bucketName + " location: " + location).isTrue();
       } finally {
          returnContainer(bucketName);
       }

--- a/providers/azureblob/src/test/java/org/jclouds/azureblob/AzureBlobClientLiveTest.java
+++ b/providers/azureblob/src/test/java/org/jclouds/azureblob/AzureBlobClientLiveTest.java
@@ -77,7 +77,7 @@ public class AzureBlobClientLiveTest extends BaseBlobStoreIntegrationTest {
    @Test
    public void testListContainers() throws Exception {
       Set<ContainerProperties> response = getApi().listContainers();
-      assert null != response;
+      assertThat(null != response).isTrue();
       long initialContainerCount = response.size();
       assertTrue(initialContainerCount >= 0);
 
@@ -101,7 +101,7 @@ public class AzureBlobClientLiveTest extends BaseBlobStoreIntegrationTest {
          }
       }
       Set<ContainerProperties> response = getApi().listContainers(includeMetadata());
-      assert null != response;
+      assertThat(null != response).isTrue();
       long containerCount = response.size();
       assertTrue(containerCount >= 1);
       ListBlobsResponse list = getApi().listBlobs(privateContainer);
@@ -170,7 +170,7 @@ public class AzureBlobClientLiveTest extends BaseBlobStoreIntegrationTest {
 
       BoundedSet<ContainerProperties> response = getApi().listContainers(
             ListOptions.Builder.prefix(privateContainer).maxResults(1).includeMetadata());
-      assert null != response;
+      assertThat(null != response).isTrue();
       long initialContainerCount = response.size();
       assertTrue(initialContainerCount >= 0);
       assertEquals(privateContainer, response.getPrefix());
@@ -234,7 +234,7 @@ public class AzureBlobClientLiveTest extends BaseBlobStoreIntegrationTest {
       assertEquals(base16().lowerCase().encode(md5),
             base16().lowerCase().encode(object.getProperties().getContentMetadata().getContentMD5()));
       // Test HEAD of missing object
-      assert getApi().getBlobProperties(privateContainer, "non-existent-object") == null;
+      assertThat(getApi().getBlobProperties(privateContainer, "non-existent-object") == null).isTrue();
 
       // Test HEAD of object
       BlobProperties metadata = getApi().getBlobProperties(privateContainer, object.getProperties().getName());
@@ -260,7 +260,7 @@ public class AzureBlobClientLiveTest extends BaseBlobStoreIntegrationTest {
       assertThat(eTag2).isNotNull().isNotEqualTo(eTag);
 
       // Test GET of missing object
-      assert getApi().getBlob(privateContainer, "non-existent-object") == null;
+      assertThat(getApi().getBlob(privateContainer, "non-existent-object") == null).isTrue();
 
       // Test GET of object (including updated metadata)
       AzureBlob getBlob = getApi().getBlob(privateContainer, object.getProperties().getName());
@@ -316,7 +316,7 @@ public class AzureBlobClientLiveTest extends BaseBlobStoreIntegrationTest {
                GetOptions.Builder.ifETagDoesntMatch(newEtag));
       } catch (Exception e) {
          HttpResponseException httpEx = Throwables2.getFirstThrowableOfType(e, HttpResponseException.class);
-         assert httpEx != null : "expected http exception, not " + e;
+         assertThat(httpEx != null).as("expected http exception, not " + e).isTrue();
          assertEquals(httpEx.getResponse().getStatusCode(), 304);
       }
 

--- a/providers/azureblob/src/test/java/org/jclouds/azureblob/xml/AccountNameEnumerationResultsHandlerTest.java
+++ b/providers/azureblob/src/test/java/org/jclouds/azureblob/xml/AccountNameEnumerationResultsHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.azureblob.xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -48,7 +49,7 @@ public class AccountNameEnumerationResultsHandlerTest extends BaseHandlerTest {
    protected void setUpInjector() {
       super.setUpInjector();
       dateService = injector.getInstance(DateService.class);
-      assert dateService != null;
+      assertThat(dateService != null).isTrue();
    }
 
    public void testApplyInputStream() {

--- a/providers/azureblob/src/test/java/org/jclouds/azureblob/xml/ContainerNameEnumerationResultsHandlerTest.java
+++ b/providers/azureblob/src/test/java/org/jclouds/azureblob/xml/ContainerNameEnumerationResultsHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.azureblob.xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -50,7 +51,7 @@ public class ContainerNameEnumerationResultsHandlerTest extends BaseHandlerTest 
    protected void setUpInjector() {
       super.setUpInjector();
       dateService = injector.getInstance(DateService.class);
-      assert dateService != null;
+      assertThat(dateService != null).isTrue();
    }
 
    public void testApplyInputStream() {

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/predicates/RecordPredicatesTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/predicates/RecordPredicatesTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.dynect.v3.predicates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.dynect.v3.domain.RecordId.recordIdBuilder;
 import static org.jclouds.dynect.v3.predicates.RecordPredicates.typeEquals;
 
@@ -32,11 +33,11 @@ public class RecordPredicatesTest {
 
    @Test
    public void testTypeEqualsWhenEqual() {
-      assert typeEquals("SOA").apply(recordId);
+      assertThat(typeEquals("SOA").apply(recordId)).isTrue();
    }
 
    @Test
    public void testTypeEqualsWhenNotEqual() {
-      assert !typeEquals("NS").apply(recordId);
+      assertThat(!typeEquals("NS").apply(recordId)).isTrue();
    }
 }

--- a/providers/glesys/src/test/java/org/jclouds/glesys/GleSYSApiTest.java
+++ b/providers/glesys/src/test/java/org/jclouds/glesys/GleSYSApiTest.java
@@ -25,6 +25,8 @@ import org.jclouds.rest.internal.BaseRestAnnotationProcessingTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Tests behavior of {@code GleSYSApi}
  */
@@ -40,10 +42,10 @@ public class GleSYSApiTest extends BaseRestAnnotationProcessingTest<GleSYSApi> {
    }
    
    public void testSync() throws SecurityException, NoSuchMethodException, InterruptedException, ExecutionException {
-      assert syncApi.getServerApi() != null;
-      assert syncApi.getIpApi() != null;
-      assert syncApi.getDomainApi() != null;
-      assert syncApi.getArchiveApi() != null;
+      assertThat(syncApi.getServerApi() != null).isTrue();
+      assertThat(syncApi.getIpApi() != null).isTrue();
+      assertThat(syncApi.getDomainApi() != null).isTrue();
+      assertThat(syncApi.getArchiveApi() != null).isTrue();
    }
 
    @BeforeClass

--- a/providers/glesys/src/test/java/org/jclouds/glesys/features/ServerApiLiveTest.java
+++ b/providers/glesys/src/test/java/org/jclouds/glesys/features/ServerApiLiveTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.glesys.features;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.util.Predicates2.retry;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -93,13 +94,13 @@ public class ServerApiLiveTest extends BaseGleSYSApiWithAServerLiveTest {
    private void checkAllowedArguments(AllowedArgumentsForCreateServer t) {
       assertNotNull(t);
 
-      assert !t.getDataCenters().isEmpty() : t;
-      assert !t.getCpuCoreOptions().getAllowedUnits().isEmpty() : t;
-      assert !t.getDiskSizesInGB().getAllowedUnits().isEmpty() : t;
-      assert !t.getMemorySizesInMB().getAllowedUnits().isEmpty() : t;
-      assert !t.getTemplateNames().isEmpty() : t;
-      assert !t.getTransfersInGB().getAllowedUnits().isEmpty() : t;
-      assert !t.getTransfersInGB().getAllowedUnits().isEmpty() : t;
+      assertThat(!t.getDataCenters().isEmpty()).as(String.valueOf(t)).isTrue();
+      assertThat(!t.getCpuCoreOptions().getAllowedUnits().isEmpty()).as(String.valueOf(t)).isTrue();
+      assertThat(!t.getDiskSizesInGB().getAllowedUnits().isEmpty()).as(String.valueOf(t)).isTrue();
+      assertThat(!t.getMemorySizesInMB().getAllowedUnits().isEmpty()).as(String.valueOf(t)).isTrue();
+      assertThat(!t.getTemplateNames().isEmpty()).as(String.valueOf(t)).isTrue();
+      assertThat(!t.getTransfersInGB().getAllowedUnits().isEmpty()).as(String.valueOf(t)).isTrue();
+      assertThat(!t.getTransfersInGB().getAllowedUnits().isEmpty()).as(String.valueOf(t)).isTrue();
    }
 
    public void testListTemplates() throws Exception {
@@ -116,8 +117,8 @@ public class ServerApiLiveTest extends BaseGleSYSApiWithAServerLiveTest {
       assertNotNull(t.getOs());
 
       assertNotNull(t.getPlatform());
-      assert t.getMinDiskSize() > 0 : t;
-      assert t.getMinMemSize() > 0 : t;
+      assertThat(t.getMinDiskSize() > 0).as(String.valueOf(t)).isTrue();
+      assertThat(t.getMinMemSize() > 0).as(String.valueOf(t)).isTrue();
     }
 
    public void testListServers() throws Exception {
@@ -265,11 +266,11 @@ public class ServerApiLiveTest extends BaseGleSYSApiWithAServerLiveTest {
 
    private void checkServer(ServerDetails server) {
       // description can be null
-      assert server.getCpuCores() > 0 : server;
-      assert server.getDiskSizeGB() > 0 : server;
-      assert server.getMemorySizeMB() > 0 : server;
-      assert server.getCost() != null;
-      assert server.getTransferGB() > 0 : server;
+      assertThat(server.getCpuCores() > 0).as(String.valueOf(server)).isTrue();
+      assertThat(server.getDiskSizeGB() > 0).as(String.valueOf(server)).isTrue();
+      assertThat(server.getMemorySizeMB() > 0).as(String.valueOf(server)).isTrue();
+      assertThat(server.getCost() != null).isTrue();
+      assertThat(server.getTransferGB() > 0).as(String.valueOf(server)).isTrue();
 
       assertNotNull(server.getTemplateName());
       assertNotNull(server.getIps());
@@ -282,14 +283,14 @@ public class ServerApiLiveTest extends BaseGleSYSApiWithAServerLiveTest {
 
       for (ResourceStatus usage : new ResourceStatus[] { status.getCpu(), status.getDisk(), status.getMemory() }) {
          assertNotNull(usage);
-         assert usage.getMax() >= 0.0 : status;
-         assert usage.getUsage() >= 0.0 : status;
+         assertThat(usage.getMax() >= 0.0).as(String.valueOf(status)).isTrue();
+         assertThat(usage.getUsage() >= 0.0).as(String.valueOf(status)).isTrue();
 
          assertNotNull(usage.getUnit());
       }
 
       assertNotNull(status.getUptime());
-      assert status.getUptime().getCurrent() > 0 : status;
+      assertThat(status.getUptime().getCurrent() > 0).as(String.valueOf(status)).isTrue();
       assertNotNull(status.getUptime().getUnit());
    }
 }

--- a/providers/gogrid/src/test/java/org/jclouds/gogrid/GoGridApiTest.java
+++ b/providers/gogrid/src/test/java/org/jclouds/gogrid/GoGridApiTest.java
@@ -23,6 +23,8 @@ import org.jclouds.gogrid.features.BaseGoGridApiTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Tests behavior of {@code GoGridApi}
  */
@@ -34,11 +36,11 @@ public class GoGridApiTest extends BaseGoGridApiTest<GoGridApi> {
 
    public void testSync() throws SecurityException, NoSuchMethodException, InterruptedException,
             ExecutionException {
-      assert syncClient.getImageServices() != null;
-      assert syncClient.getIpServices() != null;
-      assert syncClient.getJobServices() != null;
-      assert syncClient.getLoadBalancerServices() != null;
-      assert syncClient.getServerServices() != null;
+      assertThat(syncClient.getImageServices() != null).isTrue();
+      assertThat(syncClient.getIpServices() != null).isTrue();
+      assertThat(syncClient.getJobServices() != null).isTrue();
+      assertThat(syncClient.getLoadBalancerServices() != null).isTrue();
+      assertThat(syncClient.getServerServices() != null).isTrue();
    }
 
    @BeforeClass

--- a/providers/gogrid/src/test/java/org/jclouds/gogrid/GoGridLiveTestDisabled.java
+++ b/providers/gogrid/src/test/java/org/jclouds/gogrid/GoGridLiveTestDisabled.java
@@ -19,6 +19,7 @@ package org.jclouds.gogrid;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.util.Predicates2.retry;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -114,7 +115,7 @@ public class GoGridLiveTestDisabled extends BaseApiLiveTest<GoGridApi> {
                "GSI-f8979644-e646-4711-ad58-d98a5fa3612c", ram, availableIp.getIp(),
                new AddServerOptions().withDescription(description));
       assertNotNull(createdServer);
-      assert serverLatestJobCompleted.apply(createdServer);
+      assertThat(serverLatestJobCompleted.apply(createdServer)).isTrue();
 
       assertEquals(Iterables.getLast(api.getServerServices().getServersByName(nameOfServer)).getDescription(),
                description);
@@ -139,36 +140,36 @@ public class GoGridLiveTestDisabled extends BaseApiLiveTest<GoGridApi> {
       Server createdServer = api.getServerServices().addServer(nameOfServer,
                "GSI-f8979644-e646-4711-ad58-d98a5fa3612c", ram, availableIp.getIp());
       assertNotNull(createdServer);
-      assert serverLatestJobCompleted.apply(createdServer);
+      assertThat(serverLatestJobCompleted.apply(createdServer)).isTrue();
 
       // get server by name
       Set<Server> response = api.getServerServices().getServersByName(nameOfServer);
-      assert response.size() == 1;
+      assertThat(response.size() == 1).isTrue();
 
       // restart the server
       api.getServerServices().power(nameOfServer, PowerCommand.RESTART);
 
       Set<Job> jobs = api.getJobServices().getJobsForObjectName(nameOfServer);
-      assert "RestartVirtualServer".equals(Iterables.getLast(jobs).getCommand().getName());
+      assertThat("RestartVirtualServer".equals(Iterables.getLast(jobs).getCommand().getName())).isTrue();
 
-      assert serverLatestJobCompleted.apply(createdServer);
+      assertThat(serverLatestJobCompleted.apply(createdServer)).isTrue();
 
       int serverCountAfterAddingOneServer = api.getServerServices().getServerList().size();
-      assert serverCountAfterAddingOneServer == serverCountBeforeTest + 1 : "There should be +1 increase in the number of servers since the test started";
+      assertThat(serverCountAfterAddingOneServer == serverCountBeforeTest + 1).as("There should be +1 increase in the number of servers since the test started").isTrue();
 
       // delete the server
       api.getServerServices().deleteByName(nameOfServer);
 
       jobs = api.getJobServices().getJobsForObjectName(nameOfServer);
-      assert "DeleteVirtualServer".equals(Iterables.getLast(jobs).getCommand().getName());
+      assertThat("DeleteVirtualServer".equals(Iterables.getLast(jobs).getCommand().getName())).isTrue();
 
-      assert serverLatestJobCompleted.apply(createdServer);
+      assertThat(serverLatestJobCompleted.apply(createdServer)).isTrue();
 
       int serverCountAfterDeletingTheServer = api.getServerServices().getServerList().size();
-      assert serverCountAfterDeletingTheServer == serverCountBeforeTest : "There should be the same # of servers as since the test started";
+      assertThat(serverCountAfterDeletingTheServer == serverCountBeforeTest).as("There should be the same # of servers as since the test started").isTrue();
 
       // make sure that IP is put back to "unassigned"
-      assert api.getIpServices().getUnassignedIpList().contains(availableIp);
+      assertThat(api.getIpServices().getUnassignedIpList().contains(availableIp)).isTrue();
    }
 
    /**
@@ -187,7 +188,7 @@ public class GoGridLiveTestDisabled extends BaseApiLiveTest<GoGridApi> {
       Server createdServer = api.getServerServices().addServer(nameOfServer,
                "GSI-f8979644-e646-4711-ad58-d98a5fa3612c", ram, Iterables.getLast(availableIps).getIp());
 
-      assert serverLatestJobCompleted.apply(createdServer);
+      assertThat(serverLatestJobCompleted.apply(createdServer)).isTrue();
 
       // restart the server
       api.getServerServices().power(nameOfServer, PowerCommand.RESTART);
@@ -199,7 +200,7 @@ public class GoGridLiveTestDisabled extends BaseApiLiveTest<GoGridApi> {
 
       Job latestJobFetched = Iterables.getOnlyElement(api.getJobServices().getJobsById(latestJobId));
 
-      assert latestJob.equals(latestJobFetched) : "Job and its representation found by ID don't match";
+      assertThat(latestJob.equals(latestJobFetched)).as("Job and its representation found by ID don't match").isTrue();
 
       long[] idsOfAllJobs = new long[jobs.size()];
       int i = 0;
@@ -208,9 +209,9 @@ public class GoGridLiveTestDisabled extends BaseApiLiveTest<GoGridApi> {
       }
 
       Set<Job> jobsFetched = api.getJobServices().getJobsById(idsOfAllJobs);
-      assert jobsFetched.size() == jobs.size() : format(
+      assertThat(jobsFetched.size() == jobs.size()).as(format(
                "Number of jobs fetched by ids doesn't match the number of jobs "
-                        + "requested. Requested/expected: %d. Found: %d.", jobs.size(), jobsFetched.size());
+                        + "requested. Requested/expected: %d. Found: %d.", jobs.size(), jobsFetched.size())).isTrue();
 
       // delete the server
       api.getServerServices().deleteByName(nameOfServer);
@@ -240,14 +241,14 @@ public class GoGridLiveTestDisabled extends BaseApiLiveTest<GoGridApi> {
                LoadBalancerPersistenceType.SOURCE_ADDRESS);
       LoadBalancer createdLoadBalancer = api.getLoadBalancerServices().addLoadBalancer(nameOfLoadBalancer,
                IpPortPair.builder().ip(vip).port(80).build(), Arrays.asList(IpPortPair.builder().ip(realIp1).port(80).build(),
-               IpPortPair.builder().ip(realIp2).port(80).build()),
+                      IpPortPair.builder().ip(realIp2).port(80).build()),
                options);
       assertNotNull(createdLoadBalancer);
-      assert loadBalancerLatestJobCompleted.apply(createdLoadBalancer);
+      assertThat(loadBalancerLatestJobCompleted.apply(createdLoadBalancer)).isTrue();
 
       // get load balancer by name
       Set<LoadBalancer> response = api.getLoadBalancerServices().getLoadBalancersByName(nameOfLoadBalancer);
-      assert response.size() == 1;
+      assertThat(response.size() == 1).isTrue();
       createdLoadBalancer = Iterables.getOnlyElement(response);
       assertNotNull(createdLoadBalancer.getRealIpList());
       assertEquals(createdLoadBalancer.getRealIpList().size(), 2);
@@ -256,24 +257,24 @@ public class GoGridLiveTestDisabled extends BaseApiLiveTest<GoGridApi> {
 
       LoadBalancer editedLoadBalancer = api.getLoadBalancerServices().editLoadBalancerNamed(nameOfLoadBalancer,
                Arrays.asList(IpPortPair.builder().ip(realIp3).port(8181).build()));
-      assert loadBalancerLatestJobCompleted.apply(editedLoadBalancer);
+      assertThat(loadBalancerLatestJobCompleted.apply(editedLoadBalancer)).isTrue();
       assertNotNull(editedLoadBalancer.getRealIpList());
       assertEquals(editedLoadBalancer.getRealIpList().size(), 1);
       assertEquals(Iterables.getOnlyElement(editedLoadBalancer.getRealIpList()).getIp().getIp(), realIp3.getIp());
 
       int lbCountAfterAddingOneServer = api.getLoadBalancerServices().getLoadBalancerList().size();
-      assert lbCountAfterAddingOneServer == lbCountBeforeTest + 1 : "There should be +1 increase in the number of load balancers since the test started";
+      assertThat(lbCountAfterAddingOneServer == lbCountBeforeTest + 1).as("There should be +1 increase in the number of load balancers since the test started").isTrue();
 
       // delete the load balancer
       api.getLoadBalancerServices().deleteByName(nameOfLoadBalancer);
 
       Set<Job> jobs = api.getJobServices().getJobsForObjectName(nameOfLoadBalancer);
-      assert "DeleteLoadBalancer".equals(Iterables.getLast(jobs).getCommand().getName());
+      assertThat("DeleteLoadBalancer".equals(Iterables.getLast(jobs).getCommand().getName())).isTrue();
 
-      assert loadBalancerLatestJobCompleted.apply(createdLoadBalancer);
+      assertThat(loadBalancerLatestJobCompleted.apply(createdLoadBalancer)).isTrue();
 
       int lbCountAfterDeletingTheServer = api.getLoadBalancerServices().getLoadBalancerList().size();
-      assert lbCountAfterDeletingTheServer == lbCountBeforeTest : "There should be the same # of load balancers as since the test started";
+      assertThat(lbCountAfterDeletingTheServer == lbCountBeforeTest).as("There should be the same # of load balancers as since the test started").isTrue();
    }
 
    /**
@@ -291,7 +292,7 @@ public class GoGridLiveTestDisabled extends BaseApiLiveTest<GoGridApi> {
          }
       };
 
-      assert Iterables.all(images, isDatabaseServer) : "All of the images should've been of database type";
+      assertThat(Iterables.all(images, isDatabaseServer)).as("All of the images should've been of database type").isTrue();
 
       ServerImage image = Iterables.getLast(images);
       ServerImage imageFromServer = Iterables
@@ -319,11 +320,11 @@ public class GoGridLiveTestDisabled extends BaseApiLiveTest<GoGridApi> {
       Server createdServer = api.getServerServices().addServer(nameOfServer,
                "GSI-f8979644-e646-4711-ad58-d98a5fa3612c", "1", availableIp.getIp());
       assertNotNull(createdServer);
-      assert serverLatestJobCompleted.apply(createdServer);
+      assertThat(serverLatestJobCompleted.apply(createdServer)).isTrue();
 
       // get server by name
       Set<Server> response = api.getServerServices().getServersByName(nameOfServer);
-      assert response.size() == 1;
+      assertThat(response.size() == 1).isTrue();
       createdServer = Iterables.getOnlyElement(response);
 
       Map<String, Credentials> credsMap = api.getServerServices().getServerCredentialsList();

--- a/providers/gogrid/src/test/java/org/jclouds/gogrid/compute/GoGridComputeServiceLiveTest.java
+++ b/providers/gogrid/src/test/java/org/jclouds/gogrid/compute/GoGridComputeServiceLiveTest.java
@@ -20,6 +20,7 @@ import static com.google.common.collect.Iterables.get;
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.compute.predicates.NodePredicates.inGroup;
 import static org.jclouds.util.Predicates2.retry;
 import static org.testng.Assert.assertEquals;
@@ -55,8 +56,8 @@ public class GoGridComputeServiceLiveTest extends BaseComputeServiceLiveTest {
    // gogrid does not support metadata
    @Override
    protected void checkUserMetadataContains(NodeMetadata node, ImmutableMap<String, String> userMetadata) {
-      assert node.getUserMetadata().equals(ImmutableMap.<String, String> of()) : String.format(
-            "node userMetadata did not match %s %s", userMetadata, node);
+      assertThat(node.getUserMetadata().equals(ImmutableMap.<String, String> of())).as(String.format(
+            "node userMetadata did not match %s %s", userMetadata, node)).isTrue();
    }
    
    protected void checkResponseEqualsHostname(ExecResponse execResponse, NodeMetadata node1) {
@@ -80,7 +81,7 @@ public class GoGridComputeServiceLiveTest extends BaseComputeServiceLiveTest {
 
          Server updatedServer = api.getServerServices().editServerRam(Long.valueOf(node.getId()), ram);
          assertNotNull(updatedServer);
-         assert serverLatestJobCompleted.apply(updatedServer);
+         assertThat(serverLatestJobCompleted.apply(updatedServer)).isTrue();
 
          assertEquals(getLast(api.getServerServices().getServersById(Long.valueOf(node.getId()))).getRam().getName(),
                ram);

--- a/providers/gogrid/src/test/java/org/jclouds/gogrid/compute/config/GoGridComputeServiceContextModuleTest.java
+++ b/providers/gogrid/src/test/java/org/jclouds/gogrid/compute/config/GoGridComputeServiceContextModuleTest.java
@@ -19,6 +19,8 @@ package org.jclouds.gogrid.compute.config;
 import org.jclouds.gogrid.domain.ServerState;
 import org.testng.annotations.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 //NOTE:without testName, this will not call @Before* and fail w/NPE during surefire
 @Test(groups = "unit", testName = "GoGridComputeServiceContextModuleTest")
 public class GoGridComputeServiceContextModuleTest {
@@ -26,7 +28,7 @@ public class GoGridComputeServiceContextModuleTest {
    public void testAllStatusCovered() {
 
       for (ServerState state : ServerState.values()) {
-         assert GoGridComputeServiceContextModule.toPortableNodeStatus.containsKey(state) : state;
+         assertThat(GoGridComputeServiceContextModule.toPortableNodeStatus.containsKey(state)).as(String.valueOf(state)).isTrue();
       }
 
    }

--- a/providers/gogrid/src/test/java/org/jclouds/gogrid/features/GridImageApiLiveTest.java
+++ b/providers/gogrid/src/test/java/org/jclouds/gogrid/features/GridImageApiLiveTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.gogrid.features;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.util.Predicates2.retry;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -46,9 +47,9 @@ public class GridImageApiLiveTest extends BaseGoGridApiLiveTest {
 
    public void testListImages() throws Exception {
       Set<ServerImage> response = api.getImageServices().getImageList();
-      assert null != response;
+      assertThat(null != response).isTrue();
       for (ServerImage image : response) {
-         assert image.getId() >= 0 : image;
+         assertThat(image.getId() >= 0).as(String.valueOf(image)).isTrue();
          checkImage(image);
 
          ServerImage query = Iterables.getOnlyElement(api.getImageServices()
@@ -60,20 +61,20 @@ public class GridImageApiLiveTest extends BaseGoGridApiLiveTest {
    }
 
    private void checkImage(ServerImage image) {
-      assert image.getArchitecture() != null : image;
-      assert image.getBillingTokens() != null : image;
+      assertThat(image.getArchitecture() != null).as(String.valueOf(image)).isTrue();
+      assertThat(image.getBillingTokens() != null).as(String.valueOf(image)).isTrue();
       if (image.getCreatedTime() == null)
          Logger.getAnonymousLogger().warning("image " + image.getId() + " is missing the createdTime field");
-      assert image.getDescription() != null : image;
-      assert image.getFriendlyName() != null : image;
-      assert image.getId() >= 0 : image;
-      assert image.getLocation() != null : image;
-      assert image.getName() != null : image;
-      assert image.getOs() != null : image;
-      assert image.getOwner() != null : image;
-      assert image.getPrice() >= 0 : image;
-      assert image.getState() != null : image;
-      assert image.getType() != null : image;
+      assertThat(image.getDescription() != null).as(String.valueOf(image)).isTrue();
+      assertThat(image.getFriendlyName() != null).as(String.valueOf(image)).isTrue();
+      assertThat(image.getId() >= 0).as(String.valueOf(image)).isTrue();
+      assertThat(image.getLocation() != null).as(String.valueOf(image)).isTrue();
+      assertThat(image.getName() != null).as(String.valueOf(image)).isTrue();
+      assertThat(image.getOs() != null).as(String.valueOf(image)).isTrue();
+      assertThat(image.getOwner() != null).as(String.valueOf(image)).isTrue();
+      assertThat(image.getPrice() >= 0).as(String.valueOf(image)).isTrue();
+      assertThat(image.getState() != null).as(String.valueOf(image)).isTrue();
+      assertThat(image.getType() != null).as(String.valueOf(image)).isTrue();
       if (image.getUpdatedTime() == null)
          Logger.getAnonymousLogger().warning("image " + image.getId() + " is missing the updatedTime field");
    }
@@ -92,7 +93,7 @@ public class GridImageApiLiveTest extends BaseGoGridApiLiveTest {
          Server createdServer = api.getServerServices()
                .addServer(nameOfServer, "5489", "1", availableIp.getIp());
          assertNotNull(createdServer);
-         assert serverLatestJobCompleted.apply(createdServer);
+         assertThat(serverLatestJobCompleted.apply(createdServer)).isTrue();
          image = api
                .getImageServices()
                .saveImageFromServer("friendlyName", createdServer.getName(),

--- a/providers/gogrid/src/test/java/org/jclouds/gogrid/features/GridJobApiLiveTest.java
+++ b/providers/gogrid/src/test/java/org/jclouds/gogrid/features/GridJobApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.gogrid.features;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Set;
@@ -32,10 +33,10 @@ public class GridJobApiLiveTest extends BaseGoGridApiLiveTest {
 
    public void testListJobs() throws Exception {
       Set<Job> response = api.getJobServices().getJobList(GetJobListOptions.Builder.maxItems(10));
-      assert null != response;
-      assert response.size() <= 10 : response;
+      assertThat(null != response).isTrue();
+      assertThat(response.size() <= 10).as(String.valueOf(response)).isTrue();
       for (Job job : response) {
-         assert job.getId() >= 0 : job;
+         assertThat(job.getId() >= 0).as(String.valueOf(job)).isTrue();
          checkJob(job);
 
          Job query = Iterables.getOnlyElement(api.getJobServices().getJobsById(job.getId()));
@@ -46,15 +47,15 @@ public class GridJobApiLiveTest extends BaseGoGridApiLiveTest {
    }
 
    private void checkJob(Job job) {
-      assert job.getAttempts() >= 0 : job;
-      assert job.getCommand() != null : job;
-      assert job.getCreatedOn() != null : job;
-      assert job.getCreatedOn() != null : job;
-      assert job.getDetails() != null : job;
-      assert job.getHistory() != null : job;
-      assert job.getId() >= 0 : job;
-      assert job.getLastUpdatedOn() != null : job;
-      assert job.getObjectType() != null : job;
-      assert job.getOwner() != null : job;
+      assertThat(job.getAttempts() >= 0).as(String.valueOf(job)).isTrue();
+      assertThat(job.getCommand() != null).as(String.valueOf(job)).isTrue();
+      assertThat(job.getCreatedOn() != null).as(String.valueOf(job)).isTrue();
+      assertThat(job.getCreatedOn() != null).as(String.valueOf(job)).isTrue();
+      assertThat(job.getDetails() != null).as(String.valueOf(job)).isTrue();
+      assertThat(job.getHistory() != null).as(String.valueOf(job)).isTrue();
+      assertThat(job.getId() >= 0).as(String.valueOf(job)).isTrue();
+      assertThat(job.getLastUpdatedOn() != null).as(String.valueOf(job)).isTrue();
+      assertThat(job.getObjectType() != null).as(String.valueOf(job)).isTrue();
+      assertThat(job.getOwner() != null).as(String.valueOf(job)).isTrue();
    }
 }

--- a/providers/gogrid/src/test/java/org/jclouds/gogrid/options/AddServerOptionsTest.java
+++ b/providers/gogrid/src/test/java/org/jclouds/gogrid/options/AddServerOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.gogrid.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.gogrid.options.AddServerOptions.Builder.asSandboxType;
 import static org.jclouds.gogrid.options.AddServerOptions.Builder.withDescription;
 import static org.testng.Assert.assertEquals;
@@ -34,8 +35,8 @@ public class AddServerOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(AddServerOptions.class);
-      assert !String.class.isAssignableFrom(AddServerOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(AddServerOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(AddServerOptions.class)).isTrue();
    }
 
    @Test

--- a/providers/gogrid/src/test/java/org/jclouds/gogrid/options/SaveImageOptionsTest.java
+++ b/providers/gogrid/src/test/java/org/jclouds/gogrid/options/SaveImageOptionsTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.gogrid.options;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.gogrid.options.SaveImageOptions.Builder.withDescription;
 import static org.testng.Assert.assertEquals;
 
@@ -33,8 +34,8 @@ public class SaveImageOptionsTest {
 
    @Test
    public void testAssignability() {
-      assert HttpRequestOptions.class.isAssignableFrom(SaveImageOptions.class);
-      assert !String.class.isAssignableFrom(SaveImageOptions.class);
+      assertThat(HttpRequestOptions.class.isAssignableFrom(SaveImageOptions.class)).isTrue();
+      assertThat(!String.class.isAssignableFrom(SaveImageOptions.class)).isTrue();
    }
 
    @Test

--- a/providers/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceLiveTest.java
+++ b/providers/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceLiveTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.googlecomputeengine.compute;
 
 import static com.google.common.collect.Iterables.contains;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.util.Strings2.toStringAndClose;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -137,7 +138,7 @@ public class GoogleComputeEngineServiceLiveTest extends BaseComputeServiceLiveTe
    protected void checkTagsInNodeEquals(NodeMetadata node, ImmutableSet<String> tags) {
       Set<String> nodeTags = node.getTags();
       for (String tag : tags){
-         assert nodeTags.contains(tag) : String.format("node tags did not match %s %s node:", tags, nodeTags, node);
+         assertThat(nodeTags.contains(tag)).as(String.format("node tags did not match %s %s node:", tags, nodeTags, node)).isTrue();
       }
    }
 

--- a/providers/hpcloud-objectstorage/src/test/java/org/jclouds/hpcloud/objectstorage/HPCloudObjectStorageClientLiveTest.java
+++ b/providers/hpcloud-objectstorage/src/test/java/org/jclouds/hpcloud/objectstorage/HPCloudObjectStorageClientLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.hpcloud.objectstorage;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -76,10 +77,10 @@ public class HPCloudObjectStorageClientLiveTest extends CommonSwiftClientLiveTes
          assertEquals(cdnMetadata.getCDNUri(), cdnUri);
 
          cdnMetadata = getApi().getCDNExtension().get().get(containerNameWithoutCDN);
-         assert cdnMetadata == null || !cdnMetadata.isCDNEnabled() : containerNameWithoutCDN
-                  + " should not have metadata";
+         assertThat(cdnMetadata == null || !cdnMetadata.isCDNEnabled()).as(containerNameWithoutCDN
+                  + " should not have metadata").isTrue();
 
-         assert getApi().getCDNExtension().get().get("DoesNotExist") == null;
+         assertThat(getApi().getCDNExtension().get().get("DoesNotExist") == null).isTrue();
 
          // List CDN metadata for containers, and ensure all CDN info is
          // available for enabled

--- a/providers/hpcloud-objectstorage/src/test/java/org/jclouds/hpcloud/objectstorage/blobstore/integration/HPCloudObjectStorageBlobIntegrationLiveTest.java
+++ b/providers/hpcloud-objectstorage/src/test/java/org/jclouds/hpcloud/objectstorage/blobstore/integration/HPCloudObjectStorageBlobIntegrationLiveTest.java
@@ -21,6 +21,8 @@ import org.jclouds.openstack.swift.blobstore.integration.SwiftBlobIntegrationLiv
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Test(groups = "live")
 public class HPCloudObjectStorageBlobIntegrationLiveTest extends SwiftBlobIntegrationLiveTest {
    public HPCloudObjectStorageBlobIntegrationLiveTest() {
@@ -43,10 +45,10 @@ public class HPCloudObjectStorageBlobIntegrationLiveTest extends SwiftBlobIntegr
 
    @Override
    protected void checkContentDisposition(Blob blob, String contentDisposition) {
-      assert blob.getPayload().getContentMetadata().getContentDisposition().startsWith(contentDisposition) : blob
-               .getPayload().getContentMetadata().getContentDisposition();
-      assert blob.getMetadata().getContentMetadata().getContentDisposition().startsWith(contentDisposition) : blob
-               .getMetadata().getContentMetadata().getContentDisposition();
+      assertThat(blob.getPayload().getContentMetadata().getContentDisposition().startsWith(contentDisposition)).as(blob
+               .getPayload().getContentMetadata().getContentDisposition()).isTrue();
+      assertThat(blob.getMetadata().getContentMetadata().getContentDisposition().startsWith(contentDisposition)).as(blob
+               .getMetadata().getContentMetadata().getContentDisposition()).isTrue();
    }
 
 }

--- a/providers/softlayer/src/test/java/org/jclouds/softlayer/compute/SoftLayerComputeServiceAdapterLiveTest.java
+++ b/providers/softlayer/src/test/java/org/jclouds/softlayer/compute/SoftLayerComputeServiceAdapterLiveTest.java
@@ -45,6 +45,7 @@ import org.testng.annotations.Test;
 import java.util.Properties;
 import java.util.Random;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -94,7 +95,7 @@ public class SoftLayerComputeServiceAdapterLiveTest extends BaseSoftLayerApiLive
       assertEquals(guest.getNodeId(), guest.getNode().getId() + "");
       assertEquals(guest.getNode().getDomain(), template.getOptions().as(SoftLayerTemplateOptions.class)
             .getDomainName());
-      assert InetAddresses.isInetAddress(guest.getNode().getPrimaryBackendIpAddress()) : guest;
+      assertThat(InetAddresses.isInetAddress(guest.getNode().getPrimaryBackendIpAddress())).as(String.valueOf(guest)).isTrue();
       doConnectViaSsh(guest.getNode(), prioritizeCredentialsFromTemplate.apply(template, guest.getCredentials()));
    }
 

--- a/providers/softlayer/src/test/java/org/jclouds/softlayer/compute/SoftLayerComputeServiceLiveTest.java
+++ b/providers/softlayer/src/test/java/org/jclouds/softlayer/compute/SoftLayerComputeServiceLiveTest.java
@@ -26,6 +26,8 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Module;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Test(groups = "live", enabled = true, singleThreaded = true)
 public class SoftLayerComputeServiceLiveTest extends BaseComputeServiceLiveTest {
 
@@ -42,8 +44,8 @@ public class SoftLayerComputeServiceLiveTest extends BaseComputeServiceLiveTest 
    // softlayer does not support metadata
    @Override
    protected void checkUserMetadataContains(NodeMetadata node, ImmutableMap<String, String> userMetadata) {
-      assert node.getUserMetadata().equals(ImmutableMap.<String, String> of()) : String.format(
-            "node userMetadata did not match %s %s", userMetadata, node);
+      assertThat(node.getUserMetadata().equals(ImmutableMap.<String, String> of())).as(String.format(
+            "node userMetadata did not match %s %s", userMetadata, node)).isTrue();
    }
 
    @Override

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/login/ReplaceShadowPasswordEntryOfLoginUserTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/login/ReplaceShadowPasswordEntryOfLoginUserTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.scriptbuilder.statements.login;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import org.jclouds.scriptbuilder.domain.OsFamily;
@@ -34,9 +35,9 @@ public class ReplaceShadowPasswordEntryOfLoginUserTest {
 
    public void testWithPasswordUNIX() {
       String cmd = new ReplaceShadowPasswordEntryOfLoginUser(crypt, "password").render(OsFamily.UNIX);
-      assert cmd.startsWith("awk -v user=^${SUDO_USER:=${USER}}: -v password='CRYPT") : cmd;
-      assert cmd
-            .endsWith("' 'BEGIN { FS=OFS=\":\" } $0 ~ user { $2 = password } 1' /etc/shadow >/etc/shadow.${SUDO_USER:=${USER}}\ntest -f /etc/shadow.${SUDO_USER:=${USER}} && mv /etc/shadow.${SUDO_USER:=${USER}} /etc/shadow\n") : cmd;
+      assertThat(cmd.startsWith("awk -v user=^${SUDO_USER:=${USER}}: -v password='CRYPT")).as(cmd).isTrue();
+      assertThat(cmd
+            .endsWith("' 'BEGIN { FS=OFS=\":\" } $0 ~ user { $2 = password } 1' /etc/shadow >/etc/shadow.${SUDO_USER:=${USER}}\ntest -f /etc/shadow.${SUDO_USER:=${USER}} && mv /etc/shadow.${SUDO_USER:=${USER}} /etc/shadow\n")).as(cmd).isTrue();
    }
 
    @Test(expectedExceptions = UnsupportedOperationException.class)

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/login/ReplaceShadowPasswordEntryTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/login/ReplaceShadowPasswordEntryTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.scriptbuilder.statements.login;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import org.jclouds.scriptbuilder.domain.OsFamily;
@@ -34,9 +35,9 @@ public class ReplaceShadowPasswordEntryTest {
 
    public void testWithPasswordUNIX() {
       String userAdd = new ReplaceShadowPasswordEntry(crypt, "foo", "password").render(OsFamily.UNIX);
-      assert userAdd.startsWith("awk -v user=^foo: -v password='CRYPT") : userAdd;
-      assert userAdd
-            .endsWith("' 'BEGIN { FS=OFS=\":\" } $0 ~ user { $2 = password } 1' /etc/shadow >/etc/shadow.foo\ntest -f /etc/shadow.foo && mv /etc/shadow.foo /etc/shadow\n") : userAdd;
+      assertThat(userAdd.startsWith("awk -v user=^foo: -v password='CRYPT")).as(userAdd).isTrue();
+      assertThat(userAdd
+            .endsWith("' 'BEGIN { FS=OFS=\":\" } $0 ~ user { $2 = password } 1' /etc/shadow >/etc/shadow.foo\ntest -f /etc/shadow.foo && mv /etc/shadow.foo /etc/shadow\n")).as(userAdd).isTrue();
    }
 
    @Test(expectedExceptions = UnsupportedOperationException.class)

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/login/UserAddTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/login/UserAddTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.scriptbuilder.statements.login;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import org.jclouds.scriptbuilder.domain.OsFamily;
@@ -63,8 +64,8 @@ public class UserAddTest {
 
    public void testWithPasswordUNIX() {
       String userAdd = UserAdd.builder().cryptFunction(crypt).login("me").password("password").group("wheel").build().render(OsFamily.UNIX);
-      assert userAdd.startsWith("mkdir -p /home/users\nchmod 0755 /home/users\ngroupadd -f wheel\nuseradd -c me -s /bin/bash -g wheel -m  -d /home/users/me -p 'CRYPT'") : userAdd;
-      assert userAdd.endsWith("' me\nchown -R me /home/users/me\n") : userAdd;
+      assertThat(userAdd.startsWith("mkdir -p /home/users\nchmod 0755 /home/users\ngroupadd -f wheel\nuseradd -c me -s /bin/bash -g wheel -m  -d /home/users/me -p 'CRYPT'")).as(userAdd).isTrue();
+      assertThat(userAdd.endsWith("' me\nchown -R me /home/users/me\n")).as(userAdd).isTrue();
    }
 
    public void testWithSshAuthorizedKeyUNIX() {

--- a/skeletons/standalone-compute/src/test/java/org/jclouds/servermanager/compute/ServerManagerComputeServiceLiveTest.java
+++ b/skeletons/standalone-compute/src/test/java/org/jclouds/servermanager/compute/ServerManagerComputeServiceLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.servermanager.compute;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.compute.util.ComputeServiceUtils.getCores;
 import static org.testng.Assert.assertEquals;
 
@@ -53,8 +54,8 @@ public class ServerManagerComputeServiceLiveTest extends BaseComputeServiceLiveT
    // servermanager does not support metadata
    @Override
    protected void checkUserMetadataContains(NodeMetadata node, ImmutableMap<String, String> userMetadata) {
-      assert node.getUserMetadata().equals(ImmutableMap.<String, String> of()) : String.format(
-            "node userMetadata did not match %s %s", userMetadata, node);
+      assertThat(node.getUserMetadata().equals(ImmutableMap.<String, String> of())).as(String.format(
+            "node userMetadata did not match %s %s", userMetadata, node)).isTrue();
    }
    
 }


### PR DESCRIPTION
This is a straightforward replace of

assert x -> assertThat(x).isTrue()

It doesn't specialize cases like:

assert x == null -> assertThat(x).isNull()