### PR TITLE
Use canned ACLs with S3

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/S3Client.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/S3Client.java
@@ -62,6 +62,7 @@ import org.jclouds.rest.annotations.XMLResponseParser;
 import org.jclouds.s3.binders.BindACLToXMLPayload;
 import org.jclouds.s3.binders.BindAsHostPrefixIfConfigured;
 import org.jclouds.s3.binders.BindBucketLoggingToXmlPayload;
+import org.jclouds.s3.binders.BindCannedAclToRequest;
 import org.jclouds.s3.binders.BindIterableAsPayloadToDeleteRequest;
 import org.jclouds.s3.binders.BindNoBucketLoggingToXmlPayload;
 import org.jclouds.s3.binders.BindObjectMetadataToRequest;
@@ -71,6 +72,7 @@ import org.jclouds.s3.binders.BindS3ObjectMetadataToRequest;
 import org.jclouds.s3.domain.AccessControlList;
 import org.jclouds.s3.domain.BucketLogging;
 import org.jclouds.s3.domain.BucketMetadata;
+import org.jclouds.s3.domain.CannedAccessPolicy;
 import org.jclouds.s3.domain.DeleteResult;
 import org.jclouds.s3.domain.ListBucketResponse;
 import org.jclouds.s3.domain.ObjectMetadata;
