### PR TITLE
bump sshj version to 0.20.0

### DIFF
--- a/drivers/sshj/pom.xml
+++ b/drivers/sshj/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>com.hierynomus</groupId>
       <artifactId>sshj</artifactId>
-      <version>0.12.0</version>
+      <version>0.20.0</version>
       <exclusions>
         <!-- provided by the jclouds-bouncycastle driver -->
         <exclusion>


### PR DESCRIPTION
- this version contains some new features and bug fixes especially useful for OSGi (see https://github.com/hierynomus/sshj/issues/300 for more details), in fact I've tested `jclouds-karaf` with this version and it works as well.

/cc @nacx 

