### PR TITLE
JCLOUDS-1321: Use separate credential stores per context

### DIFF
--- a/core/src/main/java/org/jclouds/rest/config/CredentialStoreModule.java
+++ b/core/src/main/java/org/jclouds/rest/config/CredentialStoreModule.java
@@ -42,7 +42,6 @@ import com.google.inject.TypeLiteral;
 @Beta
 @ConfiguresCredentialStore
 public class CredentialStoreModule extends AbstractModule {
-   private static final Map<String, ByteSource> BACKING = new ConcurrentHashMap<String, ByteSource>();
    private final Map<String, ByteSource> backing;
 
    public CredentialStoreModule(Map<String, ByteSource> backing) {
@@ -50,7 +49,7 @@ public class CredentialStoreModule extends AbstractModule {
    }
 
    public CredentialStoreModule() {
-      this(null);
+      this(new ConcurrentHashMap<String, ByteSource>());
    }
 
    @Override
@@ -59,13 +58,8 @@ public class CredentialStoreModule extends AbstractModule {
       }).to(CredentialsToJsonByteSource.class);
       bind(new TypeLiteral<Function<ByteSource, Credentials>>() {
       }).to(CredentialsFromJsonByteSource.class);
-      if (backing != null) {
-         bind(new TypeLiteral<Map<String, ByteSource>>() {
-         }).toInstance(backing);
-      } else {
-         bind(new TypeLiteral<Map<String, ByteSource>>() {
-         }).toInstance(BACKING);
-      }
+      bind(new TypeLiteral<Map<String, ByteSource>>() {
+      }).toInstance(backing);
    }
 
    public static class CredentialsToJsonByteSource implements Function<Credentials, ByteSource> {

--- a/core/src/test/java/org/jclouds/rest/CredentialStoreModuleTest.java
+++ b/core/src/test/java/org/jclouds/rest/CredentialStoreModuleTest.java
@@ -95,34 +95,38 @@ public class CredentialStoreModuleTest {
 
    }
 
-   public void testDefaultConsistentAcrossMultipleInjectors() throws IOException {
-      Map<String, ByteSource> map = getMap(createInjector());
+   public void testDefaultDifferentAcrossMultipleInjectors() throws IOException {
+      Injector injector = createInjector();
+      Map<String, ByteSource> map = getMap(injector);
+      put(map, getStore(injector), "test", new Credentials("user", "pass"));
 
-      put(map, getStore(createInjector()), "test", new Credentials("user", "pass"));
-      checkConsistent(map, getStore(createInjector()), "test", new Credentials("user", "pass"));
-      checkConsistent(map, getStore(createInjector()), "test", new Credentials("user", "pass"));
-      remove(map, getStore(createInjector()), "test");
-
+      Map<String, Credentials> anotherStore = getStore(createInjector());
+      assertEquals(anotherStore.size(), 0);
+      assertFalse(anotherStore.containsKey("test"));
    }
 
-   public void testLoginConsistentAcrossMultipleInjectorsAndLooksNice() throws IOException {
-      Map<String, ByteSource> map = getMap(createInjector());
+   public void testLoginDifferentAcrossMultipleInjectorsAndLooksNice() throws IOException {
+      Injector injector = createInjector();
+      Map<String, ByteSource> map = getMap(injector);
       LoginCredentials creds = LoginCredentials.builder().user("user").password("pass").build();
-      put(map, getStore(createInjector()), "test", creds);
-      checkConsistent(map, getStore(createInjector()), "test", creds, "{\"user\":\"user\",\"password\":\"pass\"}");
-      checkConsistent(map, getStore(createInjector()), "test", creds, "{\"user\":\"user\",\"password\":\"pass\"}");
-      remove(map, getStore(createInjector()), "test");
+      Map<String, Credentials> store = getStore(injector);
+      put(map, store, "test", creds);
+      checkConsistent(map, store, "test", creds, "{\"user\":\"user\",\"password\":\"pass\"}");
+      checkConsistent(map, store, "test", creds, "{\"user\":\"user\",\"password\":\"pass\"}");
+      remove(map, store, "test");
    }
 
-   public void testLoginConsistentAcrossMultipleInjectorsAndLooksNiceWithSudo() throws IOException {
-      Map<String, ByteSource> map = getMap(createInjector());
+   public void testLoginDifferentAcrossMultipleInjectorsAndLooksNiceWithSudo() throws IOException {
+      Injector injector = createInjector();
+      Map<String, ByteSource> map = getMap(injector);
       LoginCredentials creds = LoginCredentials.builder().user("user").password("pass").authenticateSudo(true).build();
-      put(map, getStore(createInjector()), "test", creds);
-      checkConsistent(map, getStore(createInjector()), "test", creds,
+      Map<String, Credentials> store = getStore(injector);
+      put(map, store, "test", creds);
+      checkConsistent(map, store, "test", creds,
             "{\"user\":\"user\",\"password\":\"pass\",\"authenticateSudo\":true}");
-      checkConsistent(map, getStore(createInjector()), "test", creds,
+      checkConsistent(map, store, "test", creds,
             "{\"user\":\"user\",\"password\":\"pass\",\"authenticateSudo\":true}");
-      remove(map, getStore(createInjector()), "test");
+      remove(map, store, "test");
    }
 
    public void testCredentialsToByteSourceConversion() throws Exception {


### PR DESCRIPTION
With a shared credential store the configuration of one compute service leaks in all others, causing the wrong credentials to be used when not overridden.

The particular problem this fixes - [Azure sets default username/password for images](https://github.com/jclouds/jclouds-labs/blob/master/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/AzureComputeProviderMetadata.java#L98) which leaks to other providers (through [GetLoginForProviderFromPropertiesAndStoreCredentialsOrReturnNull](https://github.com/jclouds/jclouds/blob/master/compute/src/main/java/org/jclouds/compute/config/GetLoginForProviderFromPropertiesAndStoreCredentialsOrReturnNull.java#L51)), causing the wrong username/password to be used.
Even if the credentials are scoped to a specific provider in the map, it still will cause cross-talk between differently configured compute services. The cache should only apply to the current compute service.