### PR TITLE
Added RateLimit exception

### DIFF
--- a/core/src/main/java/org/jclouds/rest/RateLimitExceededException.java
+++ b/core/src/main/java/org/jclouds/rest/RateLimitExceededException.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rest;
+
+/**
+ * Thrown when a request fails because the rate limit has been exceeded.
+ */
+public class RateLimitExceededException extends RuntimeException {
+
+   private static final long serialVersionUID = 1L;
+
+   public RateLimitExceededException() {
+      super();
+   }
+
+   public RateLimitExceededException(String message, Throwable cause) {
+      super(message, cause);
+   }
+
+   public RateLimitExceededException(String message) {
+      super(message);
+   }
+
+   public RateLimitExceededException(Throwable cause) {
+      super(cause);
+   }
+
+}

--- a/core/src/main/java/org/jclouds/util/Throwables2.java
+++ b/core/src/main/java/org/jclouds/util/Throwables2.java
@@ -27,6 +27,7 @@ import org.jclouds.concurrent.TransformParallelException;
 import org.jclouds.http.HttpResponseException;
 import org.jclouds.rest.AuthorizationException;
 import org.jclouds.rest.InsufficientResourcesException;
+import org.jclouds.rest.RateLimitExceededException;
 import org.jclouds.rest.ResourceAlreadyExistsException;
 import org.jclouds.rest.ResourceNotFoundException;
 
@@ -135,6 +136,7 @@ public class Throwables2 {
          ResourceAlreadyExistsException.class,
          ResourceNotFoundException.class,
          InsufficientResourcesException.class,
+         RateLimitExceededException.class,
          HttpResponseException.class);
 
    // Note this needs to be kept up-to-date with all top-level exceptions jclouds works against


### PR DESCRIPTION
Added the `RateLimitExceededException` as a propagable exception. This will allow providers dealing with the service rate limits to propagate a meaningful error. Related to [JCLOUDS-1022](https://issues.apache.org/jira/browse/JCLOUDS-1022).