### PR TITLE
clean up logic and docs for setting proxies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ atlassian-ide-plugin.xml
 .java-version
 .factorypath
 .apt_generated
+.checkstyle

--- a/core/src/main/java/org/jclouds/Constants.java
+++ b/core/src/main/java/org/jclouds/Constants.java
@@ -100,9 +100,37 @@ public final class Constants {
    /**
     * Boolean property.
     * <p/>
-    * Whether or not to use the proxy setup from the underlying operating system.
+    * Whether or not to attempt to use the proxy setup from the underlying operating system.
+    * Defaults to false. 
+    * Only considered if {@link #PROPERTY_PROXY_FROM_JVM} is false
+    * and {@link #PROPERTY_PROXY_HOST} is not supplied.
+    * Due to how Java's <code>java.net.useSystemProxies</code> is handled,
+    * this may have limited effectiveness.
     */
+   // TODO: should this be deprecated? the impl attempts to set the corresponding JVM system property
+   // but that is documented to have no effect if set after system startup;
+   // see e.g. https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html
    public static final String PROPERTY_PROXY_SYSTEM = "jclouds.use-system-proxy";
+   
+   /**
+    * Boolean property.
+    * <p/>
+    * Whether or not jclouds is permitted to use the default proxy detected by the JVM
+    * and configured there using the usual Java settings:
+    * <ul>
+    * <li> <code>java.net.useSystemProxies</code>
+    * <li> <code>java.net.httpProxyHost</code>
+    * <li> <code>java.net.httpProxyPort</code>
+    * </ul>
+    * <p/> 
+    * Defaults to true so that the Java standard way of setting proxies can be used.
+    * However if {@link #PROPERTY_PROXY_HOST} is set that will always take priority
+    * when jclouds looks for a proxy.
+    * If this property is explicitly set <code>false</code>, 
+    * then jclouds will not use a proxy irrespective of the <code>java.net.*</code> settings,
+    * unless {@link #PROPERTY_PROXY_HOST} is set or {@link #PROPERTY_PROXY_SYSTEM} is true.
+    */
+   public static final String PROPERTY_PROXY_FROM_JVM = "jclouds.use-jvm-proxy";
    
    /**
     * String property.
@@ -132,6 +160,7 @@ public final class Constants {
     * String property.
     * <p/>
     * Explicitly sets the user name credential for proxy authentication.
+    * This only applies when {@link #PROPERTY_PROXY_HOST} is supplied.
     */
    public static final String PROPERTY_PROXY_USER = "jclouds.proxy-user";
    
@@ -139,6 +168,7 @@ public final class Constants {
     * String property.
     * <p/>
     * Explicitly sets the password credential for proxy authentication.
+    * This only applies when {@link #PROPERTY_PROXY_HOST} is supplied.
     */
    public static final String PROPERTY_PROXY_PASSWORD = "jclouds.proxy-password";
 

--- a/core/src/main/java/org/jclouds/Constants.java
+++ b/core/src/main/java/org/jclouds/Constants.java
@@ -102,11 +102,11 @@ public final class Constants {
     * <p/>
     * Whether or not to attempt to use the proxy setup from the underlying operating system.
     * Defaults to false. 
-    * Only considered if {@link #PROPERTY_PROXY_FROM_JVM} is false
+    * Only considered if {@link #PROPERTY_PROXY_ENABLE_JVM_PROXY} is false
     * and {@link #PROPERTY_PROXY_HOST} is not supplied.
     * Due to how Java's <code>java.net.useSystemProxies</code> is handled,
     * this may have limited effectiveness.
-    * @deprecated in 2.0.0, replaced by {@link #PROPERTY_PROXY_FROM_JVM} does what this intended but better
+    * @deprecated in 2.0.0, replaced by {@link #PROPERTY_PROXY_ENABLE_JVM_PROXY} does what this intended but better
     */
    @Deprecated
    // deprecated because:  the impl attempts to set the corresponding JVM system property
@@ -132,7 +132,7 @@ public final class Constants {
     * then jclouds will not use a proxy irrespective of the <code>java.net.*</code> settings,
     * unless {@link #PROPERTY_PROXY_HOST} is set or {@link #PROPERTY_PROXY_SYSTEM} is true.
     */
-   public static final String PROPERTY_PROXY_FROM_JVM = "jclouds.use-jvm-proxy";
+   public static final String PROPERTY_PROXY_ENABLE_JVM_PROXY = "jclouds.enable-jvm-proxy";
    
    /**
     * String property.

--- a/core/src/main/java/org/jclouds/Constants.java
+++ b/core/src/main/java/org/jclouds/Constants.java
@@ -106,8 +106,10 @@ public final class Constants {
     * and {@link #PROPERTY_PROXY_HOST} is not supplied.
     * Due to how Java's <code>java.net.useSystemProxies</code> is handled,
     * this may have limited effectiveness.
+    * @deprecated in 2.0.0, replaced by {@link #PROPERTY_PROXY_FROM_JVM} does what this intended but better
     */
-   // TODO: should this be deprecated? the impl attempts to set the corresponding JVM system property
+   @Deprecated
+   // deprecated because:  the impl attempts to set the corresponding JVM system property
    // but that is documented to have no effect if set after system startup;
    // see e.g. https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html
    public static final String PROPERTY_PROXY_SYSTEM = "jclouds.use-system-proxy";

--- a/core/src/main/java/org/jclouds/proxy/ProxyConfig.java
+++ b/core/src/main/java/org/jclouds/proxy/ProxyConfig.java
@@ -36,6 +36,11 @@ public interface ProxyConfig {
     * @see org.jclouds.Constants#PROPERTY_PROXY_SYSTEM
     */
    boolean useSystem();
+
+   /**
+    * @see org.jclouds.Constants#PROPERTY_PROXY_FROM_JVM
+    */
+   boolean canUseProxyFromJvm();
    
    /**
     * @see org.jclouds.Constants#PROPERTY_PROXY_TYPE
@@ -43,6 +48,8 @@ public interface ProxyConfig {
    Type getType();
    
    /**
+    * Returns the host and port of the proxy configured here, if there is one
+    * 
     * @see org.jclouds.Constants#PROPERTY_PROXY_HOST
     * @see org.jclouds.Constants#PROPERTY_PROXY_PORT
     */

--- a/core/src/main/java/org/jclouds/proxy/ProxyConfig.java
+++ b/core/src/main/java/org/jclouds/proxy/ProxyConfig.java
@@ -33,8 +33,9 @@ import com.google.inject.ImplementedBy;
 public interface ProxyConfig {
 
    /**
+    * @deprecated
     * @see org.jclouds.Constants#PROPERTY_PROXY_SYSTEM
-    */
+    */ @Deprecated
    boolean useSystem();
 
    /**

--- a/core/src/main/java/org/jclouds/proxy/ProxyConfig.java
+++ b/core/src/main/java/org/jclouds/proxy/ProxyConfig.java
@@ -41,7 +41,7 @@ public interface ProxyConfig {
    /**
     * @see org.jclouds.Constants#PROPERTY_PROXY_FROM_JVM
     */
-   boolean canUseProxyFromJvm();
+   boolean isJvmProxyEnabled();
    
    /**
     * @see org.jclouds.Constants#PROPERTY_PROXY_TYPE

--- a/core/src/main/java/org/jclouds/proxy/ProxyForURI.java
+++ b/core/src/main/java/org/jclouds/proxy/ProxyForURI.java
@@ -65,15 +65,12 @@ public class ProxyForURI implements Function<URI, Proxy> {
    public Proxy apply(URI endpoint) {
       if (!useProxyForSockets && "socket".equals(endpoint.getScheme())) {
          return Proxy.NO_PROXY;
-      } else if (config.useSystem()) {
-         System.setProperty("java.net.useSystemProxies", "true");
-         Iterable<Proxy> proxies = ProxySelector.getDefault().select(endpoint);
-         return getLast(proxies);
-      } else if (config.getProxy().isPresent()) {
+      }
+      if (config.getProxy().isPresent()) {
          SocketAddress addr = new InetSocketAddress(config.getProxy().get().getHostText(), config.getProxy().get()
-               .getPort());
+            .getPort());
          Proxy proxy = new Proxy(config.getType(), addr);
-
+         
          final Optional<Credentials> creds = config.getCredentials();
          if (creds.isPresent()) {
             Authenticator authenticator = new Authenticator() {
@@ -84,9 +81,20 @@ public class ProxyForURI implements Function<URI, Proxy> {
             Authenticator.setDefault(authenticator);
          }
          return proxy;
-      } else {
-         return Proxy.NO_PROXY;
       }
+      if (config.canUseProxyFromJvm()) {
+         return getDefaultProxy(endpoint);
+      }
+      if (config.useSystem()) {
+         System.setProperty("java.net.useSystemProxies", "true");
+         return getDefaultProxy(endpoint);
+      }
+      return Proxy.NO_PROXY;
+   }
+
+   private Proxy getDefaultProxy(URI endpoint) {
+      Iterable<Proxy> proxies = ProxySelector.getDefault().select(endpoint);
+      return getLast(proxies);
    }
 
 }

--- a/core/src/main/java/org/jclouds/proxy/ProxyForURI.java
+++ b/core/src/main/java/org/jclouds/proxy/ProxyForURI.java
@@ -82,10 +82,12 @@ public class ProxyForURI implements Function<URI, Proxy> {
          }
          return proxy;
       }
-      if (config.canUseProxyFromJvm()) {
+      if (config.isJvmProxyEnabled()) {
          return getDefaultProxy(endpoint);
       }
       if (config.useSystem()) {
+         // see notes on the Constant which initialized the above for deprecation;
+         // in short the following applied after startup is documented to have no effect.
          System.setProperty("java.net.useSystemProxies", "true");
          return getDefaultProxy(endpoint);
       }

--- a/core/src/main/java/org/jclouds/proxy/internal/GuiceProxyConfig.java
+++ b/core/src/main/java/org/jclouds/proxy/internal/GuiceProxyConfig.java
@@ -17,6 +17,7 @@
 package org.jclouds.proxy.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.jclouds.Constants.PROPERTY_PROXY_FROM_JVM;
 import static org.jclouds.Constants.PROPERTY_PROXY_HOST;
 import static org.jclouds.Constants.PROPERTY_PROXY_PASSWORD;
 import static org.jclouds.Constants.PROPERTY_PROXY_PORT;
@@ -49,6 +50,9 @@ public class GuiceProxyConfig implements ProxyConfig {
    @Named(PROPERTY_PROXY_SYSTEM)
    private boolean systemProxies = Boolean.parseBoolean(System.getProperty("java.net.useSystemProxies", "false"));
    @Inject(optional = true)
+   @Named(PROPERTY_PROXY_FROM_JVM)
+   private boolean canUseProxyFromJvm = true;
+   @Inject(optional = true)
    @Named(PROPERTY_PROXY_HOST)
    private String host;
    @Inject(optional = true)
@@ -66,7 +70,7 @@ public class GuiceProxyConfig implements ProxyConfig {
 
    @Override
    public Optional<HostAndPort> getProxy() {
-      if (host == null)
+      if (Strings.isNullOrEmpty(host))
          return Optional.absent();
       Integer port = this.port;
       if (port == null) {
@@ -107,13 +111,19 @@ public class GuiceProxyConfig implements ProxyConfig {
       return systemProxies;
    }
 
+   @Override
+   public boolean canUseProxyFromJvm() {
+      return canUseProxyFromJvm;
+   }
+   
    /**
     * {@inheritDoc}
     */
    @Override
    public String toString() {
       return Objects.toStringHelper(this).omitNullValues().add("systemProxies", systemProxies ? "true" : null)
-            .add("proxy", getProxy().orNull()).add("user", user).add("type", host != null ? type : null).toString();
+            .add("canUseProxyFromJvm", canUseProxyFromJvm ? "true" : "false")
+            .add("proxyHostPort", getProxy().orNull()).add("user", user).add("type", host != null ? type : null).toString();
    }
 
 }

--- a/core/src/main/java/org/jclouds/proxy/internal/GuiceProxyConfig.java
+++ b/core/src/main/java/org/jclouds/proxy/internal/GuiceProxyConfig.java
@@ -17,7 +17,7 @@
 package org.jclouds.proxy.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.jclouds.Constants.PROPERTY_PROXY_FROM_JVM;
+import static org.jclouds.Constants.PROPERTY_PROXY_ENABLE_JVM_PROXY;
 import static org.jclouds.Constants.PROPERTY_PROXY_HOST;
 import static org.jclouds.Constants.PROPERTY_PROXY_PASSWORD;
 import static org.jclouds.Constants.PROPERTY_PROXY_PORT;
@@ -52,8 +52,8 @@ public class GuiceProxyConfig implements ProxyConfig {
    @Deprecated
    private boolean systemProxies = Boolean.parseBoolean(System.getProperty("java.net.useSystemProxies", "false"));
    @Inject(optional = true)
-   @Named(PROPERTY_PROXY_FROM_JVM)
-   private boolean canUseProxyFromJvm = true;
+   @Named(PROPERTY_PROXY_ENABLE_JVM_PROXY)
+   private boolean jvmProxyEnabled = true;
    @Inject(optional = true)
    @Named(PROPERTY_PROXY_HOST)
    private String host;
@@ -114,8 +114,8 @@ public class GuiceProxyConfig implements ProxyConfig {
    }
 
    @Override
-   public boolean canUseProxyFromJvm() {
-      return canUseProxyFromJvm;
+   public boolean isJvmProxyEnabled() {
+      return jvmProxyEnabled;
    }
    
    /**
@@ -124,7 +124,7 @@ public class GuiceProxyConfig implements ProxyConfig {
    @Override
    public String toString() {
       return Objects.toStringHelper(this).omitNullValues().add("systemProxies", systemProxies ? "true" : null)
-            .add("canUseProxyFromJvm", canUseProxyFromJvm ? "true" : "false")
+            .add("jvmProxyEnabled", jvmProxyEnabled ? "true" : "false")
             .add("proxyHostPort", getProxy().orNull()).add("user", user).add("type", host != null ? type : null).toString();
    }
 

--- a/core/src/main/java/org/jclouds/proxy/internal/GuiceProxyConfig.java
+++ b/core/src/main/java/org/jclouds/proxy/internal/GuiceProxyConfig.java
@@ -46,8 +46,10 @@ import com.google.inject.Inject;
 @Singleton
 public class GuiceProxyConfig implements ProxyConfig {
 
+   @SuppressWarnings("deprecation")
    @Inject(optional = true)
    @Named(PROPERTY_PROXY_SYSTEM)
+   @Deprecated
    private boolean systemProxies = Boolean.parseBoolean(System.getProperty("java.net.useSystemProxies", "false"));
    @Inject(optional = true)
    @Named(PROPERTY_PROXY_FROM_JVM)

--- a/core/src/test/java/org/jclouds/proxy/ProxyForURITest.java
+++ b/core/src/test/java/org/jclouds/proxy/ProxyForURITest.java
@@ -76,7 +76,7 @@ public class ProxyForURITest {
       }
 
       @Override
-      public boolean canUseProxyFromJvm() {
+      public boolean isJvmProxyEnabled() {
          return canUseProxyFromJvm;
       }
    }

--- a/core/src/test/java/org/jclouds/proxy/ProxyForURITest.java
+++ b/core/src/test/java/org/jclouds/proxy/ProxyForURITest.java
@@ -17,6 +17,7 @@
 package org.jclouds.proxy;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 
 import java.lang.reflect.Field;
@@ -160,6 +161,16 @@ public class ProxyForURITest {
       URI uri = new URI("http://example.com/file");
       // could return a proxy, could return NO_PROXY, depends on the tester's environment
       assertNotNull(new ProxyForURI(config).apply(uri));
+   }
+
+   @Test
+   public void testJcloudsProxyHostsPreferredOverJvmProxy() throws URISyntaxException {
+      ProxyConfig test = new MyProxyConfig(true, true, Proxy.Type.HTTP, hostAndPort, noCreds);
+      ProxyConfig jclouds = new MyProxyConfig(false, false, Proxy.Type.HTTP, hostAndPort, noCreds);
+      ProxyConfig jvm = new MyProxyConfig(false, true, Proxy.Type.HTTP, noHostAndPort, noCreds);
+      URI uri = new URI("http://example.com/file");
+      assertEquals(new ProxyForURI(test).apply(uri), new ProxyForURI(jclouds).apply(uri));
+      assertNotEquals(new ProxyForURI(test).apply(uri), new ProxyForURI(jvm).apply(uri));
    }
 
    @Test

--- a/core/src/test/java/org/jclouds/proxy/ProxyForURITest.java
+++ b/core/src/test/java/org/jclouds/proxy/ProxyForURITest.java
@@ -41,12 +41,14 @@ public class ProxyForURITest {
 
    private class MyProxyConfig implements ProxyConfig {
       private boolean useSystem;
+      private boolean canUseProxyFromJvm;
       private Type type;
       private Optional<HostAndPort> proxy;
       private Optional<Credentials> credentials;
 
-      MyProxyConfig(boolean useSystem, Type type, Optional<HostAndPort> proxy, Optional<Credentials> credentials) {
+      MyProxyConfig(boolean useSystem, boolean canUseProxyFromJvm, Type type, Optional<HostAndPort> proxy, Optional<Credentials> credentials) {
          this.useSystem = useSystem;
+         this.canUseProxyFromJvm = canUseProxyFromJvm;
          this.type = type;
          this.proxy = proxy;
          this.credentials = credentials;
@@ -71,11 +73,16 @@ public class ProxyForURITest {
       public Optional<Credentials> getCredentials() {
          return credentials;
       }
+
+      @Override
+      public boolean canUseProxyFromJvm() {
+         return canUseProxyFromJvm;
+      }
    }
 
    @Test
    public void testDontUseProxyForSockets() throws Exception {
-      ProxyConfig config = new MyProxyConfig(false, Proxy.Type.HTTP, hostAndPort, creds);
+      ProxyConfig config = new MyProxyConfig(false, false, Proxy.Type.HTTP, hostAndPort, creds);
       ProxyForURI proxy = new ProxyForURI(config);
       Field useProxyForSockets = proxy.getClass().getDeclaredField("useProxyForSockets");
       useProxyForSockets.setAccessible(true);
@@ -86,7 +93,7 @@ public class ProxyForURITest {
 
    @Test
    public void testUseProxyForSockets() throws Exception {
-      ProxyConfig config = new MyProxyConfig(false, Proxy.Type.HTTP, hostAndPort, creds);
+      ProxyConfig config = new MyProxyConfig(false, false, Proxy.Type.HTTP, hostAndPort, creds);
       ProxyForURI proxy = new ProxyForURI(config);
       URI uri = new URI("socket://ssh.example.com:22");
       assertEquals(proxy.apply(uri), new Proxy(Proxy.Type.HTTP, new InetSocketAddress("proxy.example.com", 8080)));
@@ -94,7 +101,7 @@ public class ProxyForURITest {
 
    @Test
    public void testUseProxyForSocketsSettingShouldntAffectHTTP() throws Exception {
-      ProxyConfig config = new MyProxyConfig(false, Proxy.Type.HTTP, hostAndPort, creds);
+      ProxyConfig config = new MyProxyConfig(false, false, Proxy.Type.HTTP, hostAndPort, creds);
       ProxyForURI proxy = new ProxyForURI(config);
       Field useProxyForSockets = proxy.getClass().getDeclaredField("useProxyForSockets");
       useProxyForSockets.setAccessible(true);
@@ -105,47 +112,62 @@ public class ProxyForURITest {
 
    @Test
    public void testHTTPDirect() throws URISyntaxException {
-      ProxyConfig config = new MyProxyConfig(false, Proxy.Type.DIRECT, noHostAndPort, noCreds);
+      ProxyConfig config = new MyProxyConfig(false, false, Proxy.Type.DIRECT, noHostAndPort, noCreds);
       URI uri = new URI("http://example.com/file");
       assertEquals(new ProxyForURI(config).apply(uri), Proxy.NO_PROXY);
    }
 
    @Test
    public void testHTTPSDirect() throws URISyntaxException {
-      ProxyConfig config = new MyProxyConfig(false, Proxy.Type.DIRECT, noHostAndPort, noCreds);
+      ProxyConfig config = new MyProxyConfig(false, false, Proxy.Type.DIRECT, noHostAndPort, noCreds);
       URI uri = new URI("https://example.com/file");
       assertEquals(new ProxyForURI(config).apply(uri), Proxy.NO_PROXY);
    }
 
    @Test
    public void testFTPDirect() throws URISyntaxException {
-      ProxyConfig config = new MyProxyConfig(false, Proxy.Type.DIRECT, noHostAndPort, noCreds);
+      ProxyConfig config = new MyProxyConfig(false, false, Proxy.Type.DIRECT, noHostAndPort, noCreds);
       URI uri = new URI("ftp://ftp.example.com/file");
       assertEquals(new ProxyForURI(config).apply(uri), Proxy.NO_PROXY);
    }
 
    @Test
    public void testSocketDirect() throws URISyntaxException {
-      ProxyConfig config = new MyProxyConfig(false, Proxy.Type.DIRECT, noHostAndPort, noCreds);
+      ProxyConfig config = new MyProxyConfig(false, false, Proxy.Type.DIRECT, noHostAndPort, noCreds);
       URI uri = new URI("socket://ssh.example.com:22");
       assertEquals(new ProxyForURI(config).apply(uri), Proxy.NO_PROXY);
    }
 
    @Test
    public void testHTTPThroughHTTPProxy() throws URISyntaxException {
-      ProxyConfig config = new MyProxyConfig(false, Proxy.Type.HTTP, hostAndPort, creds);
+      ProxyConfig config = new MyProxyConfig(false, false, Proxy.Type.HTTP, hostAndPort, creds);
       URI uri = new URI("http://example.com/file");
       assertEquals(new ProxyForURI(config).apply(uri), new Proxy(Proxy.Type.HTTP, new InetSocketAddress(
             "proxy.example.com", 8080)));
    }
 
    @Test
-   public void testHTTPThroughSystemProxy() throws URISyntaxException {
-      ProxyConfig config = new MyProxyConfig(true, Proxy.Type.DIRECT, noHostAndPort, noCreds);
+   public void testThroughJvmProxy() throws URISyntaxException {
+      ProxyConfig config = new MyProxyConfig(false, true, Proxy.Type.HTTP, noHostAndPort, noCreds);
       URI uri = new URI("http://example.com/file");
-      // could return a proxy, could return NO_PROXY, depends on the tester's
-      // environment
+      // could return a proxy, could return NO_PROXY, depends on the tester's environment
       assertNotNull(new ProxyForURI(config).apply(uri));
+   }
+   
+   @Test
+   public void testThroughSystemProxy() throws URISyntaxException {
+      ProxyConfig config = new MyProxyConfig(true, false, Proxy.Type.HTTP, noHostAndPort, noCreds);
+      URI uri = new URI("http://example.com/file");
+      // could return a proxy, could return NO_PROXY, depends on the tester's environment
+      assertNotNull(new ProxyForURI(config).apply(uri));
+   }
+
+   @Test
+   public void testJvmProxyAlwaysPreferredOverSystem() throws URISyntaxException {
+      ProxyConfig test = new MyProxyConfig(true, true, Proxy.Type.HTTP, noHostAndPort, noCreds);
+      ProxyConfig jvm = new MyProxyConfig(false, true, Proxy.Type.HTTP, noHostAndPort, noCreds);
+      URI uri = new URI("http://example.com/file");
+      assertEquals(new ProxyForURI(test).apply(uri), new ProxyForURI(jvm).apply(uri));
    }
 
 }

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -518,6 +518,7 @@
             <exclude>**/modernizer_exclusions.txt</exclude>
             <exclude>**/.factorypath</exclude>
             <exclude>**/.apt_generated/**</exclude>
+            <exclude>**/.checkstyle</exclude>
 
             <!-- Temporary files generated on CloudBees slaves -->
             <exclude>.repository/**</exclude>


### PR DESCRIPTION
In the absence of any special `jclouds.*proxy*` settings, jclouds should respect the normal JVM conventions for proxy detection, such as the `java.net.httpProxyHost` property.  For it to default to no proxy, unlike everything else in java, is surprising.  Previously jclouds only looked for the JVM proxy if `jclouds.use-system-proxies` was set, and then in a cumbersome way:

* `jclouds.use-system-proxies` tried to set `java.net.useSystemProxy` but that is read once at startup and subsequently ignored by the JVM so it had little effect
* so the effect of `jclouds.use-system-proxies` was effectively to tell jclouds to use the default proxy chosen by the JVM looking at the `java.net.*` properties, *not* necessarily the OS proxy referred to by `java.net.useSystemProxy`
* the *default* value of `jclouds.use-system-proxies` was taken from `java.net.useSystemProxy` and so while that succeeds in causing `java.net.useSystemProxy` to take effect, it was succeeding in a strange accidental way:  the only way for the normal `java.net.httpProxyHost` and others to take effect was to set `jclouds.use-system-proxies=true` but make sure `java.net.useSystemProxy=false`

This adds explicit control over whether the JVM default proxy is usable (true by default), and switches the precedence so that if a user specifies a `jclouds.proxy-host` then it is used -- irrespective of whether any other system proxies or jvm proxies are specified.

I think this is more what a user would expect if they do need to set special proxy settings for jclouds to use.  More importantly in most cases they can now just set JVM proxy settings and the right thing will happen.