### PR TITLE
Add ModifySubnetAttribute

### DIFF
--- a/apis/sts/src/main/java/org/jclouds/aws/filters/FormSignerUtils.java
+++ b/apis/sts/src/main/java/org/jclouds/aws/filters/FormSignerUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.aws.filters;
+
+import org.jclouds.http.HttpRequest;
+import org.jclouds.reflect.Invocation;
+import org.jclouds.rest.annotations.SinceApiVersion;
+import org.jclouds.rest.internal.GeneratedHttpRequest;
+
+import com.google.common.base.Optional;
+import com.google.common.reflect.Invokable;
+
+/**
+ * Utilities for FormSigner implementations.
+ */
+public final class FormSignerUtils {
+
+   private FormSignerUtils() {}
+
+   /**
+    * Get the version from a @SinceApiVersion() annotation on an API method or its owning class.
+    * @param request The API request for the method.
+    * @return An optional of the value of the annotation.
+    */
+   public static Optional<String> getAnnotatedApiVersion(HttpRequest request) {
+      if (request instanceof GeneratedHttpRequest) {
+         GeneratedHttpRequest generatedRequest = (GeneratedHttpRequest) request;
+         return getAnnotatedApiVersion(generatedRequest.getInvocation());
+      } else {
+         return Optional.absent();
+      }
+   }
+
+   private static Optional<String> getAnnotatedApiVersion(Invocation invocation) {
+      final Invokable<?, ?> invokable = invocation.getInvokable();
+      if (invokable.isAnnotationPresent(SinceApiVersion.class)) {
+         return Optional.fromNullable(invokable.getAnnotation(SinceApiVersion.class).value());
+      } else {
+         final Class<?> owner = invokable.getOwnerType().getRawType();
+         if (owner.isAnnotationPresent(SinceApiVersion.class)) {
+            return Optional.fromNullable(owner.getAnnotation(SinceApiVersion.class).value());
+         }
+      }
+      return Optional.absent();
+   }
+
+}

--- a/apis/sts/src/main/java/org/jclouds/aws/filters/FormSignerUtils.java
+++ b/apis/sts/src/main/java/org/jclouds/aws/filters/FormSignerUtils.java
@@ -18,7 +18,7 @@ package org.jclouds.aws.filters;
 
 import org.jclouds.http.HttpRequest;
 import org.jclouds.reflect.Invocation;
-import org.jclouds.rest.annotations.SinceApiVersion;
+import org.jclouds.rest.annotations.ApiVersionOverride;
 import org.jclouds.rest.internal.GeneratedHttpRequest;
 
 import com.google.common.base.Optional;
