### PR TITLE
Add keystone authentication with an existing token

### DIFF
--- a/apis/openstack-keystone/pom.xml
+++ b/apis/openstack-keystone/pom.xml
@@ -84,6 +84,11 @@
       <artifactId>auto-service</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/AuthenticationApi.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/AuthenticationApi.java
@@ -28,6 +28,7 @@ import org.jclouds.openstack.keystone.v2_0.binders.BindAuthToJsonPayload;
 import org.jclouds.openstack.keystone.v2_0.domain.Access;
 import org.jclouds.openstack.keystone.v2_0.domain.ApiAccessKeyCredentials;
 import org.jclouds.openstack.keystone.v2_0.domain.PasswordCredentials;
+import org.jclouds.openstack.keystone.v2_0.domain.TokenCredentials;
 import org.jclouds.rest.annotations.MapBinder;
 import org.jclouds.rest.annotations.PayloadParam;
 import org.jclouds.rest.annotations.SelectJson;
@@ -88,4 +89,29 @@ public interface AuthenticationApi extends Closeable {
    @MapBinder(BindAuthToJsonPayload.class)
    Access authenticateWithTenantIdAndCredentials(@Nullable @PayloadParam("tenantId") String tenantId,
          ApiAccessKeyCredentials apiAccessKeyCredentials);
+
+   /**
+    * Authenticate to generate a token.
+    *
+    * @return access with token
+    */
+   @Named("authenticate")
+   @POST
+   @SelectJson("access")
+   @MapBinder(BindAuthToJsonPayload.class)
+   Access authenticateWithTenantNameAndCredentials(@Nullable @PayloadParam("tenantName") String tenantName,
+         TokenCredentials tokenCredentials);
+
+   /**
+    * Authenticate to generate a token.
+    *
+    * @return access with token
+    */
+   @Named("authenticate")
+   @POST
+   @SelectJson("access")
+   @MapBinder(BindAuthToJsonPayload.class)
+   Access authenticateWithTenantIdAndCredentials(@Nullable @PayloadParam("tenantId") String tenantId,
+         TokenCredentials tokenCredentials);
+
 }

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/CredentialType.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/CredentialType.java
@@ -17,6 +17,7 @@
 package org.jclouds.openstack.keystone.v2_0.config;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -29,6 +30,7 @@ import javax.inject.Qualifier;
 @Retention(value = RetentionPolicy.RUNTIME)
 @Target(value = { ElementType.TYPE, ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD })
 @Qualifier
