### PR TITLE
Swift container JSON requests and null checks

### DIFF
--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/blobstore/RegionScopedSwiftBlobStore.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/blobstore/RegionScopedSwiftBlobStore.java
@@ -430,7 +430,7 @@ public class RegionScopedSwiftBlobStore implements BlobStore {
    public long countBlobs(String containerName) {
       Container container = api.getContainerApi(regionId).get(containerName);
       // undefined if container doesn't exist, so default to zero
-      return container != null ? container.getObjectCount() : 0;
+      return container != null && container.getObjectCount() != null ? container.getObjectCount() : 0;
    }
 
    @Override

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/domain/Container.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/domain/Container.java
@@ -39,14 +39,14 @@ import com.google.common.collect.Multimap;
 public class Container implements Comparable<Container> {
 
    private final String name;
-   private final long objectCount;
-   private final long bytesUsed;
+   private final Long objectCount;
+   private final Long bytesUsed;
    private final Optional<Boolean> anybodyRead;
    private final Map<String, String> metadata;
    private final Multimap<String, String> headers;
 
    @ConstructorProperties({ "name", "count", "bytes", "anybodyRead", "metadata", "headers"})
-   protected Container(String name, long objectCount, long bytesUsed, Optional<Boolean> anybodyRead,
+   protected Container(String name, Long objectCount, Long bytesUsed, Optional<Boolean> anybodyRead,
          Map<String, String> metadata, Multimap<String, String> headers) {
       this.name = checkNotNull(name, "name");
       this.objectCount = objectCount;
@@ -66,14 +66,14 @@ public class Container implements Comparable<Container> {
    /**
     * @return The count of objects for this container.
     */
-   public long getObjectCount() {
+   public Long getObjectCount() {
       return objectCount;
    }
 
    /**
     * @return The number of bytes used by this container.
     */
-   public long getBytesUsed() {
+   public Long getBytesUsed() {
       return bytesUsed;
    }
 
@@ -160,8 +160,8 @@ public class Container implements Comparable<Container> {
 
    public static class Builder {
       protected String name;
-      protected long objectCount;
-      protected long bytesUsed;
+      protected Long objectCount;
+      protected Long bytesUsed;
       protected Optional<Boolean> anybodyRead = Optional.absent();
       protected Map<String, String> metadata = ImmutableMap.of();
       protected Multimap<String, String> headers = ImmutableMultimap.of();
@@ -177,7 +177,7 @@ public class Container implements Comparable<Container> {
       /**
        * @see Container#getObjectCount()
        */
-      public Builder objectCount(long objectCount) {
+      public Builder objectCount(Long objectCount) {
          this.objectCount = objectCount;
          return this;
       }
@@ -185,7 +185,7 @@ public class Container implements Comparable<Container> {
       /**
        * @see Container#getBytesUsed()
        */
-      public Builder bytesUsed(long bytesUsed) {
+      public Builder bytesUsed(Long bytesUsed) {
          this.bytesUsed = bytesUsed;
          return this;
       }

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/features/ContainerApi.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/features/ContainerApi.java
@@ -97,6 +97,7 @@ public interface ContainerApi {
    @Named("container:list")
    @GET
    @Fallback(EmptyFluentIterableOnNotFoundOr404.class)
+   @QueryParams(keys = "format", values = "json")
    FluentIterable<Container> list(ListContainerOptions options);
 
    /**

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/features/ObjectApi.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/features/ObjectApi.java
@@ -57,6 +57,7 @@ import org.jclouds.openstack.swift.v1.options.PutOptions;
 import org.jclouds.rest.annotations.BinderParam;
 import org.jclouds.rest.annotations.Fallback;
 import org.jclouds.rest.annotations.Headers;
+import org.jclouds.rest.annotations.QueryParams;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.ResponseParser;
 
@@ -83,6 +84,7 @@ public interface ObjectApi {
    @GET
    @ResponseParser(ParseObjectListFromResponse.class)
    @Fallback(NullOnNotFoundOr404.class)
+   @QueryParams(keys = "format", values = "json")
    @Nullable
    ObjectList list();
 
@@ -100,6 +102,7 @@ public interface ObjectApi {
    @GET
    @ResponseParser(ParseObjectListFromResponse.class)
    @Fallback(NullOnNotFoundOr404.class)
+   @QueryParams(keys = "format", values = "json")
    @Nullable
    ObjectList list(ListContainerOptions options);
 
@@ -169,6 +172,7 @@ public interface ObjectApi {
    @Path("/{objectName}")
    @ResponseParser(ParseObjectFromResponse.class)
    @Fallback(NullOnNotFoundOr404.class)
+   @QueryParams(keys = "format", values = "json")
    @Nullable
    SwiftObject get(@PathParam("objectName") String objectName);
 
@@ -187,6 +191,7 @@ public interface ObjectApi {
    @Path("/{objectName}")
    @ResponseParser(ParseObjectFromResponse.class)
    @Fallback(NullOnNotFoundOr404.class)
+   @QueryParams(keys = "format", values = "json")
    @Nullable
    SwiftObject get(@PathParam("objectName") String objectName, GetOptions options);
 

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/features/StaticLargeObjectApi.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/features/StaticLargeObjectApi.java
@@ -128,6 +128,6 @@ public interface StaticLargeObjectApi {
    @Named("staticLargeObject:getManifest")
    @GET
    @Fallback(EmptyListOnNotFoundOr404.class)
-   @QueryParams(keys = "multipart-manifest", values = "get")
+   @QueryParams(keys = {"format", "multipart-manifest"}, values = {"json", "get"})
    List<Segment> getManifest(@PathParam("objectName") String objectName);
 }

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/functions/ParseContainerFromHeaders.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/functions/ParseContainerFromHeaders.java
@@ -36,11 +36,13 @@ public class ParseContainerFromHeaders implements Function<HttpResponse, Contain
 
    @Override
    public Container apply(HttpResponse from) {
+      String bytesUsed = from.getFirstHeaderOrNull(CONTAINER_BYTES_USED);
+      String objectCount = from.getFirstHeaderOrNull(CONTAINER_OBJECT_COUNT);
       Container c = 
       Container.builder()
             .name(name)
-            .bytesUsed(Long.parseLong(from.getFirstHeaderOrNull(CONTAINER_BYTES_USED)))
-            .objectCount(Long.parseLong(from.getFirstHeaderOrNull(CONTAINER_OBJECT_COUNT)))
+            .bytesUsed(bytesUsed != null ? Long.valueOf(bytesUsed) : null)
+            .objectCount(objectCount != null ? Long.valueOf(objectCount) : null)
             .anybodyRead(CONTAINER_ACL_ANYBODY_READ.equals(from.getFirstHeaderOrNull(CONTAINER_READ)))
             .metadata(EntriesWithoutMetaPrefix.INSTANCE.apply(from.getHeaders())).build();
       return c;

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/functions/ParseObjectListFromResponse.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/functions/ParseObjectListFromResponse.java
@@ -36,6 +36,7 @@ import org.jclouds.rest.InvocationContext;
 import org.jclouds.rest.internal.GeneratedHttpRequest;
 
 import com.google.common.base.Function;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.hash.HashCode;
 import com.google.common.io.ByteSource;
@@ -91,12 +92,15 @@ public class ParseObjectListFromResponse implements Function<HttpResponse, Objec
                   .payload(payload(input.bytes, input.hash, "application/directory", input.expires))
                   .lastModified(new Date(0)).build();
          }
+         String name = Strings.nullToEmpty(input.name);
+         String etag = Strings.nullToEmpty(input.hash);
+         Date lastModified = input.last_modified == null ? new Date() : input.last_modified;
          return SwiftObject.builder()
                .uri(uriBuilder(containerUri).clearQuery().appendPath(input.name).build())
-               .name(input.name)
-               .etag(input.hash)
-               .payload(payload(input.bytes, input.hash, input.content_type, input.expires))
-               .lastModified(input.last_modified).build();
+               .name(name)
+               .etag(etag)
+               .payload(payload(input.bytes, etag, input.content_type, input.expires))
+               .lastModified(lastModified).build();
       }
    }
 

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/BulkApiLiveTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/BulkApiLiveTest.java
@@ -69,7 +69,7 @@ public class BulkApiLiveTest extends BaseSwiftApiLiveTest<SwiftApi> {
                                                      .extractArchive(containerName, payload, "tar.gz");
          assertEquals(extractResponse.getCreated(), OBJECT_COUNT);
          assertTrue(extractResponse.getErrors().isEmpty());
-         assertEquals(api.getContainerApi(regionId).get(containerName).getObjectCount(), OBJECT_COUNT);
+         assertEquals(api.getContainerApi(regionId).get(containerName).getObjectCount(), Long.valueOf(OBJECT_COUNT));
 
          // repeat the command
          extractResponse = api.getBulkApi(regionId).extractArchive(containerName, payload, "tar.gz");
@@ -85,7 +85,7 @@ public class BulkApiLiveTest extends BaseSwiftApiLiveTest<SwiftApi> {
          assertEquals(deleteResponse.getDeleted(), OBJECT_COUNT);
          assertEquals(deleteResponse.getNotFound(), 0);
          assertTrue(deleteResponse.getErrors().isEmpty());
-         assertEquals(api.getContainerApi(regionId).get(containerName).getObjectCount(), 0);
+         assertEquals(api.getContainerApi(regionId).get(containerName).getObjectCount(), Long.valueOf(0));
       }
    }
 

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/ContainerApiMockTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/ContainerApiMockTest.java
@@ -58,12 +58,12 @@ public class ContainerApiMockTest extends BaseOpenStackMockTest<SwiftApi> {
          assertEquals(containers, ImmutableList.of(
                Container.builder()
                      .name("test_container_1")
-                     .objectCount(2)
-                     .bytesUsed(78).build(),
+                     .objectCount(2L)
+                     .bytesUsed(78L).build(),
                Container.builder()
                      .name("test_container_2")
-                     .objectCount(1)
-                     .bytesUsed(17).build()));
+                     .objectCount(1L)
+                     .bytesUsed(17L).build()));
 
          assertEquals(server.getRequestCount(), 2);
          assertAuthentication(server);
@@ -87,16 +87,16 @@ public class ContainerApiMockTest extends BaseOpenStackMockTest<SwiftApi> {
          assertEquals(containers, ImmutableList.of(
                Container.builder()
                      .name("test_container_1")
-                     .objectCount(2)
-                     .bytesUsed(78).build(),
+                     .objectCount(2L)
+                     .bytesUsed(78L).build(),
                Container.builder()
                      .name("test_container_2")
-                     .objectCount(1)
-                     .bytesUsed(17).build()));
+                     .objectCount(1L)
+                     .bytesUsed(17L).build()));
 
          assertEquals(server.getRequestCount(), 2);
          assertAuthentication(server);
-         assertRequest(server.takeRequest(), "GET", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9?marker=test");
+         assertRequest(server.takeRequest(), "GET", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9?format=json&marker=test");
       } finally {
          server.shutdown();
       }
@@ -116,8 +116,8 @@ public class ContainerApiMockTest extends BaseOpenStackMockTest<SwiftApi> {
 
          Container container = api.getContainerApi("DFW").get("myContainer");
          assertEquals(container.getName(), "myContainer");
-         assertEquals(container.getObjectCount(), 42l);
-         assertEquals(container.getBytesUsed(), 323479l);
+         assertEquals(container.getObjectCount(), Long.valueOf(42l));
+         assertEquals(container.getBytesUsed(), Long.valueOf(323479l));
          for (Entry<String, String> entry : container.getMetadata().entrySet()) {
             assertEquals(container.getMetadata().get(entry.getKey().toLowerCase()), entry.getValue());
          }
@@ -236,8 +236,8 @@ public class ContainerApiMockTest extends BaseOpenStackMockTest<SwiftApi> {
          SwiftApi api = api(server.getUrl("/").toString(), "openstack-swift");
          Container container = api.getContainerApi("DFW").get("myContainer");
          assertEquals(container.getName(), "myContainer");
-         assertEquals(container.getObjectCount(), 42l);
-         assertEquals(container.getBytesUsed(), 323479l);
+         assertEquals(container.getObjectCount(), Long.valueOf(42l));
+         assertEquals(container.getBytesUsed(), Long.valueOf(323479l));
          for (Entry<String, String> entry : container.getMetadata().entrySet()) {
             assertEquals(container.getMetadata().get(entry.getKey().toLowerCase()), entry.getValue());
          }

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/ObjectApiMockTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/ObjectApiMockTest.java
@@ -119,7 +119,7 @@ public class ObjectApiMockTest extends BaseOpenStackMockTest<SwiftApi> {
 
          assertEquals(server.getRequestCount(), 2);
          assertAuthentication(server);
-         assertRequest(server.takeRequest(), "GET", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer");
+         assertRequest(server.takeRequest(), "GET", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer?format=json");
       } finally {
          server.shutdown();
       }
@@ -141,7 +141,7 @@ public class ObjectApiMockTest extends BaseOpenStackMockTest<SwiftApi> {
 
          assertEquals(server.getRequestCount(), 2);
          assertAuthentication(server);
-         assertRequest(server.takeRequest(), "GET", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer");
+         assertRequest(server.takeRequest(), "GET", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer?format=json");
       } finally {
          server.shutdown();
       }
@@ -159,7 +159,7 @@ public class ObjectApiMockTest extends BaseOpenStackMockTest<SwiftApi> {
 
          assertEquals(server.getRequestCount(), 2);
          assertAuthentication(server);
-         assertRequest(server.takeRequest(), "GET", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer?marker=test");
+         assertRequest(server.takeRequest(), "GET", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer?format=json&marker=test");
       } finally {
          server.shutdown();
       }
@@ -319,7 +319,7 @@ public class ObjectApiMockTest extends BaseOpenStackMockTest<SwiftApi> {
          assertEquals(server.takeRequest().getRequestLine(), "POST /tokens HTTP/1.1");
          RecordedRequest get = server.takeRequest();
          assertEquals(get.getRequestLine(),
-               "GET /v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer/myObject HTTP/1.1");
+               "GET /v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer/myObject?format=json HTTP/1.1");
       } finally {
          server.shutdown();
       }

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/StaticLargeObjectApiLiveTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/StaticLargeObjectApiLiveTest.java
@@ -87,7 +87,7 @@ public class StaticLargeObjectApiLiveTest extends BaseSwiftApiLiveTest<SwiftApi>
          assertEquals(bigObject.getMetadata(), ImmutableMap.of("myfoo", "Bar"));
 
          // segments are visible
-         assertEquals(api.getContainerApi(regionId).get(containerName).getObjectCount(), 3);
+         assertEquals(api.getContainerApi(regionId).get(containerName).getObjectCount(), Long.valueOf(3));
       }
    }
 
@@ -99,7 +99,7 @@ public class StaticLargeObjectApiLiveTest extends BaseSwiftApiLiveTest<SwiftApi>
          assertThat(resp.deleted()).isEqualTo(3);
          assertThat(resp.notFound()).isZero();
          assertThat(resp.errors()).isEmpty();
-         assertEquals(api.getContainerApi(regionId).get(containerName).getObjectCount(), 0);
+         assertEquals(api.getContainerApi(regionId).get(containerName).getObjectCount(), Long.valueOf(0));
       }
    }
 

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/StaticLargeObjectApiMockTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/StaticLargeObjectApiMockTest.java
@@ -139,7 +139,7 @@ public class StaticLargeObjectApiMockTest extends BaseOpenStackMockTest<SwiftApi
          assertAuthentication(server);
          RecordedRequest getRequest = server.takeRequest();
          assertRequest(getRequest, "GET",
-               "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer/myObject?multipart-manifest=get");
+               "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer/myObject?format=json&multipart-manifest=get");
       } finally {
          server.shutdown();
       }
@@ -161,7 +161,7 @@ public class StaticLargeObjectApiMockTest extends BaseOpenStackMockTest<SwiftApi
          assertAuthentication(server);
          RecordedRequest getRequest = server.takeRequest();
          assertRequest(getRequest, "GET",
-               "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer/myObject?multipart-manifest=get");
+               "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer/myObject?format=json&multipart-manifest=get");
       } finally {
          server.shutdown();
       }


### PR DESCRIPTION
1) Swift container and JSON format for requests
Regarding the following pull request by @zack-shoylev (thanks, good job) : 
https://github.com/jclouds/jclouds/pull/922
Related to this ticket : 
https://issues.apache.org/jira/browse/JCLOUDS-1080
I think that is also needed for all the @GET methods in ContainerApi.java, ObjectApi.java and StaticLargeObjectApi.java

2) Prevent NumberFormatException and NullPointerException when parsing Swift's response
We need to prevent NumberFormatException and NullPointerException as Swift will not give a value for bytesUsed, objectCount, date, etag and name.