### PR TITLE
Delete parts when removing Swift multipart objects

### DIFF
--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/blobstore/RegionScopedSwiftBlobStore.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/blobstore/RegionScopedSwiftBlobStore.java
@@ -344,7 +344,8 @@ public class RegionScopedSwiftBlobStore implements BlobStore {
 
    @Override
    public void removeBlob(String container, String name) {
-      api.getObjectApi(regionId, container).delete(name);
+      // use SLO API to delete blob regardless of whether its a single- or multi-part object
+      api.getStaticLargeObjectApi(regionId, container).delete(name);
    }
 
    @Override

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
@@ -943,6 +943,10 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
          assertThat(ByteStreams2.toByteArrayAndClose(newBlob.getPayload().openStream())).isEqualTo(byteSource.read());
          checkContentMetadata(newBlob);
          checkUserMetadata(newBlob.getMetadata().getUserMetadata(), blob.getMetadata().getUserMetadata());
+
+         // ensure that deleting multi-part manifest deletes any user-visible parts
+         blobStore.removeBlob(container, name);
+         assertThat(blobStore.list(container)).isEmpty();
       } finally {
          returnContainer(container);
       }


### PR DESCRIPTION
Swift implements multi-part upload with user-visible parts and an
explicit manifest.  When deleting an MPU blob it can delete only the
manifest or both the manifest and parts.  For consistency with other
providers, we now do the latter in the portable abstraction.  Swift
ignores the multipart-manifest=delete parameter for single-part
objects.  Fixes andrewgaul/s3proxy#92.