### PR TITLE
Fix the Jetty start statement used in compute live tests

### DIFF
--- a/compute/src/test/java/org/jclouds/compute/JettyStatements.java
+++ b/compute/src/test/java/org/jclouds/compute/JettyStatements.java
@@ -57,14 +57,11 @@ public class JettyStatements {
    
    public static Statement start() {
       return new StatementList(
-            literal("cd " + JETTY_HOME),
-            literal("nohup java -jar start.jar jetty.port=" + port + " > start.out 2> start.err < /dev/null &"),
+            literal(String.format("JETTY_PORT=%d %s/bin/jetty.sh start", port, JETTY_HOME)),
             literal("test $? && sleep 1")); // in case it is slow starting the proc
    }
    
    public static Statement stop() {
-      return new StatementList(
-            literal("cd " + JETTY_HOME),
-            literal("./bin/jetty.sh stop"));
+      return literal(JETTY_HOME + "/bin/jetty.sh stop");
    }
 }

--- a/compute/src/test/java/org/jclouds/compute/StubComputeServiceIntegrationTest.java
+++ b/compute/src/test/java/org/jclouds/compute/StubComputeServiceIntegrationTest.java
@@ -303,8 +303,7 @@ public class StubComputeServiceIntegrationTest extends BaseComputeServiceLiveTes
                clientNew.disconnect();
 
                String startJetty = new StringBuilder()
-                  .append("cd /usr/local/jetty").append('\n')
-                  .append("nohup java -jar start.jar jetty.port=8080 > start.out 2> start.err < /dev/null &").append('\n')
+                  .append("JETTY_PORT=8080 /usr/local/jetty/bin/jetty.sh start").append('\n')
                   .append("test $? && sleep 1").append('\n').toString();
 
                clientNew.connect();
@@ -312,7 +311,7 @@ public class StubComputeServiceIntegrationTest extends BaseComputeServiceLiveTes
                clientNew.disconnect();
 
                clientNew.connect();
-               expect(clientNew.exec("cd /usr/local/jetty\n./bin/jetty.sh stop\n")).andReturn(EXEC_GOOD);
+               expect(clientNew.exec("/usr/local/jetty/bin/jetty.sh stop\n")).andReturn(EXEC_GOOD);
                clientNew.disconnect();
 
                clientNew.connect();
@@ -532,6 +531,11 @@ public class StubComputeServiceIntegrationTest extends BaseComputeServiceLiveTes
    @Test(enabled = true, dependsOnMethods = { "testListNodes", "testGetNodesWithDetails", "testListNodesByIds" })
    public void testDestroyNodes() {
       super.testDestroyNodes();
+   }
+
+   @Override
+   protected void waitGracePeriodForDestroyedNodes() {
+      // Do not wait
    }
 
 }

--- a/compute/src/test/java/org/jclouds/compute/internal/BaseComputeServiceLiveTest.java
+++ b/compute/src/test/java/org/jclouds/compute/internal/BaseComputeServiceLiveTest.java
@@ -684,12 +684,16 @@ public abstract class BaseComputeServiceLiveTest extends BaseComputeServiceConte
       int toDestroy = refreshNodes().size();
       Set<? extends NodeMetadata> destroyed = client.destroyNodesMatching(inGroup(group));
       assertEquals(toDestroy, destroyed.size());
-      Uninterruptibles.sleepUninterruptibly(100, TimeUnit.SECONDS);
+      waitGracePeriodForDestroyedNodes();
       for (NodeMetadata node : filter(client.listNodesDetailsMatching(all()), inGroup(group))) {
          assert node.getStatus() == Status.TERMINATED : node;
          assert view.utils().credentialStore().get("node#" + node.getId()) == null : "credential should have been null for "
                + "node#" + node.getId();
       }
+   }
+
+   protected void waitGracePeriodForDestroyedNodes() {
+      Uninterruptibles.sleepUninterruptibly(100, TimeUnit.SECONDS);
    }
 
    private Set<? extends NodeMetadata> refreshNodes() {


### PR DESCRIPTION
During tests, the Jetty server was started manually running the jar file, and the PID file was not generated. This caused the stop statement to silently fail and Jetty kept running. This change also removes a graceful wait used in live tests that does not make sense in stubbed integration tests.