### PR TITLE
JCLOUDS-1223: Use larger block blobs for Azure

### DIFF
--- a/providers/azureblob/pom.xml
+++ b/providers/azureblob/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <test.azureblob.endpoint>https://${jclouds.identity}.blob.core.windows.net</test.azureblob.endpoint>
-    <test.azureblob.api-version>2013-08-15</test.azureblob.api-version>
+    <test.azureblob.api-version>2016-05-31</test.azureblob.api-version>
     <test.azureblob.build-version />
     <test.azureblob.identity>${test.azure.identity}</test.azureblob.identity>
     <test.azureblob.credential>${test.azure.credential}</test.azureblob.credential>

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/AzureBlobApiMetadata.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/AzureBlobApiMetadata.java
@@ -62,7 +62,7 @@ public class AzureBlobApiMetadata extends BaseHttpApiMetadata {
          .name("Microsoft Azure Blob Service API")
          .identityName("Account Name")
          .credentialName("Access Key")
-         .version("2013-08-15")
+         .version("2016-05-31")
          .defaultEndpoint("https://${jclouds.identity}.blob.core.windows.net")
          .documentation(URI.create("http://msdn.microsoft.com/en-us/library/dd135733.aspx"))
          .defaultProperties(AzureBlobApiMetadata.defaultProperties())

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/AzureBlobStore.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/AzureBlobStore.java
@@ -492,7 +492,7 @@ public class AzureBlobStore extends BaseBlobStore {
 
    @Override
    public long getMaximumMultipartPartSize() {
-      return 4 * 1024 * 1024;
+      return 100 * 1024 * 1024;
    }
 
    @Override

--- a/providers/azureblob/src/test/java/org/jclouds/azureblob/AzureBlobClientTest.java
+++ b/providers/azureblob/src/test/java/org/jclouds/azureblob/AzureBlobClientTest.java
@@ -78,7 +78,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
       GeneratedHttpRequest request = processor.createRequest(method, ImmutableList.of());
 
       assertRequestLineEquals(request, "GET https://identity.blob.core.windows.net/?comp=list HTTP/1.1");
-      assertNonPayloadHeadersEqual(request, "x-ms-version: 2013-08-15\n");
+      assertNonPayloadHeadersEqual(request, "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ParseSax.class);
@@ -93,7 +93,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
 
       assertRequestLineEquals(request,
                "GET https://identity.blob.core.windows.net/?comp=list&maxresults=1&marker=marker&prefix=prefix HTTP/1.1");
-      assertNonPayloadHeadersEqual(request, "x-ms-version: 2013-08-15\n");
+      assertNonPayloadHeadersEqual(request, "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ParseSax.class);
@@ -108,7 +108,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
 
       assertRequestLineEquals(request,
                "PUT https://identity.blob.core.windows.net/container?restype=container HTTP/1.1");
-      assertNonPayloadHeadersEqual(request, "x-ms-version: 2013-08-15\n");
+      assertNonPayloadHeadersEqual(request, "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ReturnTrueIf2xx.class);
@@ -122,7 +122,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
 
       assertRequestLineEquals(request,
                "DELETE https://identity.blob.core.windows.net/container?restype=container HTTP/1.1");
-      assertNonPayloadHeadersEqual(request, "x-ms-version: 2013-08-15\n");
+      assertNonPayloadHeadersEqual(request, "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ReleasePayloadAndReturn.class);
@@ -141,7 +141,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
       assertNonPayloadHeadersEqual(request,
                "x-ms-blob-public-access: blob\n" +
                "x-ms-meta-foo: bar\n" +
-               "x-ms-version: 2013-08-15\n");
+               "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ReturnTrueIf2xx.class);
@@ -155,7 +155,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
       GeneratedHttpRequest request = processor.createRequest(method, ImmutableList.of());
 
       assertRequestLineEquals(request, "PUT https://identity.blob.core.windows.net/$root?restype=container HTTP/1.1");
-      assertNonPayloadHeadersEqual(request, "x-ms-version: 2013-08-15\n");
+      assertNonPayloadHeadersEqual(request, "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ReturnTrueIf2xx.class);
@@ -168,7 +168,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
       GeneratedHttpRequest request = processor.createRequest(method, ImmutableList.of());
 
       assertRequestLineEquals(request, "DELETE https://identity.blob.core.windows.net/$root?restype=container HTTP/1.1");
-      assertNonPayloadHeadersEqual(request, "x-ms-version: 2013-08-15\n");
+      assertNonPayloadHeadersEqual(request, "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ReleasePayloadAndReturn.class);
@@ -185,7 +185,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
       assertNonPayloadHeadersEqual(request,
                "x-ms-blob-public-access: blob\n" +
                "x-ms-meta-foo: bar\n" +
-               "x-ms-version: 2013-08-15\n");
+               "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ReturnTrueIf2xx.class);
@@ -199,7 +199,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
 
       assertRequestLineEquals(request,
                "GET https://identity.blob.core.windows.net/container?restype=container&comp=list HTTP/1.1");
-      assertNonPayloadHeadersEqual(request, "x-ms-version: 2013-08-15\n");
+      assertNonPayloadHeadersEqual(request, "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ParseSax.class);
@@ -213,7 +213,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
 
       assertRequestLineEquals(request,
                "GET https://identity.blob.core.windows.net/container?restype=container&comp=list&include=copy,metadata,snapshots,uncommittedblobs HTTP/1.1");
-      assertNonPayloadHeadersEqual(request, "x-ms-version: 2013-08-15\n");
+      assertNonPayloadHeadersEqual(request, "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ParseSax.class);
@@ -227,7 +227,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
 
       assertRequestLineEquals(request,
                "GET https://identity.blob.core.windows.net/$root?restype=container&comp=list HTTP/1.1");
-      assertNonPayloadHeadersEqual(request, "x-ms-version: 2013-08-15\n");
+      assertNonPayloadHeadersEqual(request, "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ParseSax.class);
@@ -241,7 +241,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
 
       assertRequestLineEquals(request,
                "HEAD https://identity.blob.core.windows.net/container?restype=container HTTP/1.1");
-      assertNonPayloadHeadersEqual(request, "x-ms-version: 2013-08-15\n");
+      assertNonPayloadHeadersEqual(request, "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ParseContainerPropertiesFromHeaders.class);
@@ -255,7 +255,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
 
       assertRequestLineEquals(request,
                "HEAD https://identity.blob.core.windows.net/container?restype=container&comp=acl HTTP/1.1");
-      assertNonPayloadHeadersEqual(request, "x-ms-version: 2013-08-15\n");
+      assertNonPayloadHeadersEqual(request, "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ParsePublicAccessHeader.class);
@@ -280,7 +280,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
                "PUT https://identity.blob.core.windows.net/container?restype=container&comp=acl HTTP/1.1");
       assertNonPayloadHeadersEqual(request,
                expectedHeader +
-               "x-ms-version: 2013-08-15\n");
+               "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ParseETagHeader.class);
@@ -297,7 +297,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
                "PUT https://identity.blob.core.windows.net/container?restype=container&comp=metadata HTTP/1.1");
       assertNonPayloadHeadersEqual(request,
                "x-ms-meta-key: value\n" +
-               "x-ms-version: 2013-08-15\n");
+               "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ReleasePayloadAndReturn.class);
@@ -321,7 +321,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
             "Expect: 100-continue\n" +
             "x-ms-blob-cache-control: " + cacheControl + "\n" +
             "x-ms-blob-type: BlockBlob\n" +
-            "x-ms-version: 2013-08-15\n");
+            "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, payload, "application/unknown", false);
 
       assertResponseParserClassEquals(method, request, ParseETagHeader.class);
@@ -334,7 +334,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
       GeneratedHttpRequest request = processor.createRequest(method, ImmutableList.<Object> of("container", "blob"));
 
       assertRequestLineEquals(request, "GET https://identity.blob.core.windows.net/container/blob HTTP/1.1");
-      assertNonPayloadHeadersEqual(request, "x-ms-version: 2013-08-15\n");
+      assertNonPayloadHeadersEqual(request, "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ParseBlobFromHeadersAndHttpContent.class);
@@ -350,7 +350,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
                "PUT https://identity.blob.core.windows.net/container/blob?comp=metadata HTTP/1.1");
       assertNonPayloadHeadersEqual(request,
                "x-ms-meta-key: value\n" +
-               "x-ms-version: 2013-08-15\n");
+               "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ParseETagHeader.class);
@@ -371,7 +371,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
       assertNonPayloadHeadersEqual(request,
                "x-ms-blob-cache-control: " + cacheControl + "\n" +
                "x-ms-blob-content-type: application/unknown\n" +
-               "x-ms-version: 2013-08-15\n");
+               "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertResponseParserClassEquals(method, request, ParseETagHeader.class);
@@ -389,7 +389,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
       checkFilters(request);
       assertNonPayloadHeadersEqual(request,
                "x-ms-copy-source: https://identity.blob.core.windows.net/fromcontainer/fromblob\n" +
-               "x-ms-version: 2013-08-15\n");
+               "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
    }
 
@@ -405,7 +405,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
       assertNonPayloadHeadersEqual(request,
                "x-ms-copy-source: https://identity.blob.core.windows.net/fromcontainer/fromblob\n" +
                "x-ms-meta-foo: bar\n" +
-               "x-ms-version: 2013-08-15\n");
+               "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
    }
 
@@ -421,7 +421,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
       assertNonPayloadHeadersEqual(request,
                "x-ms-copy-source: https://identity.blob.core.windows.net/fromcontainer/fromblob\n" +
                "x-ms-source-if-modified-since: Thu, 01 Jan 1970 00:00:01 GMT\n" +
-               "x-ms-version: 2013-08-15\n");
+               "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
    }
 
@@ -437,7 +437,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
       assertNonPayloadHeadersEqual(request,
                "x-ms-copy-source: https://identity.blob.core.windows.net/fromcontainer/fromblob\n" +
                "x-ms-source-if-unmodified-since: Thu, 01 Jan 1970 00:00:01 GMT\n" +
-               "x-ms-version: 2013-08-15\n");
+               "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
    }
 
@@ -454,7 +454,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
       assertNonPayloadHeadersEqual(request,
                "x-ms-copy-source: https://identity.blob.core.windows.net/fromcontainer/fromblob\n" +
                "x-ms-source-if-match: " + eTag + "\n" +
-               "x-ms-version: 2013-08-15\n");
+               "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
    }
 
@@ -471,7 +471,7 @@ public class AzureBlobClientTest extends BaseRestAnnotationProcessingTest<AzureB
       assertNonPayloadHeadersEqual(request,
                "x-ms-copy-source: https://identity.blob.core.windows.net/fromcontainer/fromblob\n" +
                "x-ms-source-if-none-match: " + eTag + "\n" +
-               "x-ms-version: 2013-08-15\n");
+               "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
    }
 

--- a/providers/azureblob/src/test/java/org/jclouds/azureblob/blobstore/AzureBlobRequestSignerTest.java
+++ b/providers/azureblob/src/test/java/org/jclouds/azureblob/blobstore/AzureBlobRequestSignerTest.java
@@ -60,9 +60,9 @@ public class AzureBlobRequestSignerTest extends BaseRestAnnotationProcessingTest
       assertRequestLineEquals(request, "GET https://identity.blob.core.windows.net/container/name HTTP/1.1");
       assertNonPayloadHeadersEqual(
                request,
-               "Authorization: SharedKeyLite identity:cP8Cm4r3hBbhkD/OUg5t8nRwt3SkLKOIppKIb1lRce4=\n" +
+               "Authorization: SharedKeyLite identity:jg07gnCq8qSIrYB68jVeFHWoGjdBqXxnRsVaNrFByGI=\n" +
                "Date: Thu, 05 Jun 2008 16:38:19 GMT\n" +
-               "x-ms-version: 2013-08-15\n");
+               "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertEquals(request.getFilters().size(), 0);
@@ -75,9 +75,9 @@ public class AzureBlobRequestSignerTest extends BaseRestAnnotationProcessingTest
       assertRequestLineEquals(request, "DELETE https://identity.blob.core.windows.net/container/name HTTP/1.1");
       assertNonPayloadHeadersEqual(
                request,
-               "Authorization: SharedKeyLite identity:G6nXsRjrJy8HoVF74MGnuDS358KkBz/GScBROvIZSls=\n" +
+               "Authorization: SharedKeyLite identity:1VtEOOk1rhnbR3o2F9/57ALo3uy3aeUwfXMQjTroIF0=\n" +
                "Date: Thu, 05 Jun 2008 16:38:19 GMT\n" +
-               "x-ms-version: 2013-08-15\n");
+               "x-ms-version: 2016-05-31\n");
       assertPayloadEquals(request, null, null, false);
 
       assertEquals(request.getFilters().size(), 0);
@@ -99,11 +99,11 @@ public class AzureBlobRequestSignerTest extends BaseRestAnnotationProcessingTest
       assertRequestLineEquals(request, "PUT https://identity.blob.core.windows.net/container/name HTTP/1.1");
       assertNonPayloadHeadersEqual(
                request,
-               "Authorization: SharedKeyLite identity:S2cKS4t1F8ZlLOxzgOZkO8bLeCP3vEko5CTsyIKlcJE=\n" +
+               "Authorization: SharedKeyLite identity:0p2Ji00Yr3ZpPYy61QS5BVCJWSn8skZ5BOgMQb4vN4s=\n" +
                "Date: Thu, 05 Jun 2008 16:38:19 GMT\n" +
                "Expect: 100-continue\n" +
                "x-ms-blob-type: BlockBlob\n" +
-               "x-ms-version: 2013-08-15\n");
+               "x-ms-version: 2016-05-31\n");
       assertContentHeadersEqual(request, "text/plain", null, null, null, 2L, hashCode.asBytes(), new Date(1000));
 
       assertEquals(request.getFilters().size(), 0);


### PR DESCRIPTION
This raises the maximum multipart size from 195 GB to 4.77 TB.
Reference:
    
https://azure.microsoft.com/en-us/blog/general-availability-larger-block-blobs-in-azure-storage/