### PR TITLE
[elasticstack] fix for incorrect logging message

### DIFF
--- a/apis/elasticstack/src/main/java/org/jclouds/elasticstack/compute/functions/StandardDriveToWellKnownImage.java
+++ b/apis/elasticstack/src/main/java/org/jclouds/elasticstack/compute/functions/StandardDriveToWellKnownImage.java
@@ -93,7 +93,7 @@ public class StandardDriveToWellKnownImage implements Function<StandardDrive, We
          }
       });
 
-      if (family.isPresent()) {
+      if (!family.isPresent()) {
          logger.warn("could not find the operating system family for image: %s", name);
       }
 


### PR DESCRIPTION
Was logging when it was present rather than when it had failed to find it.