### PR TITLE
Do not try to connect to ssh if already connected

### DIFF
--- a/compute/src/main/java/org/jclouds/compute/callables/SudoAwareInitManager.java
+++ b/compute/src/main/java/org/jclouds/compute/callables/SudoAwareInitManager.java
@@ -71,7 +71,9 @@ public class SudoAwareInitManager {
    public ExecResponse refreshAndRunAction(String action) {
       checkState(ssh != null, "please call init() before invoking call");
       try {
-         ssh.connect();
+         if (!ssh.isConnected()) {
+            ssh.connect();
+         }
          return runAction(action);
       } finally {
          if (ssh != null)

--- a/compute/src/main/java/org/jclouds/ssh/SshClient.java
+++ b/compute/src/main/java/org/jclouds/ssh/SshClient.java
@@ -61,6 +61,8 @@ public interface SshClient {
 
    void disconnect();
 
+   boolean isConnected();
+
    void put(String path, String contents);
 
 }

--- a/drivers/jsch/src/main/java/org/jclouds/ssh/jsch/JschSshClient.java
+++ b/drivers/jsch/src/main/java/org/jclouds/ssh/jsch/JschSshClient.java
@@ -339,9 +339,15 @@ public class JschSshClient implements SshClient {
       return toString;
    }
 
+   @Override
    @PreDestroy
    public void disconnect() {
       sessionConnection.clear();
+   }
+
+   @Override
+   public boolean isConnected() {
+      return sessionConnection.getSession().isConnected();
    }
 
    protected ConnectionWithStreams<ChannelExec> execConnection(final String command) {

--- a/drivers/jsch/src/test/java/org/jclouds/ssh/jsch/JschSshClientLiveTest.java
+++ b/drivers/jsch/src/test/java/org/jclouds/ssh/jsch/JschSshClientLiveTest.java
@@ -86,6 +86,10 @@ public class JschSshClientLiveTest {
             public void disconnect() {
             }
 
+            public boolean isConnected() {
+               return false;
+            }
+
             public Payload get(String path) {
                if (path.equals("/etc/passwd")) {
                   return Payloads.newStringPayload("root");

--- a/drivers/sshj/src/main/java/org/jclouds/sshj/SshjSshClient.java
+++ b/drivers/sshj/src/main/java/org/jclouds/sshj/SshjSshClient.java
@@ -410,6 +410,15 @@ public class SshjSshClient implements SshClient {
       }
    }
 
+   @Override
+   public boolean isConnected() {
+      try {
+         return sshClientConnection.getSSHClient().isConnected();
+      } catch (Exception e) {
+         throw Throwables.propagate(e);
+      }
+   }
+
    protected Connection<Session> execConnection() {
 
       return new Connection<Session>() {

--- a/drivers/sshj/src/test/java/org/jclouds/sshj/SshjSshClientLiveTest.java
+++ b/drivers/sshj/src/test/java/org/jclouds/sshj/SshjSshClientLiveTest.java
@@ -75,6 +75,10 @@ public class SshjSshClientLiveTest {
             public void disconnect() {
             }
 
+            public boolean isConnected() {
+               return false;
+            }
+
             public Payload get(String path) {
                if (path.equals("/etc/passwd")) {
                   return Payloads.newStringPayload("root");


### PR DESCRIPTION
The `refreshAndRunAction` is called by the `future.cancel()` method when cancelling the future associated to a running script (typically obtained by calling the `compute.submitScriptOnNode` method.

I've observed that when the ssh connection is already established, this method fails to connect again and throws an exception. This was also causing random failures in the `BaseComputeServiceLiveTest.testWeCanCancelTasks`.

@devcsrj This will potentially fix [JCLOUDS-1058](https://issues.apache.org/jira/browse/JCLOUDS-1058). Could you build this branch and try running the tests?