### PR TITLE
Skip broken Azure Blob test.

### DIFF
--- a/providers/azureblob/src/test/java/org/jclouds/azureblob/blobstore/integration/AzureBlobIntegrationLiveTest.java
+++ b/providers/azureblob/src/test/java/org/jclouds/azureblob/blobstore/integration/AzureBlobIntegrationLiveTest.java
@@ -54,4 +54,10 @@ public class AzureBlobIntegrationLiveTest extends BaseBlobIntegrationTest {
    public void testSetBlobAccess() throws Exception {
       throw new SkipException("unsupported in Azure");
    }
+
+   @Override
+   @Test
+   public void testGetRange() {
+      throw new SkipException("Currently broken on Azure");
+   }
 }


### PR DESCRIPTION
Azure ```testGetRange()``` has been consistently failing for a while. Disable the test until it is fixed.