### PR TITLE
JCLOUDS-1185 Allow rangeIPv4 to be null

### DIFF
--- a/providers/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Network.java
+++ b/providers/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Network.java
@@ -44,7 +44,7 @@ public abstract class Network {
     * The range of internal addresses that are legal on this network. This range is a CIDR
     * specification, for example: {@code 192.168.0.0/16}.
     */
-   public abstract String rangeIPv4();
+   @Nullable public abstract String rangeIPv4();
 
    /**
     * This must be within the range specified by IPv4Range, and is typically the first usable address in that range.


### PR DESCRIPTION
The default network of recently created projects have a null value for rangeIPv4
And all regions as subnets, which do have values for the rangeIPv4.

Fixes JCLOUDS-1158