@@ -32,7 +32,7 @@ public final class FormSignerUtils {
    private FormSignerUtils() {}
 
    /**
-    * Get the version from a @SinceApiVersion() annotation on an API method or its owning class.
+    * Get the version from a @ApiVersionOverride() annotation on an API method or its owning class.
     * @param request The API request for the method.
     * @return An optional of the value of the annotation.
     */
@@ -47,12 +47,12 @@ public final class FormSignerUtils {
 
    private static Optional<String> getAnnotatedApiVersion(Invocation invocation) {
       final Invokable<?, ?> invokable = invocation.getInvokable();
-      if (invokable.isAnnotationPresent(SinceApiVersion.class)) {
-         return Optional.fromNullable(invokable.getAnnotation(SinceApiVersion.class).value());
+      if (invokable.isAnnotationPresent(ApiVersionOverride.class)) {
+         return Optional.fromNullable(invokable.getAnnotation(ApiVersionOverride.class).value());
       } else {
          final Class<?> owner = invokable.getOwnerType().getRawType();
-         if (owner.isAnnotationPresent(SinceApiVersion.class)) {
-            return Optional.fromNullable(owner.getAnnotation(SinceApiVersion.class).value());
+         if (owner.isAnnotationPresent(ApiVersionOverride.class)) {
+            return Optional.fromNullable(owner.getAnnotation(ApiVersionOverride.class).value());
          }
       }
       return Optional.absent();

--- a/core/src/main/java/org/jclouds/rest/annotations/ApiVersionOverride.java
+++ b/core/src/main/java/org/jclouds/rest/annotations/ApiVersionOverride.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rest.annotations;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+
+/**
+ * @Deprecated The intention is to use @SinceApiVersion for this purpose, but that would affect
+ * a number of APIs, and we would want to have good test coverage before merging that change
+ * (in {@link FormSignerUtils#getAnnotatedApiVersion}). However, there is some issue with certain tests at
+ * present that means we cannot successfully test all APIs that make use of @SinceApiVersion in order
+ * to assure ourselves that FormSignerUtils will not introduce some problem. See
+ * <a href="https://github.com/jclouds/jclouds/pull/1102#issuecomment-302682049">
+ *    comments on github</a> for details
+ * This annotation is introduced as a temporary measure in order to decouple the functionality of
+ * {@link FormSignerUtils#getAnnotatedApiVersion} from @SinceApiVersion and the tests in question.
+ * It can be removed and replaced by @SinceApiVersion when those tests are fixed.
+ *
+ * Designates that a method overrides the {@link ApiVersion} on the class with a specific value.
+ *
+ * @see ApiVersion
+ */
+@Deprecated
+@Target({ METHOD })
+@Retention(RUNTIME)
+@Qualifier
+public @interface ApiVersionOverride {
+
+   /**
+    * Value to override the default {@link ApiVersion}.
+    *
+    */
+   String value();
+
+}

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/features/AWSSubnetApi.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/features/AWSSubnetApi.java
@@ -36,6 +36,7 @@ import org.jclouds.ec2.xml.DescribeSubnetsResponseHandler;
 import org.jclouds.ec2.xml.SubnetHandler;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.location.functions.RegionToEndpointOrProviderIfNull;
+import org.jclouds.rest.annotations.ApiVersionOverride;
 import org.jclouds.rest.annotations.BinderParam;
 import org.jclouds.rest.annotations.EndpointParam;
 import org.jclouds.rest.annotations.Fallback;
@@ -141,7 +142,7 @@ public interface AWSSubnetApi extends SubnetApi {
     * @param options The options containing the attribute to modify. You can only modify one attribute at a time.
     * @return true if the modification was successful
     */
-   @SinceApiVersion("2014-06-15")
+   @ApiVersionOverride("2014-06-15")
    @Named("ModifySubnetAttribute")
    @POST
    @Path("/")

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/features/AWSSubnetApi.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/features/AWSSubnetApi.java
@@ -25,6 +25,8 @@ import javax.ws.rs.Path;
 
 import org.jclouds.Fallbacks;
 import org.jclouds.aws.ec2.options.CreateSubnetOptions;
+import org.jclouds.aws.ec2.options.ModifySubnetAttributeOptions;
+import org.jclouds.aws.ec2.xml.ReturnValueHandler;
 import org.jclouds.aws.filters.FormSigner;
 import org.jclouds.ec2.binders.BindFiltersToIndexedFormParams;
 import org.jclouds.ec2.binders.BindSubnetIdsToIndexedFormParams;
@@ -130,4 +132,24 @@ public interface AWSSubnetApi extends SubnetApi {
    FluentIterable<Subnet> describeSubnetsInRegionWithFilter(
            @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
            @BinderParam(BindFiltersToIndexedFormParams.class) Multimap<String, String> filter);
+
+   /**
+    * Modifies a subnet attribute. You can only modify one attribute at a time.
+    *
+    * @param region The region for the subnet
+    * @param subnetId The ID of the subnet
+    * @param options The options containing the attribute to modify. You can only modify one attribute at a time.
+    * @return true if the modification was successful
+    */
+   @SinceApiVersion("2014-06-15")
+   @Named("ModifySubnetAttribute")
+   @POST
+   @Path("/")
+   @FormParams(keys = ACTION, values = "ModifySubnetAttribute")
+   @XMLResponseParser(ReturnValueHandler.class)
+   @Fallback(Fallbacks.FalseOnNotFoundOr404.class)
+   boolean modifySubnetAttribute(
+      @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
+      @FormParam("SubnetId") String subnetId,
+      ModifySubnetAttributeOptions options);
 }

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/options/ModifySubnetAttributeOptions.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/options/ModifySubnetAttributeOptions.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.aws.ec2.options;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.jclouds.ec2.options.internal.BaseEC2RequestOptions;
+import org.jclouds.rest.annotations.SinceApiVersion;
+
+/**
+ * Contains options supported in the Form API for the ModifySubnetAttribute
+ * operation. <h2>
+ * Usage</h2> The recommended way to instantiate a ModifySubnetAttributeOptions
+ * object is to statically import ModifySubnetAttributeOptions.Builder.* and
+ * invoke a static creation method followed by an instance mutator (if needed):
+ * <p/>
+ * <code>
+ * import static org.jclouds.aws.ec2.options.ModifySubnetAttributeOptions.Builder.*
+ * <p/>
+ * group = connection.getAWSSubnetApi().modifySubnetAttribute(region, subnetId, mapPublicIpOnLaunch(true));
+ * <code>
+ * 
+ * @see <a href=
+ *      "http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySubnetAttribute.html"
+ *      />
+ */
+@SinceApiVersion("2014-06-15")
+public class ModifySubnetAttributeOptions extends BaseEC2RequestOptions {
+
+   /**
+    * The Availability Zone for the subnet.
+    */
+   public ModifySubnetAttributeOptions assignIpv6AddressOnCreation(Boolean assignIpv6AddressOnCreation) {
+      formParameters.put("AssignIpv6AddressOnCreation.Value",
+         checkNotNull(assignIpv6AddressOnCreation, "assignIpv6AddressOnCreation").toString());
+      return this;
+   }
+
+   public Boolean isAssignIpv6AddressOnCreation() {
+      return Boolean.parseBoolean("AssignIpv6AddressOnCreation.Value");
+   }
+
+   public ModifySubnetAttributeOptions mapPublicIpOnLaunch(Boolean mapPublicIpOnLaunch) {
+      formParameters.put("MapPublicIpOnLaunch.Value",
+         checkNotNull(mapPublicIpOnLaunch, "mapPublicIpOnLaunch").toString());
+      return this;
+   }
+
+   public Boolean isMapPublicIpOnLaunch() {
+      return Boolean.parseBoolean(getFirstFormOrNull("MapPublicIpOnLaunch.Value"));
+   }
+
+   public static class Builder {
+
+      /**
+       * @see ModifySubnetAttributeOptions#assignIpv6AddressOnCreation(Boolean )
+       */
+      public static ModifySubnetAttributeOptions assignIpv6AddressOnCreation(Boolean assignIpv6AddressOnCreation) {
+         ModifySubnetAttributeOptions options = new ModifySubnetAttributeOptions();
+         return options.assignIpv6AddressOnCreation(assignIpv6AddressOnCreation);
+      }
+
+      /**
+       * @see ModifySubnetAttributeOptions#mapPublicIpOnLaunch(Boolean)
+       */
+      public static ModifySubnetAttributeOptions mapPublicIpOnLaunch(Boolean mapPublicIpOnLaunch) {
+         ModifySubnetAttributeOptions options = new ModifySubnetAttributeOptions();
+         return options.mapPublicIpOnLaunch(mapPublicIpOnLaunch);
+      }
+
+   }
+}

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/AWSSubnetApiMockTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/features/AWSSubnetApiMockTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.aws.ec2.features;
 
+import static org.jclouds.aws.ec2.options.ModifySubnetAttributeOptions.Builder.mapPublicIpOnLaunch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -201,6 +202,25 @@ public class AWSSubnetApiMockTest extends BaseAWSEC2ApiMockTest {
       
       assertPosted(DEFAULT_REGION, "Action=DescribeRegions");
       assertPosted(region, "Action=DescribeSubnets");
+   }
+
+   public void modifySubnetAttribute() throws Exception {
+      String region = "us-west-2";
+      enqueueRegions(DEFAULT_REGION);
+      enqueue(DEFAULT_REGION,
+         new MockResponse().setBody("<ModifySubnetAttributeResponse xmlns=\"http://ec2.amazonaws.com/doc/2016-09-15/\">\n" +
+            "  <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>\n" +
+            "  <return>true</return>\n" +
+            "</ModifySubnetAttributeResponse>"));
+
+      final boolean result =
+         subnetApiForRegion(DEFAULT_REGION).modifySubnetAttribute(DEFAULT_REGION, "subnet-9d4a7b6c", mapPublicIpOnLaunch(true));
+      assertTrue(result, "Failed to match expected test result of 'true'");
+      assertPosted(DEFAULT_REGION, "Action=DescribeRegions");
+      assertPosted(DEFAULT_REGION,
+         "Action=ModifySubnetAttribute&SubnetId=subnet-9d4a7b6c&MapPublicIpOnLaunch.Value=true",
+         "2014-06-15");
+
    }
 
    private AWSSubnetApi subnetApi() {

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/internal/BaseAWSEC2ApiMockTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/internal/BaseAWSEC2ApiMockTest.java
@@ -168,7 +168,12 @@ public class BaseAWSEC2ApiMockTest {
       }
    }
 
+
    protected RecordedRequest assertPosted(String region, String postParams) throws InterruptedException {
+      return assertPosted(region, postParams, "2012-06-01");
+   }
+
+   protected RecordedRequest assertPosted(String region, String postParams, String apiVersion) throws InterruptedException {
       RecordedRequest request = regionToServers.get(region).takeRequest();
       assertEquals(request.getMethod(), "POST");
       assertEquals(request.getPath(), "/");
@@ -177,8 +182,8 @@ public class BaseAWSEC2ApiMockTest {
             request.getHeader(AUTHORIZATION)).startsWith("AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20120416/" +
             region + "/ec2/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=");
       String body = new String(request.getBody(), Charsets.UTF_8);
-      assertThat(body).contains("&Version=2012-06-01");
-      assertEquals(body.replace("&Version=2012-06-01", ""), postParams);
+      assertThat(body).contains("&Version=" + apiVersion);
+      assertEquals(body.replace("&Version=" + apiVersion, ""), postParams);
       return request;
    }
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/jclouds/jclouds/pull/1091#issuecomment-299202429.

>   +1 to merging this but I have been trying this out and I think we will need to extend it for practical purposes; if you want to create a VPC and subnet and then depl>oy a machine on to it, you also need to jump through a few other hoops apart from creating the subnet:
>   
>   modify the subnet attributes to permit auto-assign public IP ("ModifySubnetAttribute")
>   create an Internet Gateway on the VPC ("CreateInternetGateway")
>   get and then modify the routing table of the subnet to add a public (0.0.0.0/0) route through the newly added gateway ("CreateRoute" and friends)
>   But as mentioned let's merge this as-is, and do any such new stuff as a new PR!

This PR adds the capability to modify the subnet to auto-assign the public IP via `ModifySubnetAttribute`.

It turned out that the `ModifySubnetAttribute` is a method that has been added to the AWS API subsequent to the version `2012-06-01` of the other subnet methods; to allow the selective specification of a different version I am proposing in this PR the introduction of a new annotation `ApiVersionOverride`, q.v. and see its use in https://github.com/jclouds/jclouds/compare/master...geomacy:modify-subnet-attribute?expand=1#diff-aa0b3b1bb310c30b9f8fdbab82794412R145

The annotation is processed by `FormSignerV4`; should I do this in `FormSignerV2` as well?

