### PR TITLE
Create and attach tests sources as artifacts

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -1414,6 +1414,7 @@
                 <id>attach-sources</id>
                 <goals>
                   <goal>jar-no-fork</goal>
+                  <goal>test-jar-no-fork</goal>
                 </goals>
               </execution>
             </executions>


### PR DESCRIPTION
Will create `-test-sources.jar` corresponding to the `-tests.jar` binaries. Analogously to the sources generated for the release jar.
Very useful when writing tests in the IDE, needing to consult other test files we are depending on (say `BaseContextLiveTest`).