### PR TITLE
Fix: RunScriptOptions equals

### DIFF
--- a/compute/src/main/java/org/jclouds/compute/options/RunScriptOptions.java
+++ b/compute/src/main/java/org/jclouds/compute/options/RunScriptOptions.java
@@ -42,6 +42,25 @@ public class RunScriptOptions {
     */
    public static final RunScriptOptions NONE = new ImmutableRunScriptOptions(new RunScriptOptions());
 
+   public void copyTo(RunScriptOptions to) {
+      if (this.getPort() != -1)
+         to.blockOnPort(this.getPort(), this.getSeconds());
+      if (this.getTaskName() != null)
+         to.nameTask(this.getTaskName());
+      to.runAsRoot(this.shouldRunAsRoot());
+      to.blockOnComplete(this.shouldBlockOnComplete());
+      to.wrapInInitScript(this.shouldWrapInInitScript());
+      if (this.hasLoginPasswordOption())
+         to.overrideLoginPassword(this.loginPassword);
+      if (this.hasLoginPrivateKeyOption())
+         to.overrideLoginPrivateKey(this.loginPrivateKey);
+      if (this.getLoginUser() != null)
+         to.overrideLoginUser(this.getLoginUser());
+      if (this.shouldAuthenticateSudo() != null) {
+         to.overrideAuthenticateSudo(this.shouldAuthenticateSudo());
+      }
+   }
+   
    public static class ImmutableRunScriptOptions extends RunScriptOptions {
       private final RunScriptOptions delegate;
 
@@ -194,6 +213,18 @@ public class RunScriptOptions {
    public RunScriptOptions overrideLoginPrivateKey(String privateKey) {
       checkNotNull(privateKey, "privateKey");
       this.loginPrivateKey = Optional.of(privateKey);
+      return this;
+   }
+
+   public RunScriptOptions overrideLoginPassword(Optional<String> password) {
+      checkNotNull(password, "password");
+      this.loginPassword = password;
+      return this;
+   }
+
+   public RunScriptOptions overrideLoginPrivateKey(Optional<String> privateKey) {
+      checkNotNull(privateKey, "privateKey");
+      this.loginPrivateKey = privateKey;
       return this;
    }
 
@@ -453,9 +484,9 @@ public class RunScriptOptions {
    protected ToStringHelper string() {
       ToStringHelper toString = Objects.toStringHelper("").omitNullValues();
       toString.add("loginUser", loginUser);
-      if (loginPassword != null)
+      if (loginPassword != null && loginPassword.isPresent())
          toString.add("loginPasswordPresent", true);
-      if (loginPrivateKey != null)
+      if (loginPrivateKey != null && loginPrivateKey.isPresent())
          toString.add("loginPrivateKeyPresent", true);
       toString.add("authenticateSudo", authenticateSudo);
       if (port != -1 && seconds != -1) // TODO: not primitives

--- a/compute/src/main/java/org/jclouds/compute/options/TemplateOptions.java
+++ b/compute/src/main/java/org/jclouds/compute/options/TemplateOptions.java
@@ -64,6 +64,7 @@ public class TemplateOptions extends RunScriptOptions implements Cloneable {
    }
 
    public void copyTo(TemplateOptions to) {
+      super.copyTo(to);
       if (!Arrays.equals(to.getInboundPorts(), this.getInboundPorts()))
          to.inboundPorts(this.getInboundPorts());
       if (this.getRunScript() != null)
@@ -74,8 +75,6 @@ public class TemplateOptions extends RunScriptOptions implements Cloneable {
          to.installPrivateKey(this.getPrivateKey());
       if (this.getPublicKey() != null)
          to.authorizePublicKey(this.getPublicKey());
-      if (this.getPort() != -1)
-         to.blockOnPort(this.getPort(), this.getSeconds());
       if (!this.getUserMetadata().isEmpty())
          to.userMetadata(this.getUserMetadata());
       if (!this.getTags().isEmpty())
@@ -84,21 +83,6 @@ public class TemplateOptions extends RunScriptOptions implements Cloneable {
          to.nodeNames(getNodeNames());
       if (!this.shouldBlockUntilRunning())
          to.blockUntilRunning(false);
-      if (!this.shouldBlockOnComplete())
-         to.blockOnComplete(false);
-
-      LoginCredentials fromCreds = new LoginCredentials.Builder().
-            user(this.getLoginUser()).
-            password(this.hasLoginPassword() ? this.getLoginPassword() : null).
-            privateKey(this.hasLoginPrivateKeyOption() ? this.getLoginPrivateKey() : null).
-            authenticateSudo(authenticateSudo == null ? false : authenticateSudo).
-            build();
-      if (fromCreds != null) {
-         to.overrideLoginCredentials(fromCreds);
-      }
-
-      if (this.getTaskName() != null)
-         to.nameTask(this.getTaskName());
       if (!this.getNetworks().isEmpty())
          to.networks(this.getNetworks());
    }


### PR DESCRIPTION
Fix TemplateOptions.clone; adds RunScriptOptions.copyTo
    
Previously not all fields of RunScriptOptions were included in templateOptions.copyTo (e.g. runAsRoot and initScript).
    
Also options.equals(options.clone()) failed if options.loginPassword was originally null - in the cloned object, it would have become Optional.absent.

This also fixes RunScriptOptions.toString, to only say “loginPasswordPresent” if optional.isPresent().
