### PR TITLE
Fix okio version range for jclouds-okhttp

### DIFF
--- a/drivers/okhttp/pom.xml
+++ b/drivers/okhttp/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <jclouds.osgi.export>org.jclouds.http.okhttp*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
+    <jclouds.osgi.import>org.jclouds*;version="${project.version}",${okio.osgi.import},*</jclouds.osgi.import>
   </properties>
 
   <dependencies>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -226,6 +226,7 @@
     <guava.osgi.import>com.google.common.*;version="[16.0.1,20.0.0)"</guava.osgi.import>
     <guice.version>3.0</guice.version>
     <okhttp.version>2.2.0</okhttp.version>
+    <okio.osgi.import>okio;version="[1.2.0,1.3)"</okio.osgi.import>
     <surefire.version>2.17</surefire.version>
     <assertj-core.version>1.7.0</assertj-core.version>
     <assertj-guava.version>1.3.0</assertj-guava.version>


### PR DESCRIPTION
OSGi bundle for `jclouds-okhttp` should import `okio` package with correct
version range.
Currently, there is no version range specified, potentially causing it to be wired
to a higher version than intended in complex environments that have more
than one bundle for `okio` installed.