### PR TITLE
Make sure Jetty doesn't terminate on ssh disconnect

### DIFF
--- a/compute/src/test/java/org/jclouds/compute/JettyStatements.java
+++ b/compute/src/test/java/org/jclouds/compute/JettyStatements.java
@@ -57,7 +57,7 @@ public class JettyStatements {
    
    public static Statement start() {
       return new StatementList(
-            literal(String.format("JETTY_PORT=%d %s/bin/jetty.sh start", port, JETTY_HOME)),
+            literal(String.format("JETTY_PORT=%d nohup %s/bin/jetty.sh start > start.log 2>&1 < /dev/null &", port, JETTY_HOME)),
             literal("test $? && sleep 1")); // in case it is slow starting the proc
    }
    

--- a/compute/src/test/java/org/jclouds/compute/StubComputeServiceIntegrationTest.java
+++ b/compute/src/test/java/org/jclouds/compute/StubComputeServiceIntegrationTest.java
@@ -303,7 +303,7 @@ public class StubComputeServiceIntegrationTest extends BaseComputeServiceLiveTes
                clientNew.disconnect();
 
                String startJetty = new StringBuilder()
-                  .append("JETTY_PORT=8080 /usr/local/jetty/bin/jetty.sh start").append('\n')
+                  .append("JETTY_PORT=8080 nohup /usr/local/jetty/bin/jetty.sh start > start.log 2>&1 < /dev/null &").append('\n')
                   .append("test $? && sleep 1").append('\n').toString();
 
                clientNew.connect();


### PR DESCRIPTION
Fixes `BaseComputeServiceAdapterLiveTest.testCreateAndRunAService` for CentOS 7. `disown` in `jetty.sh` is not enough to detach the process from the current session so it's terminated when jclouds closes the connection.