### PR TITLE
JCLOUDS-1325: Ignore Unicode BOM in XML parser

### DIFF
--- a/core/src/main/java/org/jclouds/http/functions/ParseXMLWithJAXB.java
+++ b/core/src/main/java/org/jclouds/http/functions/ParseXMLWithJAXB.java
@@ -82,7 +82,8 @@ public class ParseXMLWithJAXB<T> implements Function<HttpResponse, T> {
 
    public <V> V apply(final InputStream stream, final Class<V> type) throws IOException {
       try {
-         return xml.fromXML(Strings2.toStringAndClose(stream), type);
+         String str = Strings2.toStringAndClose(stream);
+         return xml.fromXML(str, type);
       } finally {
          if (stream != null) {
             stream.close();

--- a/core/src/main/java/org/jclouds/xml/internal/JAXBParser.java
+++ b/core/src/main/java/org/jclouds/xml/internal/JAXBParser.java
@@ -70,7 +70,11 @@ public class JAXBParser implements XMLParser {
 
    @SuppressWarnings("unchecked")
    @Override
-   public <T> T fromXML(final String xml, final Class<T> type) throws IOException {
+   public <T> T fromXML(String xml, final Class<T> type) throws IOException {
+      // ignore byte order mark
+      if (xml.charAt(0) == 0xFEFF) {
+         xml = xml.substring(1);
+      }
       try {
          StringReader reader = new StringReader(xml);
          JAXBContext context = JAXBContext.newInstance(type);

--- a/core/src/test/java/org/jclouds/rest/binders/BindToXMLPayloadTest.java
+++ b/core/src/test/java/org/jclouds/rest/binders/BindToXMLPayloadTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.rest.binders;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -80,6 +81,13 @@ public class BindToXMLPayloadTest {
       BindToXMLPayload binder = new BindToXMLPayload(xml);
       HttpRequest request = HttpRequest.builder().method("GET").endpoint("http://momma").build();
       request = binder.bindToRequest(request, new Object());
+   }
+
+   @Test
+   public void testJAXBParserBOM() throws Exception {
+      String input = "\uFEFF<test><elem>foo</elem></test>";
+      TestJAXBDomain obj = xml.fromXML(input, TestJAXBDomain.class);
+      assertThat(obj.getElem()).isEqualTo("foo");
    }
 
    @XmlRootElement(name = "test")


### PR DESCRIPTION
This caused failures to parse Azure Queue Storage list requests.