### PR TITLE
Fix base compute service live tests

### DIFF
--- a/apis/ec2/src/test/java/org/jclouds/ec2/compute/extensions/EC2ImageExtensionLiveTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/compute/extensions/EC2ImageExtensionLiveTest.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 import org.jclouds.collect.Memoized;
 import org.jclouds.compute.domain.Image;
-import org.jclouds.compute.domain.Template;
+import org.jclouds.compute.domain.TemplateBuilder;
 import org.jclouds.compute.domain.TemplateBuilderSpec;
 import org.jclouds.compute.extensions.ImageExtension;
 import org.jclouds.compute.extensions.internal.BaseImageExtensionLiveTest;
@@ -95,8 +95,8 @@ public class EC2ImageExtensionLiveTest extends BaseImageExtensionLiveTest {
    }
 
    @Override
-   public Template getNodeTemplate() {
-      return view.getComputeService().templateBuilder().from(ebsTemplate).build();
+   public TemplateBuilder getNodeTemplate() {
+      return getNodeTemplate().from(ebsTemplate);
    }
 
    @Override

--- a/compute/src/test/java/org/jclouds/compute/extensions/internal/BaseImageExtensionLiveTest.java
+++ b/compute/src/test/java/org/jclouds/compute/extensions/internal/BaseImageExtensionLiveTest.java
@@ -35,6 +35,7 @@ import org.jclouds.compute.domain.Image;
 import org.jclouds.compute.domain.ImageTemplate;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.Template;
+import org.jclouds.compute.domain.TemplateBuilder;
 import org.jclouds.compute.extensions.ImageExtension;
 import org.jclouds.compute.internal.BaseComputeServiceContextLiveTest;
 import org.jclouds.compute.reference.ComputeServiceConstants;
@@ -66,8 +67,8 @@ public abstract class BaseImageExtensionLiveTest extends BaseComputeServiceConte
     * 
     * @return
     */
-   public Template getNodeTemplate() {
-      return view.getComputeService().templateBuilder().build();
+   public TemplateBuilder getNodeTemplate() {
+      return view.getComputeService().templateBuilder();
    }
 
    /**
@@ -96,7 +97,7 @@ public abstract class BaseImageExtensionLiveTest extends BaseComputeServiceConte
       Optional<ImageExtension> imageExtension = computeService.getImageExtension();
       assertTrue(imageExtension.isPresent(), "image extension was not present");
 
-      Template template = getNodeTemplate();
+      Template template = getNodeTemplate().build();
       NodeMetadata node = Iterables.getOnlyElement(computeService.createNodesInGroup(imageGroup, 1, template));
       checkReachable(node);
 
@@ -128,10 +129,9 @@ public abstract class BaseImageExtensionLiveTest extends BaseComputeServiceConte
       Optional<? extends Image> optImage = getImage();
       assertTrue(optImage.isPresent());
 
-      NodeMetadata node = Iterables.getOnlyElement(computeService.createNodesInGroup(imageGroup, 1, view
-               .getComputeService()
+      NodeMetadata node = Iterables.getOnlyElement(computeService.createNodesInGroup(imageGroup, 1, getNodeTemplate()
                // fromImage does not use the arg image's id (but we do need to set location)
-               .templateBuilder().imageId(optImage.get().getId()).fromImage(optImage.get()).build()));
+               .imageId(optImage.get().getId()).fromImage(optImage.get()).build()));
 
       checkReachable(node);
       view.getComputeService().destroyNode(node.getId());

--- a/providers/digitalocean2/src/main/java/org/jclouds/digitalocean2/domain/Action.java
+++ b/providers/digitalocean2/src/main/java/org/jclouds/digitalocean2/domain/Action.java
@@ -54,14 +54,14 @@ public abstract class Action {
    public abstract String type();
    public abstract Date startedAt();
    @Nullable public abstract Date completedAt();
-   public abstract Integer resourceId();
+   public abstract long resourceId();
    public abstract String resourceType();
    @Nullable public abstract Region region();
    @Nullable public abstract String regionSlug();
 
    @SerializedNames({ "id", "status", "type", "started_at", "completed_at", "resource_id", "resource_type",
       "region", "region_slug" })
-   public static Action create(int id, Status status, String type, Date startedAt, Date completedAt, int resourceId,
+   public static Action create(int id, Status status, String type, Date startedAt, Date completedAt, long resourceId,
          String resourceType, Region region, String regionSlug) {
       return new AutoValue_Action(id, status, type, startedAt, completedAt, resourceId, resourceType, region,
             regionSlug);


### PR DESCRIPTION
* Improves the test order in the `BaseComputeServiceLiveTest` to avoid skipping so many tests when the first ones fail due to SSH connection failures.
* Improves the `BaseImageExtensionLiveTest` to let subclasses properly configure custom templates.
* Fixes the DigitalOcean2 live tests.

/cc @andreaturli 