+@Inherited
 public @interface CredentialType {
    /**
     * @see CredentialTypes

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/CredentialType.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/CredentialType.java
@@ -37,4 +37,9 @@ public @interface CredentialType {
     * 
     */
    String value();
+
+   /**
+    * True if the credentials can be used multiple times, so that a request can be retried.
+    */
+   boolean retryable() default true;
 }

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/CredentialTypes.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/CredentialTypes.java
@@ -32,6 +32,8 @@ public class CredentialTypes {
 
    public static final String PASSWORD_CREDENTIALS = "passwordCredentials";
 
+   public static final String TOKEN_CREDENTIALS = "token";
+
    public static <T> String credentialTypeOf(T input) {
       Class<?> authenticationType = input.getClass();
       checkArgument(authenticationType.isAnnotationPresent(CredentialType.class),

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/CredentialTypes.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/CredentialTypes.java
@@ -34,11 +34,15 @@ public class CredentialTypes {
 
    public static final String TOKEN_CREDENTIALS = "token";
 
-   public static <T> String credentialTypeOf(T input) {
+   public static <T> CredentialType credentialTypeObjectOf(T input) {
       Class<?> authenticationType = input.getClass();
       checkArgument(authenticationType.isAnnotationPresent(CredentialType.class),
                "programming error: %s should have annotation %s", authenticationType, CredentialType.class.getName());
-      return authenticationType.getAnnotation(CredentialType.class).value();
+      return authenticationType.getAnnotation(CredentialType.class);
+   }
+
+   public static <T> String credentialTypeOf(T input) {
+      return credentialTypeObjectOf(input).value();
    }
 
    public static <T> Map<String, T> indexByCredentialType(Iterable<T> iterable) {

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneAuthenticationModule.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneAuthenticationModule.java
@@ -48,6 +48,7 @@ import org.jclouds.openstack.keystone.v2_0.domain.Access;
 import org.jclouds.openstack.keystone.v2_0.domain.Endpoint;
 import org.jclouds.openstack.keystone.v2_0.functions.AuthenticateApiAccessKeyCredentials;
 import org.jclouds.openstack.keystone.v2_0.functions.AuthenticatePasswordCredentials;
+import org.jclouds.openstack.keystone.v2_0.functions.AuthenticateTokenCredentials;
 import org.jclouds.openstack.keystone.v2_0.handlers.RetryOnRenew;
 import org.jclouds.openstack.keystone.v2_0.suppliers.LocationIdToURIFromAccessForTypeAndVersion;
 import org.jclouds.openstack.keystone.v2_0.suppliers.RegionIdToAdminURIFromAccessForTypeAndVersion;
@@ -219,6 +220,7 @@ public class KeystoneAuthenticationModule extends AbstractModule {
       Builder<Function<Credentials, Access>> fns = ImmutableSet.<Function<Credentials, Access>> builder();
       fns.add(i.getInstance(AuthenticatePasswordCredentials.class));
       fns.add(i.getInstance(AuthenticateApiAccessKeyCredentials.class));
+      fns.add(i.getInstance(AuthenticateTokenCredentials.class));
       return CredentialTypes.indexByCredentialType(fns.build());
    }
 

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneAuthenticationModule.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneAuthenticationModule.java
@@ -234,6 +234,12 @@ public class KeystoneAuthenticationModule extends AbstractModule {
       return authenticationMethods.get(credentialType);
    }
 
+   @Provides
+   @Singleton
+   protected final CredentialType credentialsRetryable(Function<Credentials, Access> getAccess) {
+      return CredentialTypes.credentialTypeObjectOf(getAccess);
+   }
+
    // TODO: what is the timeout of the session token? modify default accordingly
    // PROPERTY_SESSION_INTERVAL is default to 60 seconds, but we have this here at 11 hours for now.
    @Provides

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneProperties.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneProperties.java
@@ -28,6 +28,7 @@ public final class KeystoneProperties {
     * <ul>
     * <li>apiAccessKeyCredentials</li>
     * <li>passwordCredentials</li>
+    * <li>token</li>
     * </ul>
     *
     * @see CredentialTypes

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/domain/TokenCredentials.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/domain/TokenCredentials.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.keystone.v2_0.domain;
+
+import com.google.auto.value.AutoValue;
+import org.jclouds.openstack.keystone.v2_0.config.CredentialType;
+import org.jclouds.openstack.keystone.v2_0.config.CredentialTypes;
+
+/**
+ * Password Credentials
+ *
+ * @see <a href="http://developer.openstack.org/api-ref/identity/v2/?expanded=authenticate-detail#authenticate"/>
+ */
+@AutoValue
+@CredentialType(CredentialTypes.TOKEN_CREDENTIALS)
+public abstract class TokenCredentials {
+   TokenCredentials() {
+   }
+
+   public static Builder builder() {
+      return new AutoValue_TokenCredentials.Builder();
+   }
+
+   @AutoValue.Builder
+   public abstract static class Builder {
+      /**
+       * @see TokenCredentials#getId()
+       */
+      public abstract Builder id(String id);
+
+      public abstract TokenCredentials build();
+   }
+
+   /**
+    * @return the token id
+    */
+   public abstract String getId();
+
+}

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/functions/AuthenticateTokenCredentials.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/functions/AuthenticateTokenCredentials.java
@@ -27,7 +27,7 @@ import org.jclouds.openstack.keystone.v2_0.functions.internal.BaseAuthenticator;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-@CredentialType(CredentialTypes.TOKEN_CREDENTIALS)
+@CredentialType(value = CredentialTypes.TOKEN_CREDENTIALS, retryable = false)
 @Singleton
 public class AuthenticateTokenCredentials extends BaseAuthenticator<TokenCredentials> {
    protected final AuthenticationApi api;

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/functions/AuthenticateTokenCredentials.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/functions/AuthenticateTokenCredentials.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.keystone.v2_0.functions;
+
+import com.google.common.base.Optional;
+import org.jclouds.openstack.keystone.v2_0.AuthenticationApi;
+import org.jclouds.openstack.keystone.v2_0.config.CredentialType;
+import org.jclouds.openstack.keystone.v2_0.config.CredentialTypes;
+import org.jclouds.openstack.keystone.v2_0.domain.Access;
+import org.jclouds.openstack.keystone.v2_0.domain.TokenCredentials;
+import org.jclouds.openstack.keystone.v2_0.functions.internal.BaseAuthenticator;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@CredentialType(CredentialTypes.TOKEN_CREDENTIALS)
+@Singleton
+public class AuthenticateTokenCredentials extends BaseAuthenticator<TokenCredentials> {
+   protected final AuthenticationApi api;
+
+   @Inject
+   public AuthenticateTokenCredentials(AuthenticationApi api) {
+      this.api = api;
+   }
+
+   @Override
+   protected Access authenticateWithTenantName(Optional<String> tenantName, TokenCredentials tokenCredentials) {
+      return api.authenticateWithTenantNameAndCredentials(tenantName.orNull(), tokenCredentials);
+   }
+
+   @Override
+   protected Access authenticateWithTenantId(Optional<String> tenantId, TokenCredentials tokenCredentials) {
+      return api.authenticateWithTenantIdAndCredentials(tenantId.orNull(), tokenCredentials);
+   }
+
+   @Override
+   public TokenCredentials createCredentials(String identity, String credential) {
+      return TokenCredentials.builder().id(credential).build();
+   }
+
+   @Override
+   public String toString() {
+      return "authenticateTokenCredentials()";
+   }
+}

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/functions/internal/BaseAuthenticator.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/functions/internal/BaseAuthenticator.java
@@ -68,9 +68,9 @@ public abstract class BaseAuthenticator<C> implements Function<Credentials, Acce
          usernameOrAccessKey = input.identity.substring(input.identity.lastIndexOf(':') + 1);
       }
 
-      String passwordOrSecretKey = input.credential;
+      String passwordSecretKeyOrToken = input.credential;
 
-      C creds = createCredentials(usernameOrAccessKey, passwordOrSecretKey);
+      C creds = createCredentials(usernameOrAccessKey, passwordSecretKeyOrToken);
 
       Access access;
       if (tenantId.isPresent()) {
@@ -90,8 +90,8 @@ public abstract class BaseAuthenticator<C> implements Function<Credentials, Acce
 
    public abstract C createCredentials(String identity, String credential);
 
-   protected abstract Access authenticateWithTenantId(Optional<String> tenantId, C apiAccessKeyCredentials);
+   protected abstract Access authenticateWithTenantId(Optional<String> tenantId, C creds);
 
-   protected abstract Access authenticateWithTenantName(Optional<String> tenantId, C apiAccessKeyCredentials);
+   protected abstract Access authenticateWithTenantName(Optional<String> tenantId, C creds);
 
 }

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/handlers/RetryOnRenew.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/handlers/RetryOnRenew.java
@@ -30,6 +30,7 @@ import org.jclouds.http.HttpResponse;
 import org.jclouds.http.HttpRetryHandler;
 import org.jclouds.http.handlers.BackoffLimitedRetryHandler;
 import org.jclouds.logging.Logger;
+import org.jclouds.openstack.keystone.v2_0.config.CredentialType;
 import org.jclouds.openstack.keystone.v2_0.domain.Access;
 import org.jclouds.openstack.v2_0.reference.AuthHeaders;
 
@@ -59,11 +60,15 @@ public class RetryOnRenew implements HttpRetryHandler {
 
    private final BackoffLimitedRetryHandler backoffHandler;
 
+   private final CredentialType credentialType;
+
    @Inject
    protected RetryOnRenew(LoadingCache<Credentials, Access> authenticationResponseCache,
-         BackoffLimitedRetryHandler backoffHandler) {
+         BackoffLimitedRetryHandler backoffHandler,
+         CredentialType credentialType) {
       this.authenticationResponseCache = authenticationResponseCache;
       this.backoffHandler = backoffHandler;
+      this.credentialType = credentialType;
    }
 
    /*
@@ -86,6 +91,8 @@ public class RetryOnRenew implements HttpRetryHandler {
                Multimap<String, String> headers = command.getCurrentRequest().getHeaders();
                if (headers != null && headers.containsKey(AuthHeaders.AUTH_USER)
                      && headers.containsKey(AuthHeaders.AUTH_KEY) && !headers.containsKey(AuthHeaders.AUTH_TOKEN)) {
+                  retry = false;
+               } else if (!credentialType.retryable()) {
                   retry = false;
                } else {
                   closeClientButKeepContentStream(response);

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/config/CredentialTypesTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/config/CredentialTypesTest.java
@@ -17,8 +17,13 @@
 package org.jclouds.openstack.keystone.v2_0.config;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import org.jclouds.openstack.keystone.v2_0.domain.PasswordCredentials;
+import org.jclouds.openstack.keystone.v2_0.domain.TokenCredentials;
+import org.jclouds.openstack.keystone.v2_0.functions.AuthenticatePasswordCredentials;
+import org.jclouds.openstack.keystone.v2_0.functions.AuthenticateTokenCredentials;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
@@ -45,5 +50,21 @@ public class CredentialTypesTest {
    @Test(expectedExceptions = IllegalArgumentException.class)
    public void testIndexByCredentialTypeWithoutAnnotation() {
       CredentialTypes.indexByCredentialType(ImmutableSet.of(""));
+   }
+
+   public void testTokenCredentials() {
+      assertEquals(CredentialTypes.credentialTypeOf(
+               TokenCredentials.builder().id("d419ee71f234012a9b4525727995964").build()),
+               CredentialTypes.TOKEN_CREDENTIALS);
+   }
+
+   public void testNonRetryableCredentialType() {
+      final AuthenticateTokenCredentials authentication = new AuthenticateTokenCredentials(null);
+      assertFalse(CredentialTypes.credentialTypeObjectOf(authentication).retryable());
+   }
+
+   public void testDefaultRetryableCredentialType() {
+      final AuthenticatePasswordCredentials authentication = new AuthenticatePasswordCredentials(null);
+      assertTrue(CredentialTypes.credentialTypeObjectOf(authentication).retryable());
    }
 }

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/config/SwiftAuthenticationModule.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/config/SwiftAuthenticationModule.java
@@ -38,6 +38,7 @@ import org.jclouds.domain.Credentials;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.openstack.keystone.v2_0.AuthenticationApi;
+import org.jclouds.openstack.keystone.v2_0.config.CredentialType;
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule;
 import org.jclouds.openstack.keystone.v2_0.domain.Access;
 import org.jclouds.openstack.keystone.v2_0.domain.Endpoint;
@@ -79,6 +80,7 @@ public final class SwiftAuthenticationModule extends KeystoneAuthenticationModul
                          .put("tempAuthCredentials", i.getInstance(TempAuth.class)).build();
    }
 
+   @CredentialType("temp")
    static final class TempAuth implements Function<Credentials, Access> {
       private final TempAuthApi delegate;
 


### PR DESCRIPTION
This pull request adds the possibility to use JClouds for OpenStack with a pre-existing Keystone token.
Cf. http://developer.openstack.org/api-ref/identity/v2/?expanded=authenticate-detail

To authenticate with a tenant name and a token, you can do:

```
Properties config = new Properties();
config.setProperty(KeystoneProperties.CREDENTIAL_TYPE, CredentialTypes.TOKEN_CREDENTIALS);
ContextBuilder.newBuilder("openstack-neutron")
                .overrides(config)
                .credentials("tenantname:", "hereisthetoken")
...
```

To authenticate with a tenant ID and a token, you can do:

```
Properties config = new Properties();
config.setProperty(KeystoneProperties.CREDENTIAL_TYPE, CredentialTypes.TOKEN_CREDENTIALS);
config.setProperty(KeystoneProperties.TENANT_ID, "tenantid");
ContextBuilder.newBuilder("openstack-neutron")
                .overrides(config)
                .credentials("", "hereisthetoken")
...
```

NB1: auto-value is added to the project `openstack-keystone` because this is JCloud's good practice (https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=49578594#API/ProviderWritingPractices-(Start)UsingAuto-Valueforallvaluetypes)

NB2: `@CredentialType` is made `@Inherited` because the AutoValue concrete class must have the annotation.
