### PR TITLE
WindowsEveryonePrincipal : update regex for FR

### DIFF
--- a/apis/filesystem/src/main/java/org/jclouds/filesystem/util/Utils.java
+++ b/apis/filesystem/src/main/java/org/jclouds/filesystem/util/Utils.java
@@ -113,7 +113,7 @@ public class Utils {
                try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
                   while ((line = reader.readLine()) != null) {
                      if (line.indexOf("S-1-1-0") != -1) {
-                        return line.split(" ")[0];
+                        return line.split("\\s{2,}")[0];
                      }
                   }
                }


### PR DESCRIPTION
"Everyone" in a french Windows is "Tout le monde".
Thus, the line.split(" ") returns only "Tout" and putBlob() throws an exception.
The modified regex searches for the first two consecutive white chars to return the name.
Windows's whoami returns a bunch of 0x20 between the name and the type.

It's an update to JCLOUDS-1015 and can be released with the next 2.0 fix.