### PR TITLE
fix for deleting an invalid file

### DIFF
--- a/apis/filesystem/src/main/java/org/jclouds/filesystem/util/Utils.java
+++ b/apis/filesystem/src/main/java/org/jclouds/filesystem/util/Utils.java
@@ -27,6 +27,7 @@ import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.InvalidPathException;
 import java.nio.file.attribute.AclEntry;
 import java.nio.file.attribute.AclEntryPermission;
 import java.nio.file.attribute.AclEntryType;
@@ -77,10 +78,17 @@ public class Utils {
    }
 
    public static void delete(File file) throws IOException {
+      Path path;
+      try {
+         path = file.toPath();
+      } catch (InvalidPathException ipe) {
+         throw new IOException("Invalid file: " + file);
+      }
+      
       for (int n = 0; n < 10; n++) {
          try {
-            Files.delete(file.toPath());
-            if (Files.exists(file.toPath())) {
+            Files.delete(path);
+            if (Files.exists(path)) {
                Uninterruptibles.sleepUninterruptibly(200, TimeUnit.MILLISECONDS);
                continue;
             }
@@ -98,7 +106,7 @@ public class Utils {
          }
       }
       // File could not be deleted multiple times. It is very likely locked in another process
-      throw new IOException("Could not delete: " + file.toPath());
+      throw new IOException("Could not delete: " + path);
    }
 
    /**

--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImplTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImplTest.java
@@ -29,6 +29,7 @@ import static org.testng.Assert.fail;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.InvalidPathException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -682,6 +683,16 @@ public class FilesystemStorageStrategyImplTest {
          Fail.failBecauseExceptionWasNotThrown(IOException.class);
       } catch (IOException ioe) {
          // expected
+      }
+   }
+   
+   @Test
+   public void testDeletingInvalidPathFileEndsNormally() {
+      String invalidPathBlobKey = "A<!:!@#$%^&*?]8 ";
+      try {
+         storageStrategy.removeBlob(CONTAINER_NAME, invalidPathBlobKey);
+      } catch (InvalidPathException ipe) {
+         fail("Deleting an invalid path ended with an InvalidPathException.", ipe);
       }
    }
 

--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImplTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImplTest.java
@@ -688,7 +688,7 @@ public class FilesystemStorageStrategyImplTest {
    
    @Test
    public void testDeletingInvalidPathFileEndsNormally() {
-      String invalidPathBlobKey = "A<!:!@#$%^&*?]8 ";
+      String invalidPathBlobKey = "A<!:!@#$%^&*?]8 /\0";
       try {
          storageStrategy.removeBlob(CONTAINER_NAME, invalidPathBlobKey);
       } catch (InvalidPathException ipe) {


### PR DESCRIPTION
If the file for delete is invalid (typically a wrong filename) an IOException will be thrown.