### PR TITLE
JCLOUDS-1078: Implement ImageExtension in ProfitBricks

### DIFF
--- a/providers/profitbricks/src/main/java/org/jclouds/profitbricks/ProfitBricksProviderMetadata.java
+++ b/providers/profitbricks/src/main/java/org/jclouds/profitbricks/ProfitBricksProviderMetadata.java
@@ -17,7 +17,10 @@
 package org.jclouds.profitbricks;
 
 import static org.jclouds.Constants.PROPERTY_ISO3166_CODES;
+import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import static org.jclouds.Constants.PROPERTY_SO_TIMEOUT;
+import static org.jclouds.compute.config.ComputeServiceProperties.POLL_INITIAL_PERIOD;
+import static org.jclouds.compute.config.ComputeServiceProperties.POLL_MAX_PERIOD;
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_RUNNING;
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_SUSPENDED;
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_TERMINATED;
@@ -26,8 +29,6 @@ import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGION;
 import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
 import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONE;
 import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONES;
-import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.POLL_INITIAL_PERIOD;
-import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.POLL_MAX_PERIOD;
 import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.TIMEOUT_DATACENTER_AVAILABLE;
 
 import java.net.URI;
@@ -60,7 +61,7 @@ public class ProfitBricksProviderMetadata extends BaseProviderMetadata {
 
    public static Properties defaultProperties() {
       Properties properties = ProfitBricksApiMetadata.defaultProperties();
-      
+
       properties.setProperty(PROPERTY_REGIONS, "de,us");
       properties.setProperty(PROPERTY_REGION + ".de.zones", "de/fkb,de/fra");
       properties.setProperty(PROPERTY_REGION + ".us.zones", "us/las,us/lasdev");
@@ -72,21 +73,21 @@ public class ProfitBricksProviderMetadata extends BaseProviderMetadata {
       properties.setProperty(PROPERTY_ZONE + ".de/fra." + ISO3166_CODES, "DE-HE");
       properties.setProperty(PROPERTY_ZONE + ".us/las." + ISO3166_CODES, "US-NV");
       properties.setProperty(PROPERTY_ZONE + ".us/lasdebv." + ISO3166_CODES, "US-NV");
-      
-      properties.put(TIMEOUT_DATACENTER_AVAILABLE, 30L * 60L); // 30 minutes
-      properties.put(POLL_INITIAL_PERIOD, 5L);
-      properties.put(POLL_MAX_PERIOD, 60L);
 
       properties.put("jclouds.ssh.max-retries", "7");
       properties.put("jclouds.ssh.retry-auth", "true");
-      
+      properties.put(PROPERTY_SESSION_INTERVAL, 60 * 60);
       properties.put(PROPERTY_SO_TIMEOUT, 10 * 60 * 1000);
 
+      properties.put(TIMEOUT_DATACENTER_AVAILABLE, 30L * 60L); // 30 minutes
       // Node might still not be available even after DataCenter is done provisioning
       // Use 5-minute timeout by default
       properties.put(TIMEOUT_NODE_RUNNING, 5 * 60 * 1000);
       properties.put(TIMEOUT_NODE_SUSPENDED, 5 * 60 * 1000);
       properties.put(TIMEOUT_NODE_TERMINATED, 5 * 60 * 1000);
+
+      properties.put(POLL_INITIAL_PERIOD, 5L);
+      properties.put(POLL_MAX_PERIOD, 60L);
 
       return properties;
    }

--- a/providers/profitbricks/src/main/java/org/jclouds/profitbricks/compute/ProfitBricksComputeServiceAdapter.java
+++ b/providers/profitbricks/src/main/java/org/jclouds/profitbricks/compute/ProfitBricksComputeServiceAdapter.java
@@ -23,7 +23,7 @@ import static com.google.common.util.concurrent.Futures.allAsList;
 import static com.google.common.util.concurrent.Futures.getUnchecked;
 import static java.lang.String.format;
 import static org.jclouds.Constants.PROPERTY_USER_THREADS;
-import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.POLL_PREDICATE_DATACENTER;
+import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.TIMEOUT_DATACENTER_AVAILABLE;
 
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -90,7 +90,7 @@ public class ProfitBricksComputeServiceAdapter implements ComputeServiceAdapter<
 
    @Inject
    ProfitBricksComputeServiceAdapter(ProfitBricksApi api,
-           @Named(POLL_PREDICATE_DATACENTER) Predicate<String> waitDcUntilAvailable,
+           @Named(TIMEOUT_DATACENTER_AVAILABLE) Predicate<String> waitDcUntilAvailable,
            @Named(PROPERTY_USER_THREADS) ListeningExecutorService executorService,
            ProvisioningJob.Factory jobFactory,
            ProvisioningManager provisioningManager) {

--- a/providers/profitbricks/src/main/java/org/jclouds/profitbricks/compute/concurrent/ProvisioningJob.java
+++ b/providers/profitbricks/src/main/java/org/jclouds/profitbricks/compute/concurrent/ProvisioningJob.java
@@ -17,7 +17,7 @@
 package org.jclouds.profitbricks.compute.concurrent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.POLL_PREDICATE_DATACENTER;
+import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.TIMEOUT_DATACENTER_AVAILABLE;
 
 import java.util.concurrent.Callable;
 
@@ -40,7 +40,7 @@ public class ProvisioningJob implements Callable {
    private final Supplier<Object> operation;
 
    @Inject
-   ProvisioningJob(@Named(POLL_PREDICATE_DATACENTER) Predicate<String> waitDataCenterUntilReady,
+   ProvisioningJob(@Named(TIMEOUT_DATACENTER_AVAILABLE) Predicate<String> waitDataCenterUntilReady,
            @Assisted String group, @Assisted Supplier<Object> operation) {
       this.waitDataCenterUntilReady = waitDataCenterUntilReady;
       this.group = checkNotNull(group, "group cannot be null");

--- a/providers/profitbricks/src/main/java/org/jclouds/profitbricks/compute/config/ProfitBricksComputeServiceContextModule.java
+++ b/providers/profitbricks/src/main/java/org/jclouds/profitbricks/compute/config/ProfitBricksComputeServiceContextModule.java
@@ -16,10 +16,10 @@
  */
 package org.jclouds.profitbricks.compute.config;
 
+import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_IMAGE_AVAILABLE;
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_RUNNING;
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_SUSPENDED;
 import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.TIMEOUT_DATACENTER_AVAILABLE;
-import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.TIMEOUT_SNAPSHOT_AVAILABLE;
 import static org.jclouds.util.Predicates2.retry;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -135,7 +135,7 @@ public class ProfitBricksComputeServiceContextModule extends
 
    @Provides
    @Singleton
-   @Named(TIMEOUT_SNAPSHOT_AVAILABLE)
+   @Named(TIMEOUT_IMAGE_AVAILABLE)
    Predicate<String> provideSnapshotAvailablePredicate(final ProfitBricksApi api, Timeouts timeouts, PollPeriod constants) {
       return retry(new SnapshotProvisioningStatePredicate(
               api, ProvisioningState.AVAILABLE),

--- a/providers/profitbricks/src/main/java/org/jclouds/profitbricks/compute/extensions/ProfitBricksImageExtension.java
+++ b/providers/profitbricks/src/main/java/org/jclouds/profitbricks/compute/extensions/ProfitBricksImageExtension.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.profitbricks.compute.extensions;
+
+import static com.google.common.base.Preconditions.checkState;
+import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.TIMEOUT_SNAPSHOT_AVAILABLE;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Callable;
+
+import javax.annotation.Resource;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.jclouds.Constants;
+import org.jclouds.compute.domain.CloneImageTemplate;
+import org.jclouds.compute.domain.Image;
+import org.jclouds.compute.domain.ImageTemplate;
+import org.jclouds.compute.domain.ImageTemplateBuilder;
+import org.jclouds.compute.extensions.ImageExtension;
+import org.jclouds.compute.reference.ComputeServiceConstants;
+import org.jclouds.logging.Logger;
+import org.jclouds.profitbricks.ProfitBricksApi;
+import org.jclouds.profitbricks.domain.Provisionable;
+import org.jclouds.profitbricks.domain.Server;
+import org.jclouds.profitbricks.domain.Snapshot;
+import org.jclouds.profitbricks.domain.Storage;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.UncheckedTimeoutException;
+import com.google.inject.Inject;
+
+@Singleton
+public class ProfitBricksImageExtension implements ImageExtension {
+
+   @Resource
+   @Named(ComputeServiceConstants.COMPUTE_LOGGER)
+   protected Logger logger = Logger.NULL;
+
+   private final Predicate<Storage> matchBootDevice = new Predicate<Storage>() {
+      @Override
+      public boolean apply(Storage input) {
+         return input.bootDevice() == null ? false : input.bootDevice();
+      }
+   };
+
+   private final ProfitBricksApi api;
+   private final Predicate<String> snapshotAvailablePredicate;
+   private final Function<Provisionable, Image> imageTransformer;
+   private final ListeningExecutorService userExecutor;
+
+   @Inject
+   ProfitBricksImageExtension(ProfitBricksApi api,
+           @Named(TIMEOUT_SNAPSHOT_AVAILABLE) Predicate<String> snapshotAvailablePredicate,
+           Function<Provisionable, Image> imageTransformer,
+           @Named(Constants.PROPERTY_USER_THREADS) ListeningExecutorService userExecutor) {
+      this.api = api;
+      this.snapshotAvailablePredicate = snapshotAvailablePredicate;
+      this.imageTransformer = imageTransformer;
+      this.userExecutor = userExecutor;
+   }
+
+   @Override
+   public ImageTemplate buildImageTemplateFromNode(String name, String id) {
+      Server server = api.serverApi().getServer(id);
+
+      if (server == null)
+         throw new NoSuchElementException("Cannot find server with id: " + id);
+
+      List<Storage> storages = server.storages();
+      if (storages.isEmpty() || !Iterables.tryFind(storages, matchBootDevice).isPresent())
+         throw new NoSuchElementException("Server " + id + " does not contain a boot device");
+
+      return new ImageTemplateBuilder.CloneImageTemplateBuilder().nodeId(id).name(name).build();
+   }
+
+   @Override
+   public ListenableFuture<Image> createImage(ImageTemplate template) {
+      checkState(template instanceof CloneImageTemplate, "profitbricks only supports creating images through cloning.");
+      final CloneImageTemplate cloneTemplate = (CloneImageTemplate) template;
+      String serverId = cloneTemplate.getSourceNodeId();
+
+      Server server = api.serverApi().getServer(serverId);
+      Storage bootDevice = Iterables.find(server.storages(), matchBootDevice);
+
+      final Snapshot requested = api.snapshotApi().createSnapshot(
+              Snapshot.Request.creatingBuilder()
+              .storageId(bootDevice.id())
+              .name(template.getName())
+              .description(template.getName() + " (created with jclouds)")
+              .build());
+
+      return userExecutor.submit(new Callable<Image>() {
+         @Override
+         public Image call() throws Exception {
+            if (snapshotAvailablePredicate.apply(requested.id())) {
+               Snapshot built = api.snapshotApi().getSnapshot(requested.id());
+               return imageTransformer.apply(built);
+            }
+
+            throw new UncheckedTimeoutException("Image was not created within the time limit: "
+                    + cloneTemplate.getName());
+         }
+      });
+   }
+
+   @Override
+   public boolean deleteImage(String id) {
+      Snapshot snapshot = api.snapshotApi().getSnapshot(id);
+      if (snapshot != null)
+         try {
+            logger.debug(">> deleting snapshot %s..", id);
+            return api.snapshotApi().deleteSnapshot(id);
+         } catch (Exception ex) {
+            logger.error(ex, ">> error deleting snapshot %s..", id);
+         }
+      return true;
+   }
+
+}

--- a/providers/profitbricks/src/main/java/org/jclouds/profitbricks/compute/extensions/ProfitBricksImageExtension.java
+++ b/providers/profitbricks/src/main/java/org/jclouds/profitbricks/compute/extensions/ProfitBricksImageExtension.java
@@ -41,6 +41,7 @@ import org.jclouds.profitbricks.domain.Server;
 import org.jclouds.profitbricks.domain.Snapshot;
 import org.jclouds.profitbricks.domain.Storage;
 
+import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
@@ -49,6 +50,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.UncheckedTimeoutException;
 import com.google.inject.Inject;
 
+@Beta
 @Singleton
 public class ProfitBricksImageExtension implements ImageExtension {
 
@@ -109,7 +111,7 @@ public class ProfitBricksImageExtension implements ImageExtension {
               .description(template.getName() + " (created with jclouds)")
               .build());
 
-      logger.info(">> creating a snapshot from storage: " + bootDevice.id());
+      logger.info(">> creating a snapshot from storage: %s", bootDevice.id());
 
       return userExecutor.submit(new Callable<Image>() {
          @Override

--- a/providers/profitbricks/src/main/java/org/jclouds/profitbricks/compute/strategy/AssignDataCenterToTemplate.java
+++ b/providers/profitbricks/src/main/java/org/jclouds/profitbricks/compute/strategy/AssignDataCenterToTemplate.java
@@ -18,7 +18,7 @@ package org.jclouds.profitbricks.compute.strategy;
 
 import static com.google.common.collect.Iterables.find;
 import static org.jclouds.Constants.PROPERTY_USER_THREADS;
-import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.POLL_PREDICATE_DATACENTER;
+import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.TIMEOUT_DATACENTER_AVAILABLE;
 
 import java.util.Map;
 import java.util.Set;
@@ -70,7 +70,7 @@ public class AssignDataCenterToTemplate extends CreateNodesWithGroupEncodedIntoN
          GroupNamingConvention.Factory namingConvention,
          @Named(PROPERTY_USER_THREADS) ListeningExecutorService userExecutor,
          CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMap.Factory customizeNodeAndAddToGoodMapOrPutExceptionIntoBadMapFactory,
-         ProfitBricksApi api, @Named(POLL_PREDICATE_DATACENTER) Predicate<String> waitDcUntilAvailable) {
+         ProfitBricksApi api, @Named(TIMEOUT_DATACENTER_AVAILABLE) Predicate<String> waitDcUntilAvailable) {
       super(addNodeWithGroupStrategy, listNodesStrategy, namingConvention, userExecutor,
             customizeNodeAndAddToGoodMapOrPutExceptionIntoBadMapFactory);
       this.api = api;

--- a/providers/profitbricks/src/main/java/org/jclouds/profitbricks/config/ProfitBricksComputeProperties.java
+++ b/providers/profitbricks/src/main/java/org/jclouds/profitbricks/config/ProfitBricksComputeProperties.java
@@ -19,7 +19,6 @@ package org.jclouds.profitbricks.config;
 public class ProfitBricksComputeProperties {
 
    public static final String TIMEOUT_DATACENTER_AVAILABLE  = "jclouds.profitbricks.timeout.datacenter-available";
-   public static final String TIMEOUT_SNAPSHOT_AVAILABLE    = "jclouds.profitbricks.timeout.snapshot-available";
 
    private ProfitBricksComputeProperties() {
       throw new AssertionError("Intentionally unimplemented");

--- a/providers/profitbricks/src/test/java/org/jclouds/profitbricks/BaseProfitBricksLiveTest.java
+++ b/providers/profitbricks/src/test/java/org/jclouds/profitbricks/BaseProfitBricksLiveTest.java
@@ -16,10 +16,10 @@
  */
 package org.jclouds.profitbricks;
 
+import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_IMAGE_AVAILABLE;
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_RUNNING;
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_SUSPENDED;
 import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.TIMEOUT_DATACENTER_AVAILABLE;
-import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.TIMEOUT_SNAPSHOT_AVAILABLE;
 import static org.testng.Assert.assertTrue;
 
 import java.util.List;
@@ -65,7 +65,7 @@ public abstract class BaseProfitBricksLiveTest extends BaseApiLiveTest<ProfitBri
       dataCenterAvailable = injector.getInstance(Key.get(new TypeLiteral<Predicate<String>>() {
       }, Names.named(TIMEOUT_DATACENTER_AVAILABLE)));
       snapshotAvailable = injector.getInstance(Key.get(new TypeLiteral<Predicate<String>>() {
-      }, Names.named(TIMEOUT_SNAPSHOT_AVAILABLE)));
+      }, Names.named(TIMEOUT_IMAGE_AVAILABLE)));
       serverRunning = injector.getInstance(Key.get(new TypeLiteral<Predicate<String>>() {
       }, Names.named(TIMEOUT_NODE_RUNNING)));
       serverSuspended = injector.getInstance(Key.get(new TypeLiteral<Predicate<String>>() {

--- a/providers/profitbricks/src/test/java/org/jclouds/profitbricks/BaseProfitBricksLiveTest.java
+++ b/providers/profitbricks/src/test/java/org/jclouds/profitbricks/BaseProfitBricksLiveTest.java
@@ -18,8 +18,8 @@ package org.jclouds.profitbricks;
 
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_RUNNING;
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_SUSPENDED;
-import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.POLL_PREDICATE_DATACENTER;
-import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.POLL_PREDICATE_SNAPSHOT;
+import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.TIMEOUT_DATACENTER_AVAILABLE;
+import static org.jclouds.profitbricks.config.ProfitBricksComputeProperties.TIMEOUT_SNAPSHOT_AVAILABLE;
 import static org.testng.Assert.assertTrue;
 
 import java.util.List;
@@ -63,9 +63,9 @@ public abstract class BaseProfitBricksLiveTest extends BaseApiLiveTest<ProfitBri
    protected ProfitBricksApi create(Properties props, Iterable<Module> modules) {
       Injector injector = newBuilder().modules(modules).overrides(props).buildInjector();
       dataCenterAvailable = injector.getInstance(Key.get(new TypeLiteral<Predicate<String>>() {
-      }, Names.named(POLL_PREDICATE_DATACENTER)));
+      }, Names.named(TIMEOUT_DATACENTER_AVAILABLE)));
       snapshotAvailable = injector.getInstance(Key.get(new TypeLiteral<Predicate<String>>() {
-      }, Names.named(POLL_PREDICATE_SNAPSHOT)));
+      }, Names.named(TIMEOUT_SNAPSHOT_AVAILABLE)));
       serverRunning = injector.getInstance(Key.get(new TypeLiteral<Predicate<String>>() {
       }, Names.named(TIMEOUT_NODE_RUNNING)));
       serverSuspended = injector.getInstance(Key.get(new TypeLiteral<Predicate<String>>() {

--- a/providers/profitbricks/src/test/java/org/jclouds/profitbricks/compute/extensions/ProfitBricksImageExtensionLiveTest.java
+++ b/providers/profitbricks/src/test/java/org/jclouds/profitbricks/compute/extensions/ProfitBricksImageExtensionLiveTest.java
@@ -14,15 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jclouds.profitbricks.config;
+package org.jclouds.profitbricks.compute.extensions;
 
-public class ProfitBricksComputeProperties {
+import org.jclouds.compute.extensions.internal.BaseImageExtensionLiveTest;
+import org.jclouds.sshj.config.SshjSshClientModule;
+import org.testng.annotations.Test;
 
-   public static final String TIMEOUT_DATACENTER_AVAILABLE  = "jclouds.profitbricks.timeout.datacenter-available";
-   public static final String TIMEOUT_SNAPSHOT_AVAILABLE    = "jclouds.profitbricks.timeout.snapshot-available";
+import com.google.inject.Module;
 
-   private ProfitBricksComputeProperties() {
-      throw new AssertionError("Intentionally unimplemented");
+@Test(groups = "live", singleThreaded = true, testName = "ProfitBricksImageExtensionLiveTest")
+public class ProfitBricksImageExtensionLiveTest extends BaseImageExtensionLiveTest {
+
+   public ProfitBricksImageExtensionLiveTest() {
+      provider = "profitbricks";
+   }
+
+   @Override
+   protected Module getSshModule() {
+      return new SshjSshClientModule();
    }
 
 }


### PR DESCRIPTION
This PR mainly implements ImageExtension (Snapshots) in ProfitBricks. Some of the compute service property names were renamed as well, to reflect more closely the jclouds convention.

The live tests are failing though, with the exact stack traces from [JCLOUDS-1058](https://issues.apache.org/jira/browse/JCLOUDS-1058). Had tried ubuntu-15.10 on `de/fkb` and `de/fra` so far. I have yet to try for `us/las` and `us/lasdev` and see if I can get pass this error.

```
 mvn clean install -Plive -Dtest.profitbricks.identity=<identity> -Dtest.profitbricks.credential=<credential> -Dtest.profitbricks.template="imageId=<imageId>,loginUser=root:<password>" -Dtest=org.jclouds.profitbricks.compute.extensions.ProfitBricksImageExtensionLiveTest
```