### PR TITLE
JCLOUDS-1042: Remove unneeded ACL swizzling

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobStore.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobStore.java
@@ -74,7 +74,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
-import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -273,13 +272,6 @@ public class S3BlobStore extends BaseBlobStore {
 
       // TODO: Make use of options overrides
       PutObjectOptions options = new PutObjectOptions();
-      try {
-         AccessControlList acl = bucketAcls.getUnchecked(container);
-         if (acl != null && acl.hasPermission(GroupGranteeURI.ALL_USERS, Permission.READ))
-            options.withAcl(CannedAccessPolicy.PUBLIC_READ);
-      } catch (CacheLoader.InvalidCacheLoadException e) {
-         // nulls not permitted from cache loader
-      }
       return sync.putObject(container, blob2Object.apply(blob), options);
    }
 

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
@@ -47,6 +47,8 @@ import org.jclouds.blobstore.domain.ContainerAccess;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.options.ListContainerOptions;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpResponse;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -510,6 +512,15 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
 
          blobStore.setContainerAccess(containerName, ContainerAccess.PUBLIC_READ);
          assertThat(blobStore.getContainerAccess(containerName)).isEqualTo(ContainerAccess.PUBLIC_READ);
+
+         String blobName = "blob";
+         blobStore.putBlob(containerName, blobStore.blobBuilder(blobName).payload("").build());
+
+         // test that blob is anonymously readable
+         HttpRequest request = view.getSigner().signGetBlob(containerName, blobName).toBuilder()
+                .replaceQueryParams(ImmutableMap.<String, String>of()).build();
+         HttpResponse response = view.utils().http().invoke(request);
+         assertThat(response.getStatusCode()).isEqualTo(200);
 
          blobStore.setContainerAccess(containerName, ContainerAccess.PRIVATE);
          assertThat(blobStore.getContainerAccess(containerName)).isEqualTo(ContainerAccess.PRIVATE);


### PR DESCRIPTION
Test shows that the bucket access supersedes the blob access policy.