### PR TITLE
Fix for Go2Cloud provider endpoint

### DIFF
--- a/providers/go2cloud-jhb1/pom.xml
+++ b/providers/go2cloud-jhb1/pom.xml
@@ -32,7 +32,7 @@
   <packaging>bundle</packaging>
 
   <properties>
-    <test.go2cloud-jhb1.endpoint>http://api.jhb1.go2cloud.co.za</test.go2cloud-jhb1.endpoint>
+    <test.go2cloud-jhb1.endpoint>http://api-jhb1.go2cloud.co.za</test.go2cloud-jhb1.endpoint>
     <test.go2cloud-jhb1.api-version>2.0</test.go2cloud-jhb1.api-version>
     <test.go2cloud-jhb1.build-version />
     <test.go2cloud-jhb1.identity>FIXME_IDENTITY</test.go2cloud-jhb1.identity>

--- a/providers/go2cloud-jhb1/src/main/java/org/jclouds/go2cloud/Go2CloudJohannesburg1ProviderMetadata.java
+++ b/providers/go2cloud-jhb1/src/main/java/org/jclouds/go2cloud/Go2CloudJohannesburg1ProviderMetadata.java
@@ -53,9 +53,7 @@ public class Go2CloudJohannesburg1ProviderMetadata extends BaseProviderMetadata 
       return properties;
    }
 
-   public static class Builder
-         extends
-         BaseProviderMetadata.Builder {
+   public static class Builder extends BaseProviderMetadata.Builder {
 
       protected Builder() {
          id("go2cloud-jhb1")
@@ -64,7 +62,7 @@ public class Go2CloudJohannesburg1ProviderMetadata extends BaseProviderMetadata 
          .homepage(URI.create("https://jhb1.go2cloud.co.za"))
          .console(URI.create("https://jhb1.go2cloud.co.za/accounts"))
          .iso3166Codes("ZA-GP")
-         .endpoint("https://api.jhb1.go2cloud.co.za")
+         .endpoint("https://api-jhb1.go2cloud.co.za")
          .defaultProperties(Go2CloudJohannesburg1ProviderMetadata.defaultProperties());
       }
 
@@ -74,8 +72,7 @@ public class Go2CloudJohannesburg1ProviderMetadata extends BaseProviderMetadata 
       }
 
       @Override
-      public Builder fromProviderMetadata(
-            ProviderMetadata in) {
+      public Builder fromProviderMetadata(ProviderMetadata in) {
          super.fromProviderMetadata(in);
          return this;
       }

--- a/providers/go2cloud-jhb1/src/test/java/org/jclouds/go2cloud/compute/Go2CloudJohannesburg1TemplateBuilderLiveTest.java
+++ b/providers/go2cloud-jhb1/src/test/java/org/jclouds/go2cloud/compute/Go2CloudJohannesburg1TemplateBuilderLiveTest.java
@@ -40,7 +40,7 @@ public class Go2CloudJohannesburg1TemplateBuilderLiveTest extends BaseTemplateBu
    public void testDefaultTemplateBuilder() throws IOException {
       Template defaultTemplate = this.view.getComputeService().templateBuilder().build();
       assertEquals(defaultTemplate.getImage().getOperatingSystem().is64Bit(), true);
-      assertEquals(defaultTemplate.getImage().getOperatingSystem().getVersion(), "10.10");
+      assertEquals(defaultTemplate.getImage().getOperatingSystem().getVersion(), "12.04");
       assertEquals(defaultTemplate.getImage().getOperatingSystem().getFamily(), OsFamily.UBUNTU);
       assertEquals(defaultTemplate.getLocation().getId(), "go2cloud-jhb1");
       assertEquals(getCores(defaultTemplate.getHardware()), 1.0d);


### PR DESCRIPTION
See JCLOUDS-1004 - Update the Go2Cloud endpoint

https://issues.apache.org/jira/browse/JCLOUDS-1004

Also the default image have updated to 12.04.
All Live tests passing:

![image](https://cloud.githubusercontent.com/assets/39833/10016431/da8b3f12-611e-11e5-85c9-63c55ffe3a21.png)