@@ -427,6 +429,28 @@ public interface S3Client extends Closeable {
          @BinderParam(BindACLToXMLPayload.class) AccessControlList acl);
 
    /**
+    * Update a bucket's Access Control List settings.
+    * <p/>
+    * A PUT request operation directed at a bucket URI with the "acl" parameter sets the Access
+    * Control List (ACL) settings for that S3 item.
+    * <p />
+    * To set a bucket or object's ACL, you must have WRITE_ACP or FULL_CONTROL access to the item.
+    *
+    * @param bucketName
+    *           the bucket whose Access Control List settings will be updated.
+    * @param acl
+    *           the ACL to apply to the bucket.
+    * @return true if the bucket's Access Control List was updated successfully.
+    */
+   @Named("UpdateBucketCannedAcl")
+   @PUT
+   @Path("/")
+   @QueryParams(keys = "acl")
+   boolean updateBucketCannedACL(@Bucket @EndpointParam(parser = AssignCorrectHostnameForBucket.class) @BinderParam(
+         BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName,
+         @BinderParam(BindCannedAclToRequest.class) CannedAccessPolicy acl);
+
+   /**
     * A GET request operation directed at an object or bucket URI with the "acl" parameter retrieves
     * the Access Control List (ACL) settings for that S3 item.
     * <p />
@@ -469,6 +493,29 @@ public interface S3Client extends Closeable {
          BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName,
          @PathParam("key") String key, @BinderParam(BindACLToXMLPayload.class) AccessControlList acl);
 
+   /**
+    * Update an object's Access Control List settings.
+    * <p/>
+    * A PUT request operation directed at an object URI with the "acl" parameter sets the Access
+    * Control List (ACL) settings for that S3 item.
+    * <p />
+    * To set a bucket or object's ACL, you must have WRITE_ACP or FULL_CONTROL access to the item.
+    *
+    * @param bucketName
+    *           the bucket containing the object to be updated
+    * @param key
+    *           the key of the object whose Access Control List settings will be updated.
+    * @param acl
+    *           the ACL to apply to the object.
+    * @return true if the object's Access Control List was updated successfully.
+    */
+   @Named("UpdateObjectCannedAcl")
+   @PUT
+   @QueryParams(keys = "acl")
+   @Path("/{key}")
+   boolean updateObjectCannedACL(@Bucket @EndpointParam(parser = AssignCorrectHostnameForBucket.class) @BinderParam(
+         BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName,
+         @PathParam("key") String key, @BinderParam(BindCannedAclToRequest.class) CannedAccessPolicy acl);
 
    /**
     * A GET location request operation using a bucket URI lists the location constraint of the

--- a/apis/s3/src/main/java/org/jclouds/s3/binders/BindCannedAclToRequest.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/binders/BindCannedAclToRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.s3.binders;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.jclouds.http.HttpRequest;
+import org.jclouds.rest.Binder;
+import org.jclouds.s3.domain.CannedAccessPolicy;
+
+public class BindCannedAclToRequest implements Binder {
+   public BindCannedAclToRequest() {
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public <R extends HttpRequest> R bindToRequest(R request, Object input) {
+      checkArgument(checkNotNull(input, "input") instanceof CannedAccessPolicy, "this binder is only valid for CannedAccessPolicy!, not %s", input);
+      checkNotNull(request, "request");
+
+      CannedAccessPolicy policy = (CannedAccessPolicy) input;
+
+      request = (R) request.toBuilder().replaceHeader("x-amz-acl", policy.toString()).build();
+      return request;
+   }
+}

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobStore.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobStore.java
@@ -160,17 +160,11 @@ public class S3BlobStore extends BaseBlobStore {
 
    @Override
    public void setContainerAccess(String container, ContainerAccess access) {
-      AccessControlList acl = sync.getBucketACL(container);
+      CannedAccessPolicy acl = CannedAccessPolicy.PRIVATE;
       if (access == ContainerAccess.PUBLIC_READ) {
-         acl.revokePermission(GroupGranteeURI.ALL_USERS, Permission.FULL_CONTROL)
-               .revokePermission(GroupGranteeURI.ALL_USERS, Permission.WRITE)
-               .addPermission(GroupGranteeURI.ALL_USERS, Permission.READ);
-      } else if (access == ContainerAccess.PRIVATE) {
-         acl.revokePermission(GroupGranteeURI.ALL_USERS, Permission.FULL_CONTROL)
-               .revokePermission(GroupGranteeURI.ALL_USERS, Permission.READ)
-               .revokePermission(GroupGranteeURI.ALL_USERS, Permission.WRITE);
+         acl = CannedAccessPolicy.PUBLIC_READ;
       }
-      sync.putBucketACL(container, acl);
+      sync.updateBucketCannedACL(container, acl);
    }
 
    /**
@@ -343,17 +337,11 @@ public class S3BlobStore extends BaseBlobStore {
 
    @Override
    public void setBlobAccess(String container, String name, BlobAccess access) {
-      AccessControlList acl = sync.getObjectACL(container, name);
+      CannedAccessPolicy acl = CannedAccessPolicy.PRIVATE;
       if (access == BlobAccess.PUBLIC_READ) {
-         acl.revokePermission(GroupGranteeURI.ALL_USERS, Permission.FULL_CONTROL)
-               .revokePermission(GroupGranteeURI.ALL_USERS, Permission.WRITE)
-               .addPermission(GroupGranteeURI.ALL_USERS, Permission.READ);
-      } else if (access == BlobAccess.PRIVATE) {
-         acl.revokePermission(GroupGranteeURI.ALL_USERS, Permission.FULL_CONTROL)
-               .revokePermission(GroupGranteeURI.ALL_USERS, Permission.READ)
-               .revokePermission(GroupGranteeURI.ALL_USERS, Permission.WRITE);
+         acl = CannedAccessPolicy.PUBLIC_READ;
       }
-      sync.putObjectACL(container, name, acl);
+      sync.updateObjectCannedACL(container, name, acl);
    }
 
    @Override

--- a/apis/s3/src/test/java/org/jclouds/s3/S3ClientTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/S3ClientTest.java
@@ -377,6 +377,23 @@ public abstract class S3ClientTest<T extends S3Client> extends BaseS3ClientTest<
       checkFilters(request);
    }
 
+   public void testUpdateBucketCannedACL() throws Exception {
+      Invokable<?, ?> method = method(S3Client.class, "updateBucketCannedACL", String.class, CannedAccessPolicy.class);
+      GeneratedHttpRequest request = processor.createRequest(method, ImmutableList.<Object> of("bucket", CannedAccessPolicy.PUBLIC_READ));
+
+      assertRequestLineEquals(request, "PUT https://bucket." + url + "/?acl HTTP/1.1");
+      assertNonPayloadHeadersEqual(request,
+            "Host: bucket." + url + "\n" +
+            "x-amz-acl: public-read\n");
+      assertPayloadEquals(request, null, "text/xml", false);
+
+      assertResponseParserClassEquals(method, request, ReturnTrueIf2xx.class);
+      assertSaxResponseParserClassEquals(method, null);
+      assertFallbackClassEquals(method, null);
+
+      checkFilters(request);
+   }
+
    public void testPutBucketDefault() throws ArrayIndexOutOfBoundsException, SecurityException,
             IllegalArgumentException, NoSuchMethodException, IOException {
       Invokable<?, ?> method = method(S3Client.class, "putBucketInRegion", String.class, String.class,
@@ -425,6 +442,24 @@ public abstract class S3ClientTest<T extends S3Client> extends BaseS3ClientTest<
                         + url
                         + "/doc/2006-03-01/\"><Owner><ID>1234</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"CanonicalUser\"><ID>1234</ID></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>",
                "text/xml", false);
+
+      assertResponseParserClassEquals(method, request, ReturnTrueIf2xx.class);
+      assertSaxResponseParserClassEquals(method, null);
+      assertFallbackClassEquals(method, null);
+
+      checkFilters(request);
+   }
+
+   public void testUpdateObjectCannedACL() throws SecurityException, NoSuchMethodException, IOException {
+      Invokable<?, ?> method = method(S3Client.class, "updateObjectCannedACL", String.class, String.class, CannedAccessPolicy.class);
+      GeneratedHttpRequest request = processor.createRequest(
+              method, ImmutableList.<Object> of("bucket", "key", CannedAccessPolicy.PUBLIC_READ));
+
+      assertRequestLineEquals(request, "PUT https://bucket." + url + "/key?acl HTTP/1.1");
+      assertNonPayloadHeadersEqual(request,
+            "Host: bucket." + url + "\n" +
+            "x-amz-acl: public-read\n");
+      assertPayloadEquals(request, null, "text/xml", false);
 
       assertResponseParserClassEquals(method, request, ReturnTrueIf2xx.class);
       assertSaxResponseParserClassEquals(method, null);


### PR DESCRIPTION
These are simpler than the full XML API and better supported by
non-AWS S3 implementations, e.g., Ceph, S3Proxy.