### PR TITLE
JCLOUDS-1307: Invalidate security groups even if already externally deleted.

### DIFF
--- a/apis/ec2/src/main/java/org/jclouds/ec2/compute/extensions/EC2SecurityGroupExtension.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/compute/extensions/EC2SecurityGroupExtension.java
@@ -172,16 +172,14 @@ public class EC2SecurityGroupExtension implements SecurityGroupExtension {
       String region = parts[0];
       String groupName = parts[1];
 
+      boolean deleted = false;
       if (!client.getSecurityGroupApi().get().describeSecurityGroupsInRegion(region, groupName).isEmpty()) {
          client.getSecurityGroupApi().get().deleteSecurityGroupInRegion(region, groupName);
-         // TODO: test this clear happens
-         groupCreator.invalidate(new RegionNameAndIngressRules(region, groupName, null, false, null));
-         return true;
+         deleted = true;
       }
-
-      return false;
+      groupCreator.invalidate(new RegionNameAndIngressRules(region, groupName, null, false, null));
+      return deleted;
    }
-
 
    @Override
    public SecurityGroup addIpPermission(IpPermission ipPermission, SecurityGroup group) {


### PR DESCRIPTION
Fixes test failures for the tests added in https://github.com/jclouds/jclouds/pull/1110 for ~~`aws-ec2`~~, `ec2`, `cloudstack`. ~~I've tested this on `aws-ec2` only,~~ any help testing it on the rest will be greatly appreciated.

https://issues.apache.org/jira/browse/JCLOUDS-1307