### PR TITLE
Take into account the template properties each time the builder is retrieved

### DIFF
--- a/compute/src/test/java/org/jclouds/compute/extensions/internal/BaseImageExtensionLiveTest.java
+++ b/compute/src/test/java/org/jclouds/compute/extensions/internal/BaseImageExtensionLiveTest.java
@@ -68,7 +68,11 @@ public abstract class BaseImageExtensionLiveTest extends BaseComputeServiceConte
     * @return
     */
    public TemplateBuilder getNodeTemplate() {
-      return view.getComputeService().templateBuilder();
+      TemplateBuilder templateBuilder = view.getComputeService().templateBuilder();
+      if (templateBuilderSpec != null) {
+          templateBuilder = templateBuilder.from(templateBuilderSpec);
+      }
+      return templateBuilder;
    }
 
    /**


### PR DESCRIPTION
When getting the template for the node, always check if there is a custom property for it.