### PR TITLE
UserAdd: guard groupadd with check if group exists

### DIFF
--- a/compute/src/test/resources/initscript_with_java.sh
+++ b/compute/src/test/resources/initscript_with_java.sh
@@ -212,7 +212,7 @@ END_OF_JCLOUDS_SCRIPT
 	chmod 0440 /etc/sudoers
 	mkdir -p /home/users
 	chmod 0755 /home/users
-	groupadd -f wheel
+	getent group wheel || groupadd -f wheel
 	useradd -c 'defaultAdminUsername' -s /bin/bash -g wheel -m  -d /home/users/defaultAdminUsername -p 'crypt(randompassword)' defaultAdminUsername
 	mkdir -p /home/users/defaultAdminUsername/.ssh
 	cat >> /home/users/defaultAdminUsername/.ssh/authorized_keys <<-'END_OF_JCLOUDS_FILE'

--- a/compute/src/test/resources/initscript_with_jetty.sh
+++ b/compute/src/test/resources/initscript_with_jetty.sh
@@ -212,7 +212,7 @@ END_OF_JCLOUDS_SCRIPT
 	chmod 0440 /etc/sudoers
 	mkdir -p /home/users
 	chmod 0755 /home/users
-	groupadd -f wheel
+	getent group wheel || groupadd -f wheel
 	useradd -c 'web' -s /bin/bash -g wheel -m  -d /home/users/web -p 'crypt(randompassword)' web
 	mkdir -p /home/users/web/.ssh
 	cat >> /home/users/web/.ssh/authorized_keys <<-'END_OF_JCLOUDS_FILE'

--- a/compute/src/test/resources/runscript_adminUpdate.sh
+++ b/compute/src/test/resources/runscript_adminUpdate.sh
@@ -93,7 +93,7 @@ END_OF_JCLOUDS_SCRIPT
 	chmod 0440 /etc/sudoers
 	mkdir -p /over/ridden
 	chmod 0755 /over/ridden
