### PR TITLE
JCLOUDS-1101: Correct generics wildcard errors

### DIFF
--- a/apis/elasticstack/src/main/java/org/jclouds/elasticstack/domain/Server.java
+++ b/apis/elasticstack/src/main/java/org/jclouds/elasticstack/domain/Server.java
@@ -128,7 +128,7 @@ public class Server extends Item {
    protected final int mem;
    protected final boolean persistent;
    @Nullable
-   protected final Map<String, Device> devices;
+   protected final Map<String, ? extends Device> devices;
    protected final Set<String> bootDeviceIds;
    protected final List<NIC> nics;
    protected final VNC vnc;
@@ -184,7 +184,7 @@ public class Server extends Item {
     * 
     * @return devices present, mapped by id
     */
-   public Map<String, Device> getDevices() {
+   public Map<String, ? extends Device> getDevices() {
       return devices;
    }
 

--- a/apis/elasticstack/src/main/java/org/jclouds/elasticstack/domain/ServerMetrics.java
+++ b/apis/elasticstack/src/main/java/org/jclouds/elasticstack/domain/ServerMetrics.java
@@ -29,7 +29,7 @@ public class ServerMetrics {
       protected long tx;
       protected long rxPackets;
       protected long rx;
-      protected Map<String, DriveMetrics> driveMetrics = ImmutableMap.<String, DriveMetrics> of();
+      protected Map<String, ? extends DriveMetrics> driveMetrics = ImmutableMap.<String, DriveMetrics> of();
 
       public Builder txPackets(long txPackets) {
          this.txPackets = txPackets;
@@ -65,9 +65,9 @@ public class ServerMetrics {
    protected final long tx;
    protected final long rxPackets;
    protected final long rx;
-   protected final Map<String, DriveMetrics> driveMetrics;
+   protected final Map<String, ? extends DriveMetrics> driveMetrics;
 
-   public ServerMetrics(long tx, long txPackets, long rx, long rxPackets, Map<String, DriveMetrics> driveMetrics) {
+   public ServerMetrics(long tx, long txPackets, long rx, long rxPackets, Map<String, ? extends DriveMetrics> driveMetrics) {
       this.txPackets = txPackets;
       this.tx = tx;
       this.rxPackets = rxPackets;
@@ -99,7 +99,7 @@ public class ServerMetrics {
     * 
     * @return metrics keyed on device id ex. {@code ide:0:0}
     */
-   public Map<String, DriveMetrics> getDriveMetrics() {
+   public Map<String, ? extends DriveMetrics> getDriveMetrics() {
       return driveMetrics;
    }
 

--- a/compute/src/main/java/org/jclouds/compute/domain/internal/HardwareImpl.java
+++ b/compute/src/main/java/org/jclouds/compute/domain/internal/HardwareImpl.java
@@ -41,9 +41,9 @@ import com.google.common.collect.ImmutableList;
 
 public class HardwareImpl extends ComputeMetadataImpl implements Hardware {
 
-   private final List<Processor> processors;
+   private final List<? extends Processor> processors;
    private final int ram;
-   private final List<Volume> volumes;
+   private final List<? extends Volume> volumes;
    private final Predicate<Image> supportsImage;
    private final String hypervisor;
    private final boolean deprecated;

--- a/compute/src/main/java/org/jclouds/compute/internal/BaseComputeService.java
+++ b/compute/src/main/java/org/jclouds/compute/internal/BaseComputeService.java
@@ -337,9 +337,9 @@ public class BaseComputeService implements ComputeService {
     * {@inheritDoc}
     */
    @Override
-   public Set<ComputeMetadata> listNodes() {
+   public Set<? extends ComputeMetadata> listNodes() {
       logger.trace(">> listing nodes");
-      Set<ComputeMetadata> set = newLinkedHashSet(listNodesStrategy.listNodes());
+      Set<? extends ComputeMetadata> set = newLinkedHashSet(listNodesStrategy.listNodes());
       logger.trace("<< list(%d)", set.size());
       return set;
    }
@@ -351,7 +351,7 @@ public class BaseComputeService implements ComputeService {
    public Set<? extends NodeMetadata> listNodesByIds(Iterable<String> ids) {
       checkNotNull(ids, "ids");
       logger.trace(">> listing node with ids(%s)", ids);
-      Set<NodeMetadata> set = ImmutableSet.copyOf(listNodesStrategy.listNodesByIds(ids));
+      Set<? extends NodeMetadata> set = ImmutableSet.copyOf(listNodesStrategy.listNodesByIds(ids));
       logger.trace("<< list(%d)", set.size());
       return set;
    }
@@ -363,7 +363,7 @@ public class BaseComputeService implements ComputeService {
    public Set<? extends NodeMetadata> listNodesDetailsMatching(Predicate<ComputeMetadata> filter) {
       checkNotNull(filter, "filter");
       logger.trace(">> listing node details matching(%s)", filter);
-      Set<NodeMetadata> set = newLinkedHashSet(listNodesStrategy.listDetailsOnNodesMatching(filter));
+      Set<? extends NodeMetadata> set = newLinkedHashSet(listNodesStrategy.listDetailsOnNodesMatching(filter));
       logger.trace("<< list(%d)", set.size());
       return set;
    }

--- a/compute/src/main/java/org/jclouds/ovf/internal/BaseEnvelope.java
+++ b/compute/src/main/java/org/jclouds/ovf/internal/BaseEnvelope.java
@@ -118,8 +118,8 @@ public class BaseEnvelope<V extends BaseVirtualSystem<V>, E extends BaseEnvelope
 
    }
 
-   private final Set<DiskSection> diskSections;
-   private final Set<NetworkSection> networkSections;
+   private final Set<? extends DiskSection> diskSections;
+   private final Set<? extends NetworkSection> networkSections;
    @SuppressWarnings("unchecked")
    private final Multimap<String, Section> additionalSections;
    private final V virtualSystem;
@@ -195,7 +195,7 @@ public class BaseEnvelope<V extends BaseVirtualSystem<V>, E extends BaseEnvelope
                diskSections, networkSections, additionalSections, virtualSystem);
    }
 
-   public Set<NetworkSection> getNetworkSections() {
+   public Set<? extends NetworkSection> getNetworkSections() {
       return networkSections;
    }
 }

--- a/compute/src/main/java/org/jclouds/ovf/internal/BaseVirtualSystem.java
+++ b/compute/src/main/java/org/jclouds/ovf/internal/BaseVirtualSystem.java
@@ -168,8 +168,8 @@ public class BaseVirtualSystem<T extends BaseVirtualSystem<T>> extends Section<T
    protected final String id;
    protected final String name;
    protected final OperatingSystemSection operatingSystem;
-   protected final Set<VirtualHardwareSection> virtualHardwareSections;
-   protected final Set<ProductSection> productSections;
+   protected final Set<? extends VirtualHardwareSection> virtualHardwareSections;
+   protected final Set<? extends ProductSection> productSections;
    @SuppressWarnings("unchecked")
    protected final Multimap<String, Section> additionalSections;
 

--- a/compute/src/test/java/org/jclouds/compute/internal/BaseComputeServiceLiveTest.java
+++ b/compute/src/test/java/org/jclouds/compute/internal/BaseComputeServiceLiveTest.java
@@ -124,7 +124,7 @@ public abstract class BaseComputeServiceLiveTest extends BaseComputeServiceConte
 
    protected Predicate<HostAndPort> socketTester;
    protected OpenSocketFinder openSocketFinder;
-   protected SortedSet<NodeMetadata> nodes;
+   protected SortedSet<? extends NodeMetadata> nodes;
    protected ComputeService client;
 
    protected Template template;
@@ -383,7 +383,7 @@ public abstract class BaseComputeServiceLiveTest extends BaseComputeServiceConte
       assertFalse(node1.getName().equals("first-node") && node2.getName().equals("first-node"),
               "one node should be named something other than 'first-node");
 
-      this.nodes.addAll(nodes);
+      this.nodes = newTreeSet(concat(this.nodes, nodes));
    }
 
    private Template refreshTemplate() {
@@ -444,7 +444,7 @@ public abstract class BaseComputeServiceLiveTest extends BaseComputeServiceConte
       else
          this.assertLocationSameOrChild(checkNotNull(node.getLocation(), "location of %s", node), template.getLocation());
       checkOsMatchesTemplate(node);
-      this.nodes.add(node);
+      this.nodes = newTreeSet(concat(this.nodes, nodes));
    }
 
    @Test(enabled = true, dependsOnMethods = "testCompareSizes")
@@ -619,7 +619,7 @@ public abstract class BaseComputeServiceLiveTest extends BaseComputeServiceConte
 
          }));
 
-      SortedSet<NodeMetadata> listedNodes = ImmutableSortedSet.copyOf(client.listNodesByIds(nodeIds));
+      SortedSet<? extends NodeMetadata> listedNodes = ImmutableSortedSet.copyOf(client.listNodesByIds(nodeIds));
       // newTreeSet is here because elementsEqual cares about ordering.
       assertTrue(Iterables.elementsEqual(nodes, listedNodes),
               "nodes and listNodesByIds should be identical: was " + listedNodes + " but should be " + nodes);
@@ -923,7 +923,7 @@ public abstract class BaseComputeServiceLiveTest extends BaseComputeServiceConte
             // Destroy all nodes in the group but also make sure to destroy other created nodes that might not be in it.
             // The "testCreateTwoNodesWithOneSpecifiedName" creates nodes with an explicit name that puts them outside the group,
             // so the list of nodes should also be taken into account when destroying the nodes.
-            client.destroyNodesMatching(Predicates.<NodeMetadata> or(inGroup(group), in(nodes)));
+            client.destroyNodesMatching(Predicates.<NodeMetadata> or(inGroup(group), (Predicate<NodeMetadata>) in(nodes)));
          }
       } catch (Exception e) {
 

--- a/core/src/main/java/org/jclouds/json/internal/NamingStrategies.java
+++ b/core/src/main/java/org/jclouds/json/internal/NamingStrategies.java
@@ -261,7 +261,7 @@ public class NamingStrategies {
                         public Class<? extends Annotation> apply(Annotation input) {
                            return input.annotationType();
                         }
-                     }).anyMatch(in(markers));
+                     }).anyMatch((Predicate<Class<? extends Annotation>>) in(markers));
             }
          };
       }

--- a/loadbalancer/src/main/java/org/jclouds/loadbalancer/internal/BaseLoadBalancerService.java
+++ b/loadbalancer/src/main/java/org/jclouds/loadbalancer/internal/BaseLoadBalancerService.java
@@ -154,7 +154,7 @@ public class BaseLoadBalancerService implements LoadBalancerService {
 
    public Set<? extends LoadBalancerMetadata> listLoadBalancers() {
       logger.debug(">> listing load balancers");
-      LinkedHashSet<LoadBalancerMetadata> set = newLinkedHashSet(listLoadBalancersStrategy.listLoadBalancers());
+      LinkedHashSet<? extends LoadBalancerMetadata> set = newLinkedHashSet(listLoadBalancersStrategy.listLoadBalancers());
       logger.debug("<< list(%d)", set.size());
       return set;
    }

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/suppliers/AWSEC2ImageSupplier.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/suppliers/AWSEC2ImageSupplier.java
@@ -126,7 +126,7 @@ public final class AWSEC2ImageSupplier implements Supplier<Set<? extends Image>>
       // Forwarding so that later changes to the underlying cache are visible.
       return new ForwardingSet<Image>() {
          protected Set<Image> delegate() {
-            return ImmutableSet.copyOf(cache.get().asMap().values());
+            return (Set<Image>) ImmutableSet.copyOf(cache.get().asMap().values());
          }
       };
    }


### PR DESCRIPTION
Always incorrect but previously broken on Java 9.  Reference:

https://bugs.openjdk.java.net/browse/JDK-8075793