### PR TITLE
JCLOUDS-1045 remove swift dependency from allblobstore module

### DIFF
--- a/allblobstore/pom.xml
+++ b/allblobstore/pom.xml
@@ -50,11 +50,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.jclouds.api</groupId>
-      <artifactId>swift</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.jclouds.api</groupId>
       <artifactId>openstack-swift</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/JCLOUDS-1045

The [JCLOUDS-786](https://issues.apache.org/jira/browse/JCLOUDS-786) removed swift api, but it's still used as dependency in the `allblobstore` module.