### PR TITLE
JCLOUDS-1220 : Managing the header name in the TempAuth (Identity Protocol v1)

### DIFF
--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/SwiftApiMetadata.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/SwiftApiMetadata.java
@@ -19,7 +19,12 @@ package org.jclouds.openstack.swift.v1;
 import static org.jclouds.Constants.PROPERTY_IDEMPOTENT_METHODS;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+import static org.jclouds.openstack.swift.v1.reference.TempAuthHeaders.TEMP_AUTH_HEADER_USER;
+import static org.jclouds.openstack.swift.v1.reference.TempAuthHeaders.TEMP_AUTH_HEADER_PASS;
+import static org.jclouds.openstack.swift.v1.reference.TempAuthHeaders.DEFAULT_HEADER_USER;
+import static org.jclouds.openstack.swift.v1.reference.TempAuthHeaders.DEFAULT_HEADER_PASS;
 import static org.jclouds.reflect.Reflection2.typeToken;
+
 
 import java.net.URI;
 import java.util.Properties;
@@ -62,6 +67,8 @@ public class SwiftApiMetadata extends BaseHttpApiMetadata<SwiftApi> {
       properties.setProperty(PROPERTY_IDEMPOTENT_METHODS, "DELETE,GET,HEAD,OPTIONS,POST,PUT");
       // Can alternatively be set to "tempAuthCredentials"
       properties.setProperty(CREDENTIAL_TYPE, CredentialTypes.PASSWORD_CREDENTIALS);
+      properties.setProperty(TEMP_AUTH_HEADER_USER, DEFAULT_HEADER_USER);
+      properties.setProperty(TEMP_AUTH_HEADER_PASS, DEFAULT_HEADER_PASS);
       return properties;
    }
 

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/binders/TempAuthBinder.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/binders/TempAuthBinder.java
@@ -33,16 +33,14 @@ import com.google.inject.name.Named;
  *
  */
 public final class TempAuthBinder implements Binder{
-   @Inject
-   @Named(TEMP_AUTH_HEADER_USER)
-   private String identityHeaderNameUser;
+   private final String identityHeaderNameUser;
+   private final String identityHeaderNamePass;
 
    @Inject
-   @Named(TEMP_AUTH_HEADER_PASS)
-   private String identityHeaderNamePass;
-
-
-
+   TempAuthBinder(@Named(TEMP_AUTH_HEADER_USER) String identityHeaderNameUser, @Named(TEMP_AUTH_HEADER_PASS) String identityHeaderNamePass) {
+      this.identityHeaderNameUser = identityHeaderNameUser;
+      this.identityHeaderNamePass = identityHeaderNamePass;
+   }
 
    @Override 
    public <R extends HttpRequest> R bindToRequest(R request, Object input) {

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/binders/TempAuthBinder.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/binders/TempAuthBinder.java
@@ -18,23 +18,38 @@ package org.jclouds.openstack.swift.v1.binders;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.openstack.swift.v1.reference.TempAuthHeaders.TEMP_AUTH_HEADER_USER;
+import static org.jclouds.openstack.swift.v1.reference.TempAuthHeaders.TEMP_AUTH_HEADER_PASS;
 
 import org.jclouds.domain.Credentials;
 import org.jclouds.http.HttpRequest;
-import org.jclouds.openstack.swift.v1.config.SwiftAuthenticationModule;
 import org.jclouds.rest.Binder;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
 
 /**
  * Binder to the tempAuthAuthentication
  *
  */
-public   final class TempAuthBinder implements Binder{
+public final class TempAuthBinder implements Binder{
+   @Inject
+   @Named(TEMP_AUTH_HEADER_USER)
+   private String identityHeaderNameUser;
+
+   @Inject
+   @Named(TEMP_AUTH_HEADER_PASS)
+   private String identityHeaderNamePass;
+
+
+
+
    @Override 
    public <R extends HttpRequest> R bindToRequest(R request, Object input) {
       checkNotNull(request, "request");
       checkArgument(input instanceof Credentials, "input must be a non-null org.jclouds.domain.Credentials");
-      return (R) request.toBuilder().replaceHeader(SwiftAuthenticationModule.getIdentityHeaderName(), ((Credentials) input).identity)
-	      		.replaceHeader(SwiftAuthenticationModule.getIdentityHeaderPass(), ((Credentials) input).credential).build();
+      return (R) request.toBuilder().replaceHeader(identityHeaderNameUser, ((Credentials) input).identity)
+	      		.replaceHeader(identityHeaderNamePass, ((Credentials) input).credential).build();
    }
 }
 

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/binders/TempAuthBinder.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/binders/TempAuthBinder.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.swift.v1.binders;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.jclouds.domain.Credentials;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.openstack.swift.v1.config.SwiftAuthenticationModule;
+import org.jclouds.rest.Binder;
+
+/**
+ * Binder to the tempAuthAuthentication
+ *
+ */
+public   final class TempAuthBinder implements Binder{
+   @Override 
+   public <R extends HttpRequest> R bindToRequest(R request, Object input) {
+      checkNotNull(request, "request");
+      checkArgument(input instanceof Credentials, "input must be a non-null org.jclouds.domain.Credentials");
+      return (R) request.toBuilder().replaceHeader(SwiftAuthenticationModule.getIdentityHeaderName(), ((Credentials) input).identity)
+	      		.replaceHeader(SwiftAuthenticationModule.getIdentityHeaderPass(), ((Credentials) input).credential).build();
+   }
+}
+

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/config/SwiftAuthenticationModule.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/config/SwiftAuthenticationModule.java
@@ -103,17 +103,16 @@ public final class SwiftAuthenticationModule extends KeystoneAuthenticationModul
    static final class AdaptTempAuthResponseToAccess
          implements Function<HttpResponse, Access>, InvocationContext<AdaptTempAuthResponseToAccess> {
 
-      @Inject
-      @Named(TEMP_AUTH_HEADER_USER)
-      private String identityHeaderNameUser;
+      private final String identityHeaderNameUser;
 
       private final String apiVersion;
 
       private String host;
       private String username;
 
-      @Inject AdaptTempAuthResponseToAccess(@ApiVersion String apiVersion) {
+      @Inject AdaptTempAuthResponseToAccess(@ApiVersion String apiVersion, @Named(TEMP_AUTH_HEADER_USER) String identityHeaderNameUser) {
          this.apiVersion = apiVersion;
+         this.identityHeaderNameUser = identityHeaderNameUser;
       }
 
       @Override public Access apply(HttpResponse from) {
@@ -156,7 +155,7 @@ public final class SwiftAuthenticationModule extends KeystoneAuthenticationModul
       public AdaptTempAuthResponseToAccess setContext(HttpRequest request) {
          String host = request.getEndpoint().getHost();
          this.host = host;
-	 this.username = request.getFirstHeaderOrNull(identityHeaderNameUser);
+         this.username = request.getFirstHeaderOrNull(identityHeaderNameUser);
          return this;
       }
    }

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/reference/TempAuthHeaders.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/reference/TempAuthHeaders.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.swift.v1.reference;
+
+/**
+ * Headers for TempAuth authentication
+ */
+public final class TempAuthHeaders {
+   public static final String TEMP_AUTH_HEADER_USER = "jclouds.swift.tempAuth.headerUser";
+   public static final String TEMP_AUTH_HEADER_PASS = "jclouds.swift.tempAuth.headerPass";
+
+   public static final String DEFAULT_HEADER_USER = "X-Storage-User";
+   public static final String DEFAULT_HEADER_PASS = "X-Storage-Pass";
+   public static final String STORAGE_URL = "X-Storage-Url";
+
+   private TempAuthHeaders() {
+      throw new AssertionError("intentionally unimplemented");
+   }
+}

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/TempAuthMockTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/TempAuthMockTest.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 
 import org.jclouds.ContextBuilder;
 import org.jclouds.concurrent.config.ExecutorServiceModule;
+import org.jclouds.openstack.swift.v1.config.SwiftAuthenticationModule;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -45,13 +46,24 @@ public class TempAuthMockTest {
 
 
    public void testTempAuthRequest() throws Exception {
-      tempAuthServer.enqueue(new MockResponse().setResponseCode(204)
+     Properties overrides = null;
+     // with default values
+     test(overrides);
+     overrides = new Properties();
+     overrides.setProperty(SwiftAuthenticationModule.TEMP_AUTH_HEADER_USER , "X-Auth-User");
+     overrides.setProperty(SwiftAuthenticationModule.TEMP_AUTH_HEADER_PASS , "X-Auth-Pass");
+     // with specific Header Name values
+     test(overrides);
+   }
+   
+   private void test(Properties overrides) throws Exception{
+       tempAuthServer.enqueue(new MockResponse().setResponseCode(204)
             .addHeader("X-Auth-Token", "token")
             .addHeader("X-Storage-Url", swiftServer.getUrl("").toString()));
 
       swiftServer.enqueue(new MockResponse().setBody("[{\"name\":\"test_container_1\",\"count\":2,\"bytes\":78}]"));
 
-      SwiftApi api = api(tempAuthServer.getUrl("").toString());
+      SwiftApi api = api(tempAuthServer.getUrl("").toString(), overrides);
 
       // Region name is derived from the swift server host.
       assertEquals(api.getConfiguredRegions(), ImmutableSet.of(tempAuthServer.getHostName()));
@@ -60,8 +72,8 @@ public class TempAuthMockTest {
 
       RecordedRequest auth = tempAuthServer.takeRequest();
       assertEquals(auth.getMethod(), "GET");
-      assertEquals(auth.getHeader("X-Storage-User"), "user");
-      assertEquals(auth.getHeader("X-Storage-Pass"), "password");
+      assertEquals(auth.getHeader(SwiftAuthenticationModule.getIdentityHeaderName()), "user");
+      assertEquals(auth.getHeader(SwiftAuthenticationModule.getIdentityHeaderPass()), "password");
 
       // list request went to the destination specified in X-Storage-Url.
       RecordedRequest listContainers = swiftServer.takeRequest();
@@ -71,8 +83,10 @@ public class TempAuthMockTest {
       assertEquals(listContainers.getHeader("X-Auth-Token"), "token");
    }
 
-   private SwiftApi api(String authUrl) throws IOException {
-      Properties overrides = new Properties();
+   private SwiftApi api(String authUrl, Properties overrides) throws IOException {
+      if (overrides == null){
+         overrides = new Properties();
+      }
       overrides.setProperty(CREDENTIAL_TYPE, "tempAuthCredentials");
       return ContextBuilder.newBuilder(new SwiftApiMetadata())
             .credentials("user", "password")


### PR DESCRIPTION
State of jclouds
The openstack swift "official" client (in python) manage this v1 protocol (http://docs.openstack.org/developer/python-swiftclient/swiftclient.html) so even if we don't have a specification, we will use the code of the official client for the implementation.

In jclouds, there is currently a sort-of v1 identity protocol in the openstack-swift module: in apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/config/SwiftAuthenticationModule.java, there is a tempAuthCredentials which is almost the identity v1 protocol except that the name of the headers was not the same :
= X-Storage-User vs X-Auth-User
= X-Storage-Path vs X-Auth-Key

Pull request :
= Keep the current behaviour as default
= Add 2 parameters to change the header name through variables in the Properties put in the Builder like that :

Properties overrides = new Properties();
overrides.setProperty("jclouds.keystone.credential-type", "tempAuthCredentials");
overrides.setProperty("jclouds.swift.tempAuth.headerUser", "X-Auth-User");
overrides.setProperty("jclouds.swift.tempAuth.headerPass", "X-Auth-Pass");
swiftApi = ContextBuilder.newBuilder(provider)
.endpoint(args[1])
.credentials(identity, credential)
.modules(modules)
.overrides(overrides)
.buildApi(SwiftApi.class);
