### PR TITLE
Handle nested braces in UriTemplates.expand

### DIFF
--- a/core/src/main/java/org/jclouds/http/UriTemplates.java
+++ b/core/src/main/java/org/jclouds/http/UriTemplates.java
@@ -44,17 +44,26 @@ public class UriTemplates {
       for (char c : Lists.charactersOf(template)) {
          switch (c) {
          case '{':
+            if (inVar) {
+                builder.append('{');
+                builder.append(var);
+                var.setLength(0);
+            }
             inVar = true;
             break;
          case '}':
-            inVar = false;
             String key = var.toString();
             Object value = variables.get(var.toString());
-            if (value != null)
-               builder.append(value);
-            else
-               builder.append('{').append(key).append('}');
+            if (inVar) {
+               if (value != null)
+                  builder.append(value);
+               else
+                  builder.append('{').append(key).append('}');
+            } else {
+               builder.append('}');
+            }
             var.setLength(0);
+            inVar = false;
             break;
          default:
             if (inVar)

--- a/core/src/test/java/org/jclouds/http/UriTemplatesTest.java
+++ b/core/src/test/java/org/jclouds/http/UriTemplatesTest.java
@@ -51,4 +51,8 @@ public class UriTemplatesTest {
    public void testMissingParamProceeds() {
       assertEquals(expand("/{user-dir}", ImmutableMap.of("user_dir", "foo")), "/{user-dir}");
    }
+
+   public void testJson() {
+      assertEquals(expand("{\"key\":\"{variable}\"}", ImmutableMap.of("variable", "value")), "{\"key\":\"value\"}");
+   }
 }


### PR DESCRIPTION
This allows replacement of JSON-like payloads without using hacks like
percent-encoding braces.