### PR TITLE
Make jclouds compatible with newer OSGi framework versions

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -89,13 +89,11 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
-      <version>4.2.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.compendium</artifactId>
-      <version>4.2.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/core/src/test/java/org/jclouds/osgi/BundlesTest.java
+++ b/core/src/test/java/org/jclouds/osgi/BundlesTest.java
@@ -34,14 +34,15 @@ import com.google.common.collect.ImmutableSet;
 
 public class BundlesTest {
 
+   @SuppressWarnings("rawtypes")
    @Test
    public void testInstantiateAvailableClassesWhenAllAssignable() throws ClassNotFoundException {
       Bundle bundle = createMock(Bundle.class);
-      expect(bundle.loadClass("org.jclouds.providers.JcloudsTestBlobStoreProviderMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.providers.JcloudsTestBlobStoreProviderMetadata")).andReturn(
             JcloudsTestBlobStoreProviderMetadata.class);
-      expect(bundle.loadClass("org.jclouds.providers.JcloudsTestComputeProviderMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.providers.JcloudsTestComputeProviderMetadata")).andReturn(
             JcloudsTestComputeProviderMetadata.class);
-      expect(bundle.loadClass("org.jclouds.providers.JcloudsTestYetAnotherComputeProviderMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.providers.JcloudsTestYetAnotherComputeProviderMetadata")).andReturn(
             JcloudsTestYetAnotherComputeProviderMetadata.class);
       replay(bundle);
 
@@ -55,14 +56,15 @@ public class BundlesTest {
       verify(bundle);
    }
 
+   @SuppressWarnings("rawtypes")
    @Test
    public void testInstantiateAvailableClassesWhenNotAllAssignable() throws ClassNotFoundException {
       Bundle bundle = createMock(Bundle.class);
-      expect(bundle.loadClass("org.jclouds.providers.JcloudsTestBlobStoreProviderMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.providers.JcloudsTestBlobStoreProviderMetadata")).andReturn(
             JcloudsTestBlobStoreProviderMetadata.class);
-      expect(bundle.loadClass("org.jclouds.apis.JcloudsTestComputeApiMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.apis.JcloudsTestComputeApiMetadata")).andReturn(
             JcloudsTestComputeApiMetadata.class);
-      expect(bundle.loadClass("org.jclouds.providers.JcloudsTestYetAnotherComputeProviderMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.providers.JcloudsTestYetAnotherComputeProviderMetadata")).andReturn(
             JcloudsTestYetAnotherComputeProviderMetadata.class);
       replay(bundle);
 

--- a/core/src/test/java/org/jclouds/osgi/MetadataBundleListenerTest.java
+++ b/core/src/test/java/org/jclouds/osgi/MetadataBundleListenerTest.java
@@ -57,17 +57,18 @@ public class MetadataBundleListenerTest {
             .loadClass("org.jclouds.providers.JcloudsTestComputeProviderMetadata")));
    }
 
+   @SuppressWarnings("rawtypes")
    @Test
    public void testGetProviderMetadata() throws Exception {
       MetadataBundleListener listener = new MetadataBundleListener();
       Bundle bundle = createMock(Bundle.class);
       expect(bundle.getEntry("/META-INF/services/org.jclouds.providers.ProviderMetadata")).andReturn(
             getClass().getResource("/META-INF/services/org.jclouds.providers.ProviderMetadata")).anyTimes();
-      expect(bundle.loadClass("org.jclouds.providers.JcloudsTestBlobStoreProviderMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.providers.JcloudsTestBlobStoreProviderMetadata")).andReturn(
             JcloudsTestBlobStoreProviderMetadata.class).anyTimes();
-      expect(bundle.loadClass("org.jclouds.providers.JcloudsTestComputeProviderMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.providers.JcloudsTestComputeProviderMetadata")).andReturn(
             JcloudsTestComputeProviderMetadata.class).anyTimes();
-      expect(bundle.loadClass("org.jclouds.providers.JcloudsTestYetAnotherComputeProviderMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.providers.JcloudsTestYetAnotherComputeProviderMetadata")).andReturn(
             JcloudsTestYetAnotherComputeProviderMetadata.class).anyTimes();
       replay(bundle);
       List<ProviderMetadata> providerMetadataList = Lists.newArrayList(listener.listProviderMetadata(bundle));
@@ -79,6 +80,7 @@ public class MetadataBundleListenerTest {
       verify(bundle);
    }
 
+   @SuppressWarnings("rawtypes")
    @Test
    public void testProviderListener() throws Exception {
       MetadataBundleListener listener = new MetadataBundleListener();
@@ -90,11 +92,11 @@ public class MetadataBundleListenerTest {
       expect(bundle.getEntry("/META-INF/services/org.jclouds.providers.ProviderMetadata")).andReturn(
             getClass().getResource("/META-INF/services/org.jclouds.providers.ProviderMetadata")).anyTimes();
       expect(bundle.getEntry("/META-INF/services/org.jclouds.apis.ApiMetadata")).andReturn(null).anyTimes();
-      expect(bundle.loadClass("org.jclouds.providers.JcloudsTestBlobStoreProviderMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.providers.JcloudsTestBlobStoreProviderMetadata")).andReturn(
             JcloudsTestBlobStoreProviderMetadata.class).anyTimes();
-      expect(bundle.loadClass("org.jclouds.providers.JcloudsTestComputeProviderMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.providers.JcloudsTestComputeProviderMetadata")).andReturn(
             JcloudsTestComputeProviderMetadata.class).anyTimes();
-      expect(bundle.loadClass("org.jclouds.providers.JcloudsTestYetAnotherComputeProviderMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.providers.JcloudsTestYetAnotherComputeProviderMetadata")).andReturn(
             JcloudsTestYetAnotherComputeProviderMetadata.class).anyTimes();
 
       providerListener.added(anyObject(JcloudsTestBlobStoreProviderMetadata.class));
@@ -110,6 +112,7 @@ public class MetadataBundleListenerTest {
       verify(bundle, providerListener);
    }
 
+   @SuppressWarnings("rawtypes")
    @Test
    public void testGetProviderMetadataFromMultipleClassLoaders() throws Exception {
       ClassLoader isolatedClassLoader = createIsolatedClassLoader();
@@ -117,11 +120,11 @@ public class MetadataBundleListenerTest {
       Bundle bundle = createMock(Bundle.class);
       expect(bundle.getEntry("/META-INF/services/org.jclouds.providers.ProviderMetadata")).andReturn(
             getClass().getResource("/META-INF/services/org.jclouds.providers.ProviderMetadata")).anyTimes();
-      expect(bundle.loadClass("org.jclouds.providers.JcloudsTestBlobStoreProviderMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.providers.JcloudsTestBlobStoreProviderMetadata")).andReturn(
             isolatedClassLoader.loadClass(JcloudsTestBlobStoreProviderMetadata.class.getName())).anyTimes();
-      expect(bundle.loadClass("org.jclouds.providers.JcloudsTestComputeProviderMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.providers.JcloudsTestComputeProviderMetadata")).andReturn(
             JcloudsTestComputeProviderMetadata.class).anyTimes();
-      expect(bundle.loadClass("org.jclouds.providers.JcloudsTestYetAnotherComputeProviderMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.providers.JcloudsTestYetAnotherComputeProviderMetadata")).andReturn(
             JcloudsTestYetAnotherComputeProviderMetadata.class).anyTimes();
 
       replay(bundle);
@@ -134,17 +137,18 @@ public class MetadataBundleListenerTest {
       verify(bundle);
    }
 
+   @SuppressWarnings("rawtypes")
    @Test
    public void testGetApiMetadata() throws Exception {
       MetadataBundleListener listener = new MetadataBundleListener();
       Bundle bundle = createMock(Bundle.class);
       expect(bundle.getEntry("/META-INF/services/org.jclouds.apis.ApiMetadata")).andReturn(
             getClass().getResource("/META-INF/services/org.jclouds.apis.ApiMetadata")).anyTimes();
-      expect(bundle.loadClass("org.jclouds.apis.JcloudsTestBlobStoreApiMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.apis.JcloudsTestBlobStoreApiMetadata")).andReturn(
             JcloudsTestBlobStoreApiMetadata.class).anyTimes();
-      expect(bundle.loadClass("org.jclouds.apis.JcloudsTestComputeApiMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.apis.JcloudsTestComputeApiMetadata")).andReturn(
             JcloudsTestComputeApiMetadata.class).anyTimes();
-      expect(bundle.loadClass("org.jclouds.apis.JcloudsTestYetAnotherComputeApiMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.apis.JcloudsTestYetAnotherComputeApiMetadata")).andReturn(
             JcloudsTestYetAnotherComputeApiMetadata.class).anyTimes();
 
       replay(bundle);
@@ -157,6 +161,7 @@ public class MetadataBundleListenerTest {
       verify(bundle);
    }
 
+   @SuppressWarnings("rawtypes")
    @Test
    public void testApiListener() throws Exception {
       MetadataBundleListener listener = new MetadataBundleListener();
@@ -168,11 +173,11 @@ public class MetadataBundleListenerTest {
       expect(bundle.getEntry("/META-INF/services/org.jclouds.providers.ProviderMetadata")).andReturn(null).anyTimes();
       expect(bundle.getEntry("/META-INF/services/org.jclouds.apis.ApiMetadata")).andReturn(
             getClass().getResource("/META-INF/services/org.jclouds.apis.ApiMetadata")).anyTimes();
-      expect(bundle.loadClass("org.jclouds.apis.JcloudsTestBlobStoreApiMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.apis.JcloudsTestBlobStoreApiMetadata")).andReturn(
             JcloudsTestBlobStoreApiMetadata.class).anyTimes();
-      expect(bundle.loadClass("org.jclouds.apis.JcloudsTestComputeApiMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.apis.JcloudsTestComputeApiMetadata")).andReturn(
             JcloudsTestComputeApiMetadata.class).anyTimes();
-      expect(bundle.loadClass("org.jclouds.apis.JcloudsTestYetAnotherComputeApiMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.apis.JcloudsTestYetAnotherComputeApiMetadata")).andReturn(
             JcloudsTestYetAnotherComputeApiMetadata.class).anyTimes();
 
       apiListener.added(anyObject(JcloudsTestBlobStoreApiMetadata.class));
@@ -188,6 +193,7 @@ public class MetadataBundleListenerTest {
       verify(bundle, apiListener);
    }
 
+   @SuppressWarnings("rawtypes")
    @Test
    public void testGetApiMetadataFromMultipleClassLoaders() throws Exception {
       ClassLoader isolatedClassLoader = createIsolatedClassLoader();
@@ -195,11 +201,11 @@ public class MetadataBundleListenerTest {
       Bundle bundle = createMock(Bundle.class);
       expect(bundle.getEntry("/META-INF/services/org.jclouds.apis.ApiMetadata")).andReturn(
             getClass().getResource("/META-INF/services/org.jclouds.apis.ApiMetadata")).anyTimes();
-      expect(bundle.loadClass("org.jclouds.apis.JcloudsTestBlobStoreApiMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.apis.JcloudsTestBlobStoreApiMetadata")).andReturn(
             isolatedClassLoader.loadClass(JcloudsTestBlobStoreApiMetadata.class.getName())).anyTimes();
-      expect(bundle.loadClass("org.jclouds.apis.JcloudsTestComputeApiMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.apis.JcloudsTestComputeApiMetadata")).andReturn(
             JcloudsTestComputeApiMetadata.class).anyTimes();
-      expect(bundle.loadClass("org.jclouds.apis.JcloudsTestYetAnotherComputeApiMetadata")).andReturn(
+      expect((Class) bundle.loadClass("org.jclouds.apis.JcloudsTestYetAnotherComputeApiMetadata")).andReturn(
             JcloudsTestYetAnotherComputeApiMetadata.class).anyTimes();
 
       replay(bundle);

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -233,6 +233,8 @@
     <auto-service.version>1.0-rc2</auto-service.version>
     <auto-value.version>1.1</auto-value.version>
     <java-xmlbuilder.version>1.1</java-xmlbuilder.version>
+    <osgi.version>4.2.0</osgi.version>
+    <osgi.compendium.version>${osgi.version}</osgi.compendium.version>
     <http.proxyHost />
     <http.proxyPort />
     <jclouds.wire.httpstream.url>http://archive.apache.org/dist/commons/logging/binaries/commons-logging-1.1.1-bin.tar.gz</jclouds.wire.httpstream.url>
@@ -361,6 +363,16 @@
         <groupId>com.jamesmurty.utils</groupId>
         <artifactId>java-xmlbuilder</artifactId>
         <version>${java-xmlbuilder.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.core</artifactId>
+        <version>${osgi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.compendium</artifactId>
+        <version>${osgi.compendium.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/resources/modernizer_exclusions.txt
+++ b/resources/modernizer_exclusions.txt
@@ -20,3 +20,4 @@ com/google/common/primitives/Longs.compare:(JJ)I
 com/google/inject/Inject
 com/google/inject/Provider
 java/lang/StringBuffer."<init>":()V
+java/util/Hashtable."<init>":(I)V

--- a/scriptbuilder/pom.xml
+++ b/scriptbuilder/pom.xml
@@ -59,7 +59,6 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
-      <version>4.2.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/functionloader/osgi/BundleFunctionLoader.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/functionloader/osgi/BundleFunctionLoader.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Dictionary;
 import java.util.Enumeration;
-import java.util.HashMap;
+import java.util.Hashtable;
 
 import org.jclouds.scriptbuilder.domain.OsFamily;
 import org.jclouds.scriptbuilder.domain.ShellToken;
@@ -100,7 +100,7 @@ public class BundleFunctionLoader implements FunctionLoader {
 
    private void registerFunction(String functions) {
       String[] className = { FunctionLoader.class.getName() };
-      Dictionary dictionary = new HashMap<String, Object>();
+      Dictionary<String, Object> dictionary = new Hashtable<String, Object>(1);
       dictionary.put("function", functions);
       registration = bundleContext.registerService(className, this, dictionary);
    }

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/functionloader/osgi/BundleFunctionLoader.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/functionloader/osgi/BundleFunctionLoader.java
@@ -18,8 +18,9 @@ package org.jclouds.scriptbuilder.functionloader.osgi;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Dictionary;
 import java.util.Enumeration;
-import java.util.Properties;
+import java.util.HashMap;
 
 import org.jclouds.scriptbuilder.domain.OsFamily;
 import org.jclouds.scriptbuilder.domain.ShellToken;
@@ -98,9 +99,10 @@ public class BundleFunctionLoader implements FunctionLoader {
    }
 
    private void registerFunction(String functions) {
-      Properties properties = new Properties();
-      properties.put("function", functions);
-      registration = bundleContext.registerService(FunctionLoader.class.getName(), this, properties);
+      String[] className = { FunctionLoader.class.getName() };
+      Dictionary dictionary = new HashMap<String, Object>();
+      dictionary.put("function", functions);
+      registration = bundleContext.registerService(className, this, dictionary);
    }
 
 }


### PR DESCRIPTION
This is based on https://github.com/jclouds/jclouds/pull/1033.

This PR fixes the build of the previous one and makes the OSGi framework version configurable, so we can run builds for different environments. The scope of the OSGi dependencies is `provided`, so we can expect target platforms to have different versions than the ones used to build jclouds.

With this change, the build succeeds with the base version, and also with the latest versions:

    mvn clean install -Dosgi.version=6.0.0 -Dosgi.compendium.version=5.0.0