### PR TITLE
[JCLOUDS-1147] upgrade snakeyaml version in byon and resolve deprecations

### DIFF
--- a/apis/byon/pom.xml
+++ b/apis/byon/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.11</version>
+      <version>1.17</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.service</groupId>

--- a/apis/byon/src/main/java/org/jclouds/byon/domain/YamlNode.java
+++ b/apis/byon/src/main/java/org/jclouds/byon/domain/YamlNode.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import org.jclouds.byon.Node;
 import org.jclouds.util.Closeables2;
 import org.yaml.snakeyaml.DumperOptions;
-import org.yaml.snakeyaml.Loader;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
@@ -109,12 +108,10 @@ public class YamlNode {
       public YamlNode apply(ByteSource byteSource) {
          if (byteSource == null)
             return null;
-         // note that snakeyaml also throws nosuchmethod error when you use the non-deprecated
-         // constructor
          InputStream in = null;
          try {
             in = byteSource.openStream();
-            return (YamlNode) new Yaml(new Loader(new Constructor(YamlNode.class))).load(in);
+            return (YamlNode) new Yaml(new Constructor(YamlNode.class)).load(in);
          } catch (IOException ioe) {
             throw Throwables.propagate(ioe);
          } finally {

--- a/apis/byon/src/main/java/org/jclouds/byon/functions/NodesFromYamlStream.java
+++ b/apis/byon/src/main/java/org/jclouds/byon/functions/NodesFromYamlStream.java
@@ -29,7 +29,6 @@ import javax.inject.Singleton;
 
 import org.jclouds.byon.Node;
 import org.jclouds.byon.domain.YamlNode;
-import org.yaml.snakeyaml.Loader;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -90,10 +89,7 @@ public class NodesFromYamlStream implements Function<ByteSource, LoadingCache<St
       TypeDescription configDesc = new TypeDescription(Config.class);
       configDesc.putListPropertyType("nodes", YamlNode.class);
       constructor.addTypeDescription(configDesc);
-      // note that snakeyaml also throws nosuchmethod error when you use the
-      // non-deprecated
-      // constructor
-      Yaml yaml = new Yaml(new Loader(constructor));
+      Yaml yaml = new Yaml(constructor);
       Config config;
       InputStream in = null;
       try {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/JCLOUDS-1147

This PR upgrades snakeyaml dependency in byon api and fixes `java.lang.NoClassDefFoundError: org/yaml/snakeyaml/Loader` error when there is a newer snakeyaml dependency on classpath (`>= 1.15`).