### PR TITLE
Fix for issue https://issues.apache.org/jira/browse/JCLOUDS-1068.  Th…

### DIFF
--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/compute/functions/OperatingSystemToImage.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/compute/functions/OperatingSystemToImage.java
@@ -36,6 +36,7 @@ import org.jclouds.softlayer.domain.SoftwareLicense;
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 
 @Singleton
 public class OperatingSystemToImage implements Function<OperatingSystem, Image> {
@@ -83,7 +84,7 @@ public class OperatingSystemToImage implements Function<OperatingSystem, Image> 
               .build();
 
       return new ImageBuilder()
-              .ids(optOSReferenceCode.or(operatingSystem.getId()))
+              .ids(fromNullable(Strings.emptyToNull(operatingSystem.getId())).or(optOSReferenceCode.get()))
               .description(optOSReferenceCode.or(UNRECOGNIZED))
               .operatingSystem(os)
               .status(Image.Status.AVAILABLE)


### PR DESCRIPTION
…is commit fixes the issue where optOSReferenceCode was being selected over operatingSystem.getId(), despite getId returning a good value.  This mis-selection meant that private Softlayer images could not be retrived via jclouds.  With this change the code will now only select optOSReferenceCode if operatingSystem.getId() is empty or null.