### PR TITLE
Fix error creating list of volume bindings for Docker

### DIFF
--- a/apis/docker/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
+++ b/apis/docker/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
@@ -160,9 +160,11 @@ public class DockerComputeServiceAdapter implements
          }
 
          if (!templateOptions.getVolumes().isEmpty()) {
+            List<String> binds = Lists.newArrayList();
             for (Map.Entry<String, String> entry : templateOptions.getVolumes().entrySet()) {
-               hostConfigBuilder.binds(ImmutableList.of(entry.getKey() + ":" + entry.getValue()));
+               binds.add(entry.getKey() + ":" + entry.getValue());
             }
+            hostConfigBuilder.binds(ImmutableList.copyOf(binds));
          }
 
          if (!templateOptions.getVolumesFrom().isEmpty()) {


### PR DESCRIPTION
Currently the code only sets the last in the list of the passed in volume bindings, by continually overwriting the bindings with a single element list. This fixes that and sets all of them in a single list.