### PR TITLE
Allow overriding getUserDefinedFileAttributeView

### DIFF
--- a/apis/filesystem/src/main/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImpl.java
+++ b/apis/filesystem/src/main/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImpl.java
@@ -704,7 +704,7 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
       return null;
    }
 
-   private UserDefinedFileAttributeView getUserDefinedFileAttributeView(Path path) throws IOException {
+   protected UserDefinedFileAttributeView getUserDefinedFileAttributeView(Path path) throws IOException {
       return getFileAttributeView(path, UserDefinedFileAttributeView.class);
    }
 


### PR DESCRIPTION
Today the filesystem blobstore provider use the extended attributes of the
filesystem to store metadata. This is not always desirable as some filesystems
(such as NFSv3) do not support extended metadata.  The current source code does
not allow to change this easily. getUserDefinedFileAttributeView could easily
be overriden for this purpose and allow extensions that customize where the
metadata should be stored.

See also JCLOUDS-658