### PR TITLE
Add support for AzureBlobStore.getBlobAccess

### DIFF
--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/blobstore/RegionScopedSwiftBlobStore.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/blobstore/RegionScopedSwiftBlobStore.java
@@ -364,7 +364,7 @@ public class RegionScopedSwiftBlobStore implements BlobStore {
 
    @Override
    public BlobAccess getBlobAccess(String container, String name) {
-      throw new UnsupportedOperationException("unsupported in swift");
+      return BlobAccess.PRIVATE;
    }
 
    @Override

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/AzureBlobStore.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/AzureBlobStore.java
@@ -368,7 +368,7 @@ public class AzureBlobStore extends BaseBlobStore {
 
    @Override
    public BlobAccess getBlobAccess(String container, String key) {
-      throw new UnsupportedOperationException("unsupported in Azure");
+      return BlobAccess.PRIVATE;
    }
 
    @Override


### PR DESCRIPTION
At the moment, `AzureBlobStore.getBlobAccess` throws `UnsupportedOperationException`. I have implemented this. Please refer to this [issue](https://github.com/andrewgaul/s3proxy/issues/111) for details. @andrewgaul Please review.