### PR TITLE
JCLOUDS-948: Add support for Cache-Control header

### DIFF
--- a/apis/atmos/src/main/java/org/jclouds/atmos/domain/internal/DelegatingMutableContentMetadata.java
+++ b/apis/atmos/src/main/java/org/jclouds/atmos/domain/internal/DelegatingMutableContentMetadata.java
@@ -132,9 +132,13 @@ public class DelegatingMutableContentMetadata implements MutableContentMetadata 
    }
 
    @Override
+   public void setCacheControl(String cacheControl) {
+      delegate.setCacheControl(cacheControl);
+   }
+
+   @Override
    public void setContentDisposition(String contentDisposition) {
       delegate.setContentDisposition(contentDisposition);
-
    }
 
    @Override
@@ -145,6 +149,11 @@ public class DelegatingMutableContentMetadata implements MutableContentMetadata 
    @Override
    public void setContentLanguage(String contentLanguage) {
       delegate.setContentLanguage(contentLanguage);
+   }
+
+   @Override
+   public String getCacheControl() {
+      return delegate.getCacheControl();
    }
 
    @Override

--- a/apis/atmos/src/test/java/org/jclouds/atmos/blobstore/integration/AtmosIntegrationLiveTest.java
+++ b/apis/atmos/src/test/java/org/jclouds/atmos/blobstore/integration/AtmosIntegrationLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.atmos.blobstore.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
@@ -74,6 +75,13 @@ public class AtmosIntegrationLiveTest extends BaseBlobIntegrationTest {
    @Test(enabled = false)
    public void testGetTwoRanges() {
       // not supported
+   }
+
+   // not supported
+   @Override
+   protected void checkCacheControl(Blob blob, String cacheControl) {
+      assertThat(blob.getPayload().getContentMetadata().getCacheControl()).isNull();
+      assertThat(blob.getMetadata().getContentMetadata().getCacheControl()).isNull();
    }
 
    // not supported

--- a/apis/filesystem/src/main/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImpl.java
+++ b/apis/filesystem/src/main/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImpl.java
@@ -95,6 +95,7 @@ import com.google.common.primitives.Longs;
  */
 public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
 
+   private static final String XATTR_CACHE_CONTROL = "user.cache-control";
    private static final String XATTR_CONTENT_DISPOSITION = "user.content-disposition";
    private static final String XATTR_CONTENT_ENCODING = "user.content-encoding";
    private static final String XATTR_CONTENT_LANGUAGE = "user.content-language";
@@ -326,6 +327,7 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
          byteSource = Files.asByteSource(file);
       }
       try {
+         String cacheControl = null;
          String contentDisposition = null;
          String contentEncoding = null;
          String contentLanguage = null;
@@ -338,6 +340,7 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
          if (view != null) {
             Set<String> attributes = ImmutableSet.copyOf(view.list());
 
+            cacheControl = readStringAttributeIfPresent(view, attributes, XATTR_CACHE_CONTROL);
             contentDisposition = readStringAttributeIfPresent(view, attributes, XATTR_CONTENT_DISPOSITION);
             contentEncoding = readStringAttributeIfPresent(view, attributes, XATTR_CONTENT_ENCODING);
             contentLanguage = readStringAttributeIfPresent(view, attributes, XATTR_CONTENT_LANGUAGE);
@@ -370,6 +373,7 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
             }
 
             builder.payload(byteSource)
+               .cacheControl(cacheControl)
                .contentDisposition(contentDisposition)
                .contentEncoding(contentEncoding)
                .contentLanguage(contentLanguage)
@@ -397,6 +401,7 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
 
    private void writeCommonMetadataAttr(UserDefinedFileAttributeView view, Blob blob) throws IOException {
       ContentMetadata metadata = blob.getMetadata().getContentMetadata();
+      writeStringAttributeIfPresent(view, XATTR_CACHE_CONTROL, metadata.getCacheControl());
       writeStringAttributeIfPresent(view, XATTR_CONTENT_DISPOSITION, metadata.getContentDisposition());
       writeStringAttributeIfPresent(view, XATTR_CONTENT_ENCODING, metadata.getContentEncoding());
       writeStringAttributeIfPresent(view, XATTR_CONTENT_LANGUAGE, metadata.getContentLanguage());

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftBlobIntegrationLiveTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftBlobIntegrationLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.openstack.swift.v1.blobstore.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
 
 import java.util.Properties;
@@ -68,6 +69,14 @@ public class SwiftBlobIntegrationLiveTest extends BaseBlobIntegrationTest {
       return 422;
    }
 
+   // not supported
+   @Override
+   protected void checkCacheControl(Blob blob, String cacheControl) {
+      assertThat(blob.getPayload().getContentMetadata().getCacheControl()).isNull();
+      assertThat(blob.getMetadata().getContentMetadata().getCacheControl()).isNull();
+   }
+
+   // not supported
    @Override
    protected void checkContentLanguage(Blob blob, String contentLanguage) {
       assert blob.getPayload().getContentMetadata().getContentLanguage() == null;

--- a/apis/s3/src/main/java/org/jclouds/s3/binders/BindObjectMetadataToRequest.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/binders/BindObjectMetadataToRequest.java
@@ -54,8 +54,8 @@ public class BindObjectMetadataToRequest implements Binder {
       request = metadataPrefixer.bindToRequest(request, md.getUserMetadata());
 
       Builder<String, String> headers = ImmutableMultimap.builder();
-      if (md.getCacheControl() != null) {
-         headers.put(HttpHeaders.CACHE_CONTROL, md.getCacheControl());
+      if (md.getContentMetadata().getCacheControl() != null) {
+         headers.put(HttpHeaders.CACHE_CONTROL, md.getContentMetadata().getCacheControl());
       }
 
       if (md.getContentMetadata().getContentDisposition() != null) {

--- a/apis/s3/src/main/java/org/jclouds/s3/binders/BindS3ObjectMetadataToRequest.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/binders/BindS3ObjectMetadataToRequest.java
@@ -27,8 +27,6 @@ import org.jclouds.http.HttpRequest;
 import org.jclouds.rest.Binder;
 import org.jclouds.s3.domain.S3Object;
 
-import com.google.common.net.HttpHeaders;
-
 @Singleton
 public class BindS3ObjectMetadataToRequest implements Binder {
    protected final BindMapToHeadersWithPrefix metadataPrefixer;
@@ -53,10 +51,6 @@ public class BindS3ObjectMetadataToRequest implements Binder {
       
       request = metadataPrefixer.bindToRequest(request, s3Object.getMetadata().getUserMetadata());
 
-      if (s3Object.getMetadata().getCacheControl() != null) {
-         request = (R) request.toBuilder()
-                              .replaceHeader(HttpHeaders.CACHE_CONTROL, s3Object.getMetadata().getCacheControl()).build();
-      }
       return request;
    }
 }

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobStore.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobStore.java
@@ -278,6 +278,11 @@ public class S3BlobStore extends BaseBlobStore {
 
       Optional<ContentMetadata> contentMetadata = options.getContentMetadata();
       if (contentMetadata.isPresent()) {
+         String cacheControl = contentMetadata.get().getCacheControl();
+         if (cacheControl != null) {
+            s3Options.cacheControl(cacheControl);
+         }
+
          String contentDisposition = contentMetadata.get().getContentDisposition();
          if (contentDisposition != null) {
             s3Options.contentDisposition(contentDisposition);

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/MutableObjectMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/MutableObjectMetadata.java
@@ -59,7 +59,10 @@ public interface MutableObjectMetadata extends ObjectMetadata {
     * Can be used to specify caching behavior along the request/reply chain.
     *
     * @link http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html?sec14.9.
+    *
+    * @deprecated call getContentMetadata().setCacheControl(String) instead
     */
+   @Deprecated
    void setCacheControl(String cacheControl);
 
    @Override

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/ObjectMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/ObjectMetadata.java
@@ -63,7 +63,10 @@ public interface ObjectMetadata extends Comparable<ObjectMetadata> {
     * Can be used to specify caching behavior along the request/reply chain.
     * 
     * @link http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html?sec14.9.
+    *
+    * @deprecated call getContentMetadata().getCacheControl() instead
     */
+   @Deprecated
    String getCacheControl();
 
    Date getLastModified();

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/ObjectMetadataBuilder.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/ObjectMetadataBuilder.java
@@ -42,7 +42,6 @@ public class ObjectMetadataBuilder {
    private String bucket;
    private URI uri;
    private StorageClass storageClass = StorageClass.STANDARD;
-   private String cacheControl;
    private Date lastModified;
    private String eTag;
    private CanonicalUser owner;
@@ -84,7 +83,7 @@ public class ObjectMetadataBuilder {
    }
 
    public ObjectMetadataBuilder cacheControl(String cacheControl) {
-      this.cacheControl = cacheControl;
+      contentMetadataBuilder.cacheControl(cacheControl);
       return this;
    }
 
@@ -130,7 +129,6 @@ public class ObjectMetadataBuilder {
    public ObjectMetadata build() {
       MutableObjectMetadataImpl toReturn = new MutableObjectMetadataImpl();
       toReturn.setContentMetadata(BaseMutableContentMetadata.fromContentMetadata(contentMetadataBuilder.build()));
-      toReturn.setCacheControl(cacheControl);
       toReturn.setKey(key);
       toReturn.setBucket(bucket);
       toReturn.setUri(uri);

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/internal/MutableObjectMetadataImpl.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/internal/MutableObjectMetadataImpl.java
@@ -108,11 +108,12 @@ public class MutableObjectMetadataImpl implements MutableObjectMetadata {
    }
 
    /**
-    *{@inheritDoc}
+    * @deprecated call getContentMetadata().getCacheControl() instead
     */
+   @Deprecated
    @Override
    public String getCacheControl() {
-      return cacheControl;
+      return contentMetadata.getCacheControl();
    }
 
    /**
@@ -148,11 +149,12 @@ public class MutableObjectMetadataImpl implements MutableObjectMetadata {
    }
 
    /**
-    *{@inheritDoc}
+    * @deprecated call getContentMetadata().setCacheControl(String) instead
     */
+   @Deprecated
    @Override
    public void setCacheControl(String cacheControl) {
-      this.cacheControl = cacheControl;
+      contentMetadata.setCacheControl(cacheControl);
    }
 
    /**

--- a/apis/s3/src/main/java/org/jclouds/s3/options/CopyObjectOptions.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/options/CopyObjectOptions.java
@@ -72,6 +72,7 @@ import com.google.common.net.HttpHeaders;
 public class CopyObjectOptions extends BaseHttpRequestOptions {
    private static final DateService dateService = new SimpleDateFormatDateService();
    public static final CopyObjectOptions NONE = new CopyObjectOptions();
+   private String cacheControl;
    private String contentDisposition;
    private String contentEncoding;
    private String contentLanguage;
@@ -255,6 +256,10 @@ public class CopyObjectOptions extends BaseHttpRequestOptions {
          returnVal.put(entry.getKey().replace(DEFAULT_AMAZON_HEADERTAG, headerTag), entry.getValue());
       }
       boolean replace = false;
+      if (cacheControl != null) {
+         returnVal.put(HttpHeaders.CACHE_CONTROL, cacheControl);
+         replace = true;
+      }
       if (contentDisposition != null) {
          returnVal.put(HttpHeaders.CONTENT_DISPOSITION, contentDisposition);
          replace = true;
@@ -282,6 +287,11 @@ public class CopyObjectOptions extends BaseHttpRequestOptions {
          returnVal.put(METADATA_DIRECTIVE.replace(DEFAULT_AMAZON_HEADERTAG, headerTag), "REPLACE");
       }
       return returnVal.build();
+   }
+
+   public CopyObjectOptions cacheControl(String cacheControl) {
+      this.cacheControl = checkNotNull(cacheControl, "cacheControl");
+      return this;
    }
 
    public CopyObjectOptions contentDisposition(String contentDisposition) {
@@ -352,6 +362,11 @@ public class CopyObjectOptions extends BaseHttpRequestOptions {
       public static CopyObjectOptions ifSourceETagDoesntMatch(String eTag) {
          CopyObjectOptions options = new CopyObjectOptions();
          return options.ifSourceETagDoesntMatch(eTag);
+      }
+
+      public static CopyObjectOptions cacheControl(String cacheControl) {
+         CopyObjectOptions options = new CopyObjectOptions();
+         return options.cacheControl(cacheControl);
       }
 
       public static CopyObjectOptions contentDisposition(String contentDisposition) {

--- a/apis/s3/src/test/java/org/jclouds/s3/binders/BindS3ObjectMetadataToRequestTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/binders/BindS3ObjectMetadataToRequestTest.java
@@ -62,7 +62,6 @@ public class BindS3ObjectMetadataToRequestTest extends BaseS3ClientTest<S3Client
       payload.getContentMetadata().setContentLength(5368709120l);
       object.setPayload(payload);
       object.getMetadata().setKey("foo");
-      object.getMetadata().setCacheControl("no-cache");
       object.getMetadata().setUserMetadata(ImmutableMap.of("foo", "bar"));
 
       HttpRequest request = HttpRequest.builder().method("PUT").endpoint("http://localhost").build();
@@ -70,7 +69,7 @@ public class BindS3ObjectMetadataToRequestTest extends BaseS3ClientTest<S3Client
 
       assertEquals(binder.bindToRequest(request, object), HttpRequest.builder().method("PUT").endpoint(
                URI.create("http://localhost")).headers(
-               ImmutableMultimap.of("Cache-Control", "no-cache", "x-amz-meta-foo", "bar")).build());
+               ImmutableMultimap.of("x-amz-meta-foo", "bar")).build());
    }
 
    @Test(expectedExceptions = IllegalArgumentException.class)

--- a/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
@@ -544,6 +544,10 @@ public final class LocalBlobStore implements BlobStore {
 
          if (options.getContentMetadata().isPresent()) {
             ContentMetadata contentMetadata = options.getContentMetadata().get();
+            String cacheControl = contentMetadata.getCacheControl();
+            if (cacheControl != null) {
+               builder.cacheControl(cacheControl);
+            }
             String contentDisposition = contentMetadata.getContentDisposition();
             if (contentDisposition != null) {
                builder.contentDisposition(contentDisposition);
@@ -561,7 +565,8 @@ public final class LocalBlobStore implements BlobStore {
                builder.contentType(contentType);
             }
          } else {
-            builder.contentDisposition(metadata.getContentDisposition())
+            builder.cacheControl(metadata.getCacheControl())
+                   .contentDisposition(metadata.getContentDisposition())
                    .contentEncoding(metadata.getContentEncoding())
                    .contentLanguage(metadata.getContentLanguage())
                    .contentType(metadata.getContentType());
@@ -782,6 +787,10 @@ public final class LocalBlobStore implements BlobStore {
             .userMetadata(mpu.blobMetadata().getUserMetadata())
             .payload(new SequenceInputStream(Iterators.asEnumeration(streams.build().iterator())))
             .contentLength(contentLength);
+      String cacheControl = mpu.blobMetadata().getContentMetadata().getCacheControl();
+      if (cacheControl != null) {
+         blobBuilder.cacheControl(cacheControl);
+      }
       String contentDisposition = mpu.blobMetadata().getContentMetadata().getContentDisposition();
       if (contentDisposition != null) {
          blobBuilder.contentDisposition(contentDisposition);

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/BlobBuilder.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/BlobBuilder.java
@@ -108,6 +108,8 @@ public interface BlobBuilder {
 
    public interface PayloadBlobBuilder extends BlobBuilder {
 
+      PayloadBlobBuilder cacheControl(String cacheControl);
+
       PayloadBlobBuilder contentLength(long contentLength);
 
       /** @deprecated use {@link #contentMD5(HashCode)} instead. */

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/BlobBuilderImpl.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/BlobBuilderImpl.java
@@ -180,6 +180,12 @@ public class BlobBuilderImpl implements BlobBuilder {
       }
 
       @Override
+      public PayloadBlobBuilder cacheControl(String cacheControl) {
+         payload.getContentMetadata().setCacheControl(cacheControl);
+         return this;
+      }
+
+      @Override
       public PayloadBlobBuilder contentLength(long contentLength) {
          checkArgument(contentLength >= 0, "content length must be non-negative, was: %s", contentLength);
          payload.getContentMetadata().setContentLength(contentLength);

--- a/blobstore/src/main/java/org/jclouds/blobstore/internal/BaseBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/internal/BaseBlobStore.java
@@ -265,6 +265,7 @@ public abstract class BaseBlobStore implements BlobStore {
          ContentMetadata metadata = blob.getMetadata().getContentMetadata();
          BlobBuilder.PayloadBlobBuilder builder = blobBuilder(toName)
                .payload(is)
+               .cacheControl(metadata.getCacheControl())
                .contentDisposition(metadata.getContentDisposition())
                .contentEncoding(metadata.getContentEncoding())
                .contentLanguage(metadata.getContentLanguage())

--- a/blobstore/src/main/java/org/jclouds/blobstore/internal/BaseBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/internal/BaseBlobStore.java
@@ -262,18 +262,25 @@ public abstract class BaseBlobStore implements BlobStore {
       InputStream is = null;
       try {
          is = blob.getPayload().openStream();
-         ContentMetadata metadata = blob.getMetadata().getContentMetadata();
          BlobBuilder.PayloadBlobBuilder builder = blobBuilder(toName)
-               .payload(is)
-               .cacheControl(metadata.getCacheControl())
+               .payload(is);
+         Long contentLength = blob.getMetadata().getContentMetadata().getContentLength();
+         if (contentLength != null) {
+            builder.contentLength(contentLength);
+         }
+
+         ContentMetadata metadata;
+         if (options.getContentMetadata().isPresent()) {
+            metadata = options.getContentMetadata().get();
+         } else {
+            metadata = blob.getMetadata().getContentMetadata();
+         }
+         builder.cacheControl(metadata.getCacheControl())
                .contentDisposition(metadata.getContentDisposition())
                .contentEncoding(metadata.getContentEncoding())
                .contentLanguage(metadata.getContentLanguage())
                .contentType(metadata.getContentType());
-         Long contentLength = metadata.getContentLength();
-         if (contentLength != null) {
-            builder.contentLength(contentLength);
-         }
+
          Optional<Map<String, String>> userMetadata = options.getUserMetadata();
          if (userMetadata.isPresent()) {
             builder.userMetadata(userMetadata.get());

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
@@ -906,7 +906,6 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
             .contentEncoding("compress")
             .contentLanguage("fr")
             .contentType("audio/ogg");
-      addContentMetadata(blobBuilder);
       Blob blob = blobBuilder.build();
 
       String fromContainer = getContainerName();

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
@@ -756,6 +756,7 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
    }
 
    protected void checkContentMetadata(Blob blob) {
+      checkCacheControl(blob, "max-age=3600");
       checkContentType(blob, "text/csv");
       checkContentDisposition(blob, "attachment; filename=photo.jpg");
       checkContentEncoding(blob, "gzip");
@@ -763,10 +764,16 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
    }
 
    protected void addContentMetadata(PayloadBlobBuilder blobBuilder) {
+      blobBuilder.cacheControl("max-age=3600");
       blobBuilder.contentType("text/csv");
       blobBuilder.contentDisposition("attachment; filename=photo.jpg");
       blobBuilder.contentEncoding("gzip");
       blobBuilder.contentLanguage("en");
+   }
+
+   protected void checkCacheControl(Blob blob, String cacheControl) {
+      assertThat(blob.getPayload().getContentMetadata().getCacheControl()).isEqualTo(cacheControl);
+      assertThat(blob.getMetadata().getContentMetadata().getCacheControl()).isEqualTo(cacheControl);
    }
 
    protected void checkContentType(Blob blob, String contentType) {
@@ -893,6 +900,7 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
             .blobBuilder(fromName)
             .userMetadata(ImmutableMap.of("key1", "value1", "key2", "value2"))
             .payload(payload)
+            .cacheControl("max-age=1800")
             .contentLength(payload.size())
             .contentDisposition("attachment; filename=original.jpg")
             .contentEncoding("compress")
@@ -908,6 +916,7 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
          Map<String, String> userMetadata = ImmutableMap.of("key3", "value3", "key4", "value4");
          blobStore.copyBlob(fromContainer, fromName, toContainer, toName, CopyOptions.builder()
                .contentMetadata(ContentMetadataBuilder.create()
+                     .cacheControl("max-age=3600")
                      .contentType("text/csv")
                      .contentDisposition("attachment; filename=photo.jpg")
                      .contentEncoding("gzip")

--- a/core/src/main/java/org/jclouds/io/ContentMetadata.java
+++ b/core/src/main/java/org/jclouds/io/ContentMetadata.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 package org.jclouds.io;
+import static com.google.common.net.HttpHeaders.CACHE_CONTROL;
 import static com.google.common.net.HttpHeaders.CONTENT_DISPOSITION;
 import static com.google.common.net.HttpHeaders.CONTENT_ENCODING;
 import static com.google.common.net.HttpHeaders.CONTENT_LANGUAGE;
@@ -32,13 +33,23 @@ import com.google.common.hash.HashCode;
 import com.google.common.collect.ImmutableSet;
 
 public interface ContentMetadata {
-   Set<String> HTTP_HEADERS = ImmutableSet.of(CONTENT_LENGTH, CONTENT_MD5, CONTENT_TYPE,
-            CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LANGUAGE, EXPIRES);
+   Set<String> HTTP_HEADERS = ImmutableSet.of(
+         CACHE_CONTROL,
+         CONTENT_LENGTH,
+         CONTENT_MD5,
+         CONTENT_TYPE,
+         CONTENT_DISPOSITION,
+         CONTENT_ENCODING,
+         CONTENT_LANGUAGE,
+         EXPIRES);
 
    // See http://stackoverflow.com/questions/10584647/simpledateformat-parse-is-one-hour-out-using-rfc-1123-gmt-in-summer
    // for why not using "zzz"
    String RFC1123_DATE_PATTERN = "EEE, dd MMM yyyyy HH:mm:ss Z";
    
+   @Nullable
+   String getCacheControl();
+
    /**
     * Returns the total size of the payload, or the chunk that's available.
     * <p/>

--- a/core/src/main/java/org/jclouds/io/ContentMetadataBuilder.java
+++ b/core/src/main/java/org/jclouds/io/ContentMetadataBuilder.java
@@ -31,6 +31,7 @@ public class ContentMetadataBuilder {
       return new ContentMetadataBuilder();
    }
 
+   protected String cacheControl;
    protected String contentType = "application/unknown";
    protected Long contentLength;
    protected HashCode contentMD5;
@@ -38,6 +39,11 @@ public class ContentMetadataBuilder {
    protected String contentLanguage;
    protected String contentEncoding;
    protected Date expires;
+
+   public ContentMetadataBuilder cacheControl(@Nullable String cacheControl) {
+      this.cacheControl = cacheControl;
+      return this;
+   }
 
    public ContentMetadataBuilder contentLength(@Nullable Long contentLength) {
       this.contentLength = contentLength;
@@ -85,13 +91,14 @@ public class ContentMetadataBuilder {
    }
 
    public ContentMetadata build() {
-      return new BaseImmutableContentMetadata(contentType, contentLength,
+      return new BaseImmutableContentMetadata(cacheControl, contentType, contentLength,
                contentMD5 == null ? null : contentMD5.asBytes(), contentDisposition,
                contentLanguage, contentEncoding, expires);
    }
 
    public static ContentMetadataBuilder fromContentMetadata(ContentMetadata in) {
-      return new ContentMetadataBuilder().contentType(in.getContentType()).contentLength(in.getContentLength())
+      return new ContentMetadataBuilder()
+               .cacheControl(in.getCacheControl()).contentType(in.getContentType()).contentLength(in.getContentLength())
                .contentMD5(in.getContentMD5()).contentDisposition(in.getContentDisposition()).contentLanguage(
                         in.getContentLanguage()).contentEncoding(in.getContentEncoding()).expires(in.getExpires());
    }
@@ -111,7 +118,8 @@ public class ContentMetadataBuilder {
       if (getClass() != obj.getClass())
          return false;
       ContentMetadataBuilder other = (ContentMetadataBuilder) obj;
-      return Objects.equal(contentDisposition, other.contentDisposition) &&
+      return Objects.equal(cacheControl, other.cacheControl) &&
+             Objects.equal(contentDisposition, other.contentDisposition) &&
              Objects.equal(contentEncoding, other.contentEncoding) &&
              Objects.equal(contentLanguage, other.contentLanguage) &&
              Objects.equal(contentLength, other.contentLength) &&
@@ -122,7 +130,8 @@ public class ContentMetadataBuilder {
 
    @Override
    public String toString() {
-      return "[contentDisposition=" + contentDisposition + ", contentEncoding=" + contentEncoding
+      return "[cacheControl=" + cacheControl
+               + ", contentDisposition=" + contentDisposition + ", contentEncoding=" + contentEncoding
                + ", contentLanguage=" + contentLanguage + ", contentLength=" + contentLength + ", contentMD5="
                + contentMD5 + ", contentType=" + contentType + ", expires=" + expires + "]";
    }

--- a/core/src/main/java/org/jclouds/io/ContentMetadataCodec.java
+++ b/core/src/main/java/org/jclouds/io/ContentMetadataCodec.java
@@ -18,6 +18,7 @@ package org.jclouds.io;
 
 import static com.google.common.collect.Iterables.any;
 import static com.google.common.io.BaseEncoding.base64;
+import static com.google.common.net.HttpHeaders.CACHE_CONTROL;
 import static com.google.common.net.HttpHeaders.CONTENT_DISPOSITION;
 import static com.google.common.net.HttpHeaders.CONTENT_ENCODING;
 import static com.google.common.net.HttpHeaders.CONTENT_LANGUAGE;
@@ -85,6 +86,8 @@ public interface ContentMetadataCodec {
       @Override
       public Multimap<String, String> toHeaders(ContentMetadata md) {
          Builder<String, String> builder = ImmutableMultimap.builder();
+         if (md.getCacheControl() != null)
+            builder.put(CACHE_CONTROL, md.getCacheControl());
          if (md.getContentType() != null)
             builder.put(CONTENT_TYPE, md.getContentType());
          if (md.getContentDisposition() != null)
@@ -111,7 +114,9 @@ public interface ContentMetadataCodec {
             }
          });
          for (Entry<String, String> header : headers.entries()) {
-            if (!chunked && CONTENT_LENGTH.equalsIgnoreCase(header.getKey())) {
+            if (CACHE_CONTROL.equalsIgnoreCase(header.getKey())) {
+               contentMetadata.setCacheControl(header.getValue());
+            } else if (!chunked && CONTENT_LENGTH.equalsIgnoreCase(header.getKey())) {
                contentMetadata.setContentLength(Long.valueOf(header.getValue()));
             } else if (CONTENT_MD5.equalsIgnoreCase(header.getKey())) {
                contentMetadata.setContentMD5(base64().decode(header.getValue()));

--- a/core/src/main/java/org/jclouds/io/MutableContentMetadata.java
+++ b/core/src/main/java/org/jclouds/io/MutableContentMetadata.java
@@ -24,6 +24,8 @@ import com.google.common.hash.HashCode;
 
 public interface MutableContentMetadata extends ContentMetadata {
 
+   void setCacheControl(@Nullable String cacheControl);
+
    void setContentLength(@Nullable Long contentLength);
 
    /** @deprecated use {@link #setContentMD5(HashCode)} instead. */

--- a/core/src/main/java/org/jclouds/io/payloads/BaseImmutableContentMetadata.java
+++ b/core/src/main/java/org/jclouds/io/payloads/BaseImmutableContentMetadata.java
@@ -26,6 +26,7 @@ import com.google.common.hash.HashCode;
 
 public class BaseImmutableContentMetadata implements ContentMetadata {
 
+   protected String cacheControl;
    protected String contentType;
    protected Long contentLength;
    protected HashCode contentMD5;
@@ -34,8 +35,15 @@ public class BaseImmutableContentMetadata implements ContentMetadata {
    protected String contentEncoding;
    protected Date expires;
 
+   @Deprecated
    public BaseImmutableContentMetadata(String contentType, Long contentLength, byte[] contentMD5,
             String contentDisposition, String contentLanguage, String contentEncoding, Date expires) {
+      this(null, contentType, contentLength, contentMD5, contentDisposition, contentLanguage, contentEncoding, expires);
+   }
+
+   public BaseImmutableContentMetadata(String cacheControl, String contentType, Long contentLength, byte[] contentMD5,
+            String contentDisposition, String contentLanguage, String contentEncoding, Date expires) {
+      this.cacheControl = cacheControl;
       this.contentType = contentType;
       this.contentLength = contentLength;
       this.contentMD5 = contentMD5 == null ? null : HashCode.fromBytes(contentMD5);
@@ -43,6 +51,11 @@ public class BaseImmutableContentMetadata implements ContentMetadata {
       this.contentLanguage = contentLanguage;
       this.contentEncoding = contentEncoding;
       this.expires = expires;
+   }
+
+   @Override
+   public String getCacheControl() {
+      return cacheControl;
    }
 
    /**
@@ -108,7 +121,8 @@ public class BaseImmutableContentMetadata implements ContentMetadata {
 
    @Override
    public String toString() {
-      return "[contentType=" + contentType + ", contentLength=" + contentLength + ", contentDisposition="
+      return "[cacheControl=" + cacheControl
+               + "contentType=" + contentType + ", contentLength=" + contentLength + ", contentDisposition="
                + contentDisposition + ", contentEncoding=" + contentEncoding + ", contentLanguage=" + contentLanguage
                + ", contentMD5=" + contentMD5 + ", expires = " + expires + "]";
    }
@@ -128,6 +142,9 @@ public class BaseImmutableContentMetadata implements ContentMetadata {
       if (getClass() != obj.getClass())
          return false;
       BaseImmutableContentMetadata other = (BaseImmutableContentMetadata) obj;
+      if (!Objects.equal(cacheControl, other.cacheControl)) {
+         return false;
+      }
       if (contentDisposition == null) {
          if (other.contentDisposition != null)
             return false;

--- a/core/src/main/java/org/jclouds/io/payloads/BaseMutableContentMetadata.java
+++ b/core/src/main/java/org/jclouds/io/payloads/BaseMutableContentMetadata.java
@@ -27,6 +27,16 @@ import com.google.common.hash.HashCode;
 
 public class BaseMutableContentMetadata extends ContentMetadataBuilder implements MutableContentMetadata {
 
+   @Override
+   public String getCacheControl() {
+      return cacheControl;
+   }
+
+   @Override
+   public void setCacheControl(@Nullable String cacheControl) {
+      cacheControl(cacheControl);
+   }
+
    /**
     * {@inheritDoc}
     */
@@ -154,9 +164,14 @@ public class BaseMutableContentMetadata extends ContentMetadataBuilder implement
    }
 
    public static BaseMutableContentMetadata fromContentMetadata(ContentMetadata in) {
-      return (BaseMutableContentMetadata) new BaseMutableContentMetadata().contentType(in.getContentType())
-               .contentLength(in.getContentLength()).contentMD5(in.getContentMD5()).contentDisposition(
-                        in.getContentDisposition()).contentLanguage(in.getContentLanguage()).contentEncoding(
-                        in.getContentEncoding()).expires(in.getExpires());
+      return (BaseMutableContentMetadata) new BaseMutableContentMetadata()
+               .cacheControl(in.getCacheControl())
+               .contentDisposition(in.getContentDisposition())
+               .contentEncoding(in.getContentEncoding())
+               .contentLanguage(in.getContentLanguage())
+               .contentLength(in.getContentLength())
+               .contentMD5(in.getContentMD5())
+               .contentType(in.getContentType())
+               .expires(in.getExpires());
    }
 }

--- a/core/src/main/java/org/jclouds/logging/internal/Wire.java
+++ b/core/src/main/java/org/jclouds/logging/internal/Wire.java
@@ -159,6 +159,7 @@ public abstract class Wire {
       MutableContentMetadata wiredMd = wiredPayload.getContentMetadata();
       if (oldMd.getContentLength() != null)
          wiredMd.setContentLength(oldMd.getContentLength());
+      wiredMd.setCacheControl(oldMd.getCacheControl());
       wiredMd.setContentType(oldMd.getContentType());
       wiredMd.setContentMD5(oldMd.getContentMD5());
       wiredMd.setContentDisposition(oldMd.getContentDisposition());

--- a/providers/azureblob/src/main/java/org/jclouds/azure/storage/reference/AzureStorageHeaders.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azure/storage/reference/AzureStorageHeaders.java
@@ -23,6 +23,7 @@ package org.jclouds.azure.storage.reference;
  */
 public final class AzureStorageHeaders {
 
+   public static final String CACHE_CONTROL = "x-ms-blob-cache-control";
    public static final String CONTENT_DISPOSITION = "x-ms-blob-content-disposition";
    public static final String CONTENT_ENCODING = "x-ms-blob-content-encoding";
    public static final String CONTENT_LANGUAGE = "x-ms-blob-content-language";

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/binders/BindAzureBlobMetadataToMultipartRequest.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/binders/BindAzureBlobMetadataToMultipartRequest.java
@@ -55,6 +55,10 @@ public class BindAzureBlobMetadataToMultipartRequest implements Binder {
       // bind BlockList-specific headers
       ImmutableMap.Builder<String, String> headers = ImmutableMap.builder();
       ContentMetadata contentMetadata = blob.getProperties().getContentMetadata();
+      String cacheControl = contentMetadata.getCacheControl();
+      if (cacheControl != null) {
+         headers.put("x-ms-blob-cache-control", cacheControl);
+      }
       String contentDisposition = contentMetadata.getContentDisposition();
       if (contentDisposition != null) {
          headers.put("x-ms-blob-content-disposition", contentDisposition);

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/binders/BindAzureBlobMetadataToRequest.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/binders/BindAzureBlobMetadataToRequest.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.jclouds.azure.storage.reference.AzureStorageHeaders;
 import org.jclouds.azureblob.blobstore.functions.AzureBlobToBlob;
 import org.jclouds.azureblob.domain.AzureBlob;
 import org.jclouds.blobstore.binders.BindUserMetadataToHeadersWithPrefix;
@@ -56,6 +57,11 @@ public class BindAzureBlobMetadataToRequest implements Binder {
             && blob.getPayload().getContentMetadata().getContentLength() >= 0, "size must be set");
 
       Builder<String, String> headers = ImmutableMap.builder();
+
+      String cacheControl = blob.getPayload().getContentMetadata().getCacheControl();
+      if (cacheControl != null) {
+         headers.put(AzureStorageHeaders.CACHE_CONTROL, cacheControl);
+      }
 
       headers.put("x-ms-blob-type", blob.getProperties().getType().toString());
 

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/binders/BindAzureContentMetadataToRequest.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/binders/BindAzureContentMetadataToRequest.java
@@ -45,6 +45,11 @@ public class BindAzureContentMetadataToRequest implements Binder {
 
       ImmutableMap.Builder<String, String> headers = ImmutableMap.builder();
 
+      String cacheControl = contentMetadata.getCacheControl();
+      if (cacheControl != null) {
+         headers.put(AzureStorageHeaders.CACHE_CONTROL, cacheControl);
+      }
+
       String contentDisposition = contentMetadata.getContentDisposition();
       if (contentDisposition != null) {
          headers.put(AzureStorageHeaders.CONTENT_DISPOSITION, contentDisposition);

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/AzureBlobStore.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/AzureBlobStore.java
@@ -249,6 +249,11 @@ public class AzureBlobStore extends BaseBlobStore {
       if (contentMetadata.isPresent()) {
          ContentMetadataBuilder builder = ContentMetadataBuilder.create();
 
+         String cacheControl = contentMetadata.get().getCacheControl();
+         if (cacheControl != null) {
+            builder.cacheControl(cacheControl);
+         }
+
          String contentDisposition = contentMetadata.get().getContentDisposition();
          if (contentDisposition != null) {
             builder.contentDisposition(contentDisposition);

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/domain/internal/BlobPropertiesImpl.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/domain/internal/BlobPropertiesImpl.java
@@ -46,6 +46,7 @@ public class BlobPropertiesImpl implements BlobProperties {
    private final LeaseStatus leaseStatus;
    private final BaseImmutableContentMetadata contentMetadata;
 
+   // TODO: should this take Cache-Control as well?
    public BlobPropertiesImpl(BlobType type, String name, String container, URI url, Date lastModified, String eTag,
             long size, String contentType, @Nullable byte[] contentMD5, @Nullable String contentMetadata,
             @Nullable String contentLanguage, @Nullable Date currentExpires, LeaseStatus leaseStatus, 


### PR DESCRIPTION
Tested against Atmos, Azure, filesystem, GCS, S3, Swift, and transient.