### PR TITLE
Move Passwords implementation to jclouds-core to be reused by providers

### DIFF
--- a/core/src/main/java/org/jclouds/util/Passwords.java
+++ b/core/src/main/java/org/jclouds/util/Passwords.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jclouds.profitbricks.util;
+package org.jclouds.util;
 
 import java.util.Random;
 import java.util.regex.Pattern;

--- a/core/src/test/java/org/jclouds/util/PasswordsTest.java
+++ b/core/src/test/java/org/jclouds/util/PasswordsTest.java
@@ -14,14 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jclouds.profitbricks.util;
+package org.jclouds.util;
 
 import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
 import java.util.List;
-import static org.jclouds.profitbricks.util.Passwords.isValidPassword;
+
+import static org.jclouds.util.Passwords.isValidPassword;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
-import org.testng.annotations.Test;
 
 @Test(groups = "unit", testName = "PasswordsTest")
 public class PasswordsTest {

--- a/providers/profitbricks/src/main/java/org/jclouds/profitbricks/compute/ProfitBricksComputeServiceAdapter.java
+++ b/providers/profitbricks/src/main/java/org/jclouds/profitbricks/compute/ProfitBricksComputeServiceAdapter.java
@@ -59,7 +59,6 @@ import org.jclouds.profitbricks.domain.Server;
 import org.jclouds.profitbricks.domain.Snapshot;
 import org.jclouds.profitbricks.domain.Storage;
 import org.jclouds.profitbricks.features.ServerApi;
-import org.jclouds.profitbricks.util.Passwords;
 import org.jclouds.rest.ResourceNotFoundException;
 
 import com.google.common.base.Function;
@@ -72,6 +71,7 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.inject.Inject;
+import org.jclouds.util.Passwords;
 
 @Singleton
 public class ProfitBricksComputeServiceAdapter implements ComputeServiceAdapter<Server, Hardware, Provisionable, Location> {

--- a/providers/profitbricks/src/main/java/org/jclouds/profitbricks/util/Preconditions.java
+++ b/providers/profitbricks/src/main/java/org/jclouds/profitbricks/util/Preconditions.java
@@ -21,7 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.net.InetAddresses.isInetAddress;
 import static org.jclouds.profitbricks.util.MacAddresses.isMacAddress;
-import static org.jclouds.profitbricks.util.Passwords.isValidPassword;
+import static org.jclouds.util.Passwords.isValidPassword;
 
 import java.util.List;
 import java.util.regex.Pattern;


### PR DESCRIPTION
As discussed in https://github.com/jclouds/jclouds-labs/pull/402