-	groupadd -f wheel
+	getent group wheel || groupadd -f wheel
 	useradd -c 'foo' -s /bin/bash -g wheel -m  -d /over/ridden/foo -p 'crypt(randompassword)' foo
 	mkdir -p /over/ridden/foo/.ssh
 	cat >> /over/ridden/foo/.ssh/authorized_keys <<-'END_OF_JCLOUDS_FILE'

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/login/UserAdd.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/login/UserAdd.java
@@ -205,7 +205,7 @@ public class UserAdd implements Statement {
       userAddOptions.put("-s", shell);
       if (!groups.isEmpty()) {
          for (String group : groups)
-            statements.add(Statements.exec("groupadd -f " + group));
+            statements.add(Statements.exec("getent group " + group + " || groupadd -f " + group));
 
          List<String> groups = Lists.newArrayList(this.groups);
          String primaryGroup = groups.remove(0);

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/login/UserAddTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/login/UserAddTest.java
@@ -45,13 +45,13 @@ public class UserAddTest {
 
    public void testWithGroupUNIX() {
       assertEquals(UserAdd.builder().login("me").group("wheel").build().render(OsFamily.UNIX),
-               "mkdir -p /home/users\nchmod 0755 /home/users\ngroupadd -f wheel\nuseradd -c me -s /bin/bash -g wheel -m  -d /home/users/me me\nchown -R me /home/users/me\n");
+               "mkdir -p /home/users\nchmod 0755 /home/users\ngetent group wheel || groupadd -f wheel\nuseradd -c me -s /bin/bash -g wheel -m  -d /home/users/me me\nchown -R me /home/users/me\n");
    }
 
    public void testWithGroupsUNIX() {
       assertEquals(UserAdd.builder().login("me").groups(ImmutableList.of("wheel", "candy")).build().render(
                OsFamily.UNIX),
-               "mkdir -p /home/users\nchmod 0755 /home/users\ngroupadd -f wheel\ngroupadd -f candy\nuseradd -c me -s /bin/bash -g wheel -G candy -m  -d /home/users/me me\nchown -R me /home/users/me\n");
+               "mkdir -p /home/users\nchmod 0755 /home/users\ngetent group wheel || groupadd -f wheel\ngetent group candy || groupadd -f candy\nuseradd -c me -s /bin/bash -g wheel -G candy -m  -d /home/users/me me\nchown -R me /home/users/me\n");
    }
 
    Function<String, String> crypt = new Function<String, String>() {
@@ -63,7 +63,7 @@ public class UserAddTest {
 
    public void testWithPasswordUNIX() {
       String userAdd = UserAdd.builder().cryptFunction(crypt).login("me").password("password").group("wheel").build().render(OsFamily.UNIX);
-      assert userAdd.startsWith("mkdir -p /home/users\nchmod 0755 /home/users\ngroupadd -f wheel\nuseradd -c me -s /bin/bash -g wheel -m  -d /home/users/me -p 'CRYPT'") : userAdd;
+      assert userAdd.startsWith("mkdir -p /home/users\nchmod 0755 /home/users\ngetent group wheel || groupadd -f wheel\nuseradd -c me -s /bin/bash -g wheel -m  -d /home/users/me -p 'CRYPT'") : userAdd;
       assert userAdd.endsWith("' me\nchown -R me /home/users/me\n") : userAdd;
    }
 

--- a/scriptbuilder/src/test/resources/test_adminaccess_flipped.sh
+++ b/scriptbuilder/src/test/resources/test_adminaccess_flipped.sh
@@ -8,7 +8,7 @@ END_OF_FILE
 chmod 0440 /etc/sudoers
 mkdir -p /home/users
 chmod 0755 /home/users
-groupadd -f wheel
+getent group wheel || groupadd -f wheel
 useradd -c defaultAdminUsername -s /bin/bash -g wheel -d /home/users/defaultAdminUsername -p 'crypt(0)' defaultAdminUsername
 mkdir -p /home/users/defaultAdminUsername/.ssh
 cat >> /home/users/defaultAdminUsername/.ssh/authorized_keys <<'END_OF_FILE'

--- a/scriptbuilder/src/test/resources/test_adminaccess_params.sh
+++ b/scriptbuilder/src/test/resources/test_adminaccess_params.sh
@@ -7,7 +7,7 @@ END_OF_JCLOUDS_FILE
 chmod 0440 /etc/sudoers
 mkdir -p /over/ridden
 chmod 0755 /over/ridden
-groupadd -f wheel
+getent group wheel || groupadd -f wheel
 useradd -c 'foo' -s /bin/bash -g wheel -m  -d /over/ridden/foo -p 'crypt(bar)' foo
 mkdir -p /over/ridden/foo/.ssh
 cat >> /over/ridden/foo/.ssh/authorized_keys <<-'END_OF_JCLOUDS_FILE'

--- a/scriptbuilder/src/test/resources/test_adminaccess_params_and_fullname.sh
+++ b/scriptbuilder/src/test/resources/test_adminaccess_params_and_fullname.sh
@@ -7,7 +7,7 @@ END_OF_JCLOUDS_FILE
 chmod 0440 /etc/sudoers
 mkdir -p /over/ridden
 chmod 0755 /over/ridden
-groupadd -f wheel
+getent group wheel || groupadd -f wheel
 useradd -c 'JClouds Foo' -s /bin/bash -g wheel -m  -d /over/ridden/foo -p 'crypt(bar)' foo
 mkdir -p /over/ridden/foo/.ssh
 cat >> /over/ridden/foo/.ssh/authorized_keys <<-'END_OF_JCLOUDS_FILE'

--- a/scriptbuilder/src/test/resources/test_adminaccess_standard.sh
+++ b/scriptbuilder/src/test/resources/test_adminaccess_standard.sh
@@ -7,7 +7,7 @@ END_OF_JCLOUDS_FILE
 chmod 0440 /etc/sudoers
 mkdir -p /home/users
 chmod 0755 /home/users
-groupadd -f wheel
+getent group wheel || groupadd -f wheel
 useradd -c 'defaultAdminUsername' -s /bin/bash -g wheel -m  -d /home/users/defaultAdminUsername -p 'crypt(0)' defaultAdminUsername
 mkdir -p /home/users/defaultAdminUsername/.ssh
 cat >> /home/users/defaultAdminUsername/.ssh/authorized_keys <<-'END_OF_JCLOUDS_FILE'


### PR DESCRIPTION
On SUSE, the “-f” force option is not available for groupadd,
so `groupadd -f wheel` returns exit code 9 if the group already
exists. To avoid this, first check if the group exists.

In normal usage, this doesn’t matter: the script continues with the
next command anyway.

However, if the statements generated by UserAdd or AdminAccess are
used outside of that context (e.g. by code external to jclouds), then
this can cause them to fail.