### PR TITLE
JCLOUDS-1304: B2 native prefix and delimiter

### DIFF
--- a/providers/b2/src/main/java/org/jclouds/b2/domain/Action.java
+++ b/providers/b2/src/main/java/org/jclouds/b2/domain/Action.java
@@ -19,6 +19,7 @@ package org.jclouds.b2.domain;
 import com.google.common.base.CaseFormat;
 
 public enum Action {
+   FOLDER,
    UPLOAD,
    HIDE;
 

--- a/providers/b2/src/main/java/org/jclouds/b2/domain/B2ObjectList.java
+++ b/providers/b2/src/main/java/org/jclouds/b2/domain/B2ObjectList.java
@@ -39,13 +39,13 @@ public abstract class B2ObjectList {
    @AutoValue
    public abstract static class Entry {
       public abstract Action action();
-      public abstract String fileId();
+      @Nullable public abstract String fileId();
       public abstract String fileName();
       public abstract long size();
       public abstract Date uploadTimestamp();
 
       @SerializedNames({"action", "fileId", "fileName", "size", "uploadTimestamp"})
-      public static Entry create(Action action, String fileId, String fileName, long size, long uploadTimestamp) {
+      public static Entry create(Action action, @Nullable String fileId, String fileName, long size, long uploadTimestamp) {
          return new AutoValue_B2ObjectList_Entry(action, fileId, fileName, size, new Date(uploadTimestamp));
       }
    }

--- a/providers/b2/src/main/java/org/jclouds/b2/features/ObjectApi.java
+++ b/providers/b2/src/main/java/org/jclouds/b2/features/ObjectApi.java
@@ -120,6 +120,7 @@ public interface ObjectApi {
    @Fallback(NullOnNotFoundOr404.class)
    B2Object downloadFileByName(@PathParam("bucketName") String bucketName, @PathParam("fileName") String fileName, GetOptions options);
 
+   @Deprecated
    @Named("b2_list_file_names")
    @GET
    @Path("/b2api/v1/b2_list_file_names")
@@ -129,6 +130,16 @@ public interface ObjectApi {
    @Produces(APPLICATION_JSON)
    B2ObjectList listFileNames(@PayloadParam("bucketId") String bucketId, @PayloadParam("startFileName") @Nullable String startFileName, @PayloadParam("maxFileCount") @Nullable Integer maxFileCount);
 
+   @Named("b2_list_file_names")
+   @GET
+   @Path("/b2api/v1/b2_list_file_names")
+   @MapBinder(BindToJsonPayload.class)
+   @RequestFilters(RequestAuthorization.class)
+   @Consumes(APPLICATION_JSON)
+   @Produces(APPLICATION_JSON)
+   B2ObjectList listFileNames(@PayloadParam("bucketId") String bucketId, @PayloadParam("startFileName") @Nullable String startFileName, @PayloadParam("maxFileCount") @Nullable Integer maxFileCount, @PayloadParam("prefix") @Nullable String prefix, @Nullable @PayloadParam("delimiter") String delimiter);
+
+   @Deprecated
    @Named("b2_list_file_versions")
    @GET
    @Path("/b2api/v1/b2_list_file_versions")
@@ -137,6 +148,15 @@ public interface ObjectApi {
    @Consumes(APPLICATION_JSON)
    @Produces(APPLICATION_JSON)
    B2ObjectList listFileVersions(@PayloadParam("bucketId") String bucketId, @PayloadParam("startFileId") @Nullable String startFileId, @PayloadParam("startFileName") @Nullable String startFileName, @PayloadParam("maxFileCount") @Nullable Integer maxFileCount);
+
+   @Named("b2_list_file_versions")
+   @GET
+   @Path("/b2api/v1/b2_list_file_versions")
+   @MapBinder(BindToJsonPayload.class)
+   @RequestFilters(RequestAuthorization.class)
+   @Consumes(APPLICATION_JSON)
+   @Produces(APPLICATION_JSON)
+   B2ObjectList listFileVersions(@PayloadParam("bucketId") String bucketId, @PayloadParam("startFileId") @Nullable String startFileId, @PayloadParam("startFileName") @Nullable String startFileName, @PayloadParam("maxFileCount") @Nullable Integer maxFileCount, @PayloadParam("prefix") @Nullable String prefix, @PayloadParam("delimiter") @Nullable String delimiter);
 
    @Named("b2_hide_file")
    @POST

--- a/providers/b2/src/test/java/org/jclouds/b2/features/ObjectApiLiveTest.java
+++ b/providers/b2/src/test/java/org/jclouds/b2/features/ObjectApiLiveTest.java
@@ -195,7 +195,7 @@ public final class ObjectApiLiveTest extends BaseB2ApiLiveTest {
             uploadFiles.add(createFile(objectApi, response.bucketId(), "file" + i));
          }
 
-         B2ObjectList list = objectApi.listFileNames(response.bucketId(), null, null);
+         B2ObjectList list = objectApi.listFileNames(response.bucketId(), null, null, null, null);
          assertThat(list.files()).hasSize(numFiles);
       } finally {
          for (UploadFileResponse uploadFile : uploadFiles.build()) {
@@ -218,10 +218,10 @@ public final class ObjectApiLiveTest extends BaseB2ApiLiveTest {
             uploadFiles.add(createFile(objectApi, response.bucketId(), "file"));
          }
 
-         B2ObjectList list = objectApi.listFileNames(response.bucketId(), null, null);
+         B2ObjectList list = objectApi.listFileNames(response.bucketId(), null, null, null, null);
          assertThat(list.files()).hasSize(1);
 
-         list = objectApi.listFileVersions(response.bucketId(), null, null, null);
+         list = objectApi.listFileVersions(response.bucketId(), null, null, null, null, null);
          assertThat(list.files()).hasSize(numFiles);
       } finally {
          for (UploadFileResponse uploadFile : uploadFiles.build()) {
@@ -243,15 +243,15 @@ public final class ObjectApiLiveTest extends BaseB2ApiLiveTest {
       try {
          uploadFile = createFile(objectApi, response.bucketId(), fileName);
 
-         B2ObjectList list = objectApi.listFileNames(response.bucketId(), null, null);
+         B2ObjectList list = objectApi.listFileNames(response.bucketId(), null, null, null, null);
          assertThat(list.files()).hasSize(1);
 
          hideFile = objectApi.hideFile(response.bucketId(), fileName);
 
-         list = objectApi.listFileNames(response.bucketId(), null, null);
+         list = objectApi.listFileNames(response.bucketId(), null, null, null, null);
          assertThat(list.files()).isEmpty();
 
-         list = objectApi.listFileVersions(response.bucketId(), null, null, null);
+         list = objectApi.listFileVersions(response.bucketId(), null, null, null, null, null);
          assertThat(list.files()).hasSize(2);
       } finally {
          if (hideFile != null) {

--- a/providers/b2/src/test/java/org/jclouds/b2/features/ObjectApiMockTest.java
+++ b/providers/b2/src/test/java/org/jclouds/b2/features/ObjectApiMockTest.java
@@ -340,7 +340,7 @@ public final class ObjectApiMockTest {
          ObjectApi api = api(server.getUrl("/").toString(), "b2").getObjectApi();
          String accountId = "d522aa47a10f";
 
-         B2ObjectList list = api.listFileNames(BUCKET_ID, null, null);
+         B2ObjectList list = api.listFileNames(BUCKET_ID, null, null, null, null);
 
          assertThat(list.nextFileName()).isNull();
          assertThat(list.files()).hasSize(2);
@@ -376,7 +376,7 @@ public final class ObjectApiMockTest {
          ObjectApi api = api(server.getUrl("/").toString(), "b2").getObjectApi();
          String accountId = "d522aa47a10f";
 
-         B2ObjectList list = api.listFileVersions(BUCKET_ID, null, null, null);
+         B2ObjectList list = api.listFileVersions(BUCKET_ID, null, null, null, null, null);
 
          assertThat(list.nextFileId()).isEqualTo("4_z27c88f1d182b150646ff0b16_f100920ddab886247_d20150809_m232316_c100_v0009990_t0003");
          assertThat(list.nextFileName()).isEqualTo("files/world.txt");


### PR DESCRIPTION
Previously B2 emulated prefix and delimiter via client-side filtering.
Enabled by recent service additions.