### PR TITLE
JCLOUDS-1299: Handle % in names during Swift list

### DIFF
--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/functions/ParseObjectListFromResponse.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/functions/ParseObjectListFromResponse.java
@@ -18,6 +18,7 @@ package org.jclouds.openstack.swift.v1.functions;
 
 import static com.google.common.io.BaseEncoding.base16;
 import static org.jclouds.http.Uris.uriBuilder;
+import static org.jclouds.util.Strings2.urlEncode;
 
 import java.util.Date;
 import java.util.List;
@@ -96,7 +97,7 @@ public class ParseObjectListFromResponse implements Function<HttpResponse, Objec
          String etag = Strings.nullToEmpty(input.hash);
          Date lastModified = input.last_modified == null ? new Date() : input.last_modified;
          return SwiftObject.builder()
-               .uri(uriBuilder(containerUri).clearQuery().appendPath(input.name).build())
+               .uri(uriBuilder(containerUri).clearQuery().appendPath(urlEncode(input.name)).build())
                .name(name)
                .etag(etag)
                .payload(payload(input.bytes, etag, input.content_type, input.expires))

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
@@ -597,7 +597,7 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
 
    @DataProvider
    public Object[][] getBlobsToEscape() {
-      ImmutableSet<String> testNames = ImmutableSet.of("%20", "%20 ", " %20", " ");
+      ImmutableSet<String> testNames = ImmutableSet.of("%20", "%20 ", " %20", " ", "%", "%%");
       Object[][] result = new Object[1][1];
       result[0][0] = testNames;
       return result;


### PR DESCRIPTION
`uriBuilder.appendPath` assumes an encoded path.