### PR TITLE
Add .gitattributes to avoid line endings issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text eol=lf
+*.cmd binary


### PR DESCRIPTION
Since commit 56e687f4979d, Linux line endings (LF) are enforced. But on
Windows, a common practice is to set core.autocrlf to 'auto', wich mean
that the local copy of the file has Windows line endings, whereas the
remote copy has Linux line endings (cf. https://help.github.com/articles/dealing-with-line-endings/#platform-windows).

With core.autoclrf=auto, Checkstyle will throw an error because local
files will have Windows line endings.

This setting will set Linux line endings for all text files, except
.cmd files.