### PR TITLE
JCLOUDS-769: streaming putBlob

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/S3Client.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/S3Client.java
@@ -43,7 +43,9 @@ import org.jclouds.blobstore.BlobStoreFallbacks.ThrowContainerNotFoundOn404;
 import org.jclouds.blobstore.BlobStoreFallbacks.ThrowKeyNotFoundOn404;
 import org.jclouds.blobstore.attr.BlobScope;
 import org.jclouds.http.functions.ParseETagHeader;
+import org.jclouds.http.functions.ReturnOutputStream;
 import org.jclouds.http.options.GetOptions;
+import org.jclouds.io.ETagOutputStream;
 import org.jclouds.io.Payload;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.rest.annotations.BinderParam;
@@ -268,6 +270,16 @@ public interface S3Client extends Closeable {
    @Headers(keys = EXPECT, values = "100-continue")
    @ResponseParser(ParseETagHeader.class)
    String putObject(@Bucket @EndpointParam(parser = AssignCorrectHostnameForBucket.class) @BinderParam(
+         BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName,
+         @PathParam("key") @ParamParser(ObjectKey.class) @BinderParam(BindS3ObjectMetadataToRequest.class)
+         S3Object object, PutObjectOptions... options);
+
+   @Named("PutObject")
+   @PUT
+   @Path("/{key}")
+   @Headers(keys = EXPECT, values = "100-continue")
+   @ResponseParser(ReturnOutputStream.class)
+   ETagOutputStream putObjectStreaming(@Bucket @EndpointParam(parser = AssignCorrectHostnameForBucket.class) @BinderParam(
          BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName,
          @PathParam("key") @ParamParser(ObjectKey.class) @BinderParam(BindS3ObjectMetadataToRequest.class)
          S3Object object, PutObjectOptions... options);

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobStore.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobStore.java
@@ -51,6 +51,7 @@ import org.jclouds.collect.Memoized;
 import org.jclouds.domain.Location;
 import org.jclouds.http.options.GetOptions;
 import org.jclouds.io.ContentMetadata;
+import org.jclouds.io.ETagOutputStream;
 import org.jclouds.io.Payload;
 import org.jclouds.io.PayloadSlicer;
 import org.jclouds.s3.S3Client;
@@ -269,6 +270,17 @@ public class S3BlobStore extends BaseBlobStore {
       // TODO: S3 does not allow putObject if Tier.ARCHIVE.  Instead, copyBlob
       // after putBlob when the former supports tiers.
       return sync.putObject(container, blob2Object.apply(blob), options);
+   }
+
+   @Override
+   public ETagOutputStream putBlobStreaming(String container, Blob blob, PutOptions overrides) {
+      // TODO: multipart?
+
+      PutObjectOptions options = new PutObjectOptions();
+      if (overrides.getBlobAccess() == BlobAccess.PUBLIC_READ) {
+         options = options.withAcl(CannedAccessPolicy.PUBLIC_READ);
+      }
+      return sync.putObjectStreaming(container, blob2Object.apply(blob), options);
    }
 
    @Override

--- a/blobstore/src/main/java/org/jclouds/blobstore/BlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/BlobStore.java
@@ -37,6 +37,7 @@ import org.jclouds.blobstore.options.GetOptions;
 import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.blobstore.options.PutOptions;
 import org.jclouds.domain.Location;
+import org.jclouds.io.ETagOutputStream;
 import org.jclouds.io.Payload;
 import org.jclouds.javax.annotation.Nullable;
 
@@ -242,6 +243,8 @@ public interface BlobStore {
     *            if the container doesn't exist
     */
    String putBlob(String container, Blob blob, PutOptions options);
+
+   ETagOutputStream putBlobStreaming(String container, Blob blob, PutOptions options);
 
    /**
     * Copy blob from one container to another.  Some providers implement this

--- a/blobstore/src/main/java/org/jclouds/blobstore/LocalStorageStrategy.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/LocalStorageStrategy.java
@@ -25,7 +25,9 @@ import org.jclouds.blobstore.domain.ContainerAccess;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.options.CreateContainerOptions;
 import org.jclouds.blobstore.options.ListContainerOptions;
+import org.jclouds.blobstore.options.PutOptions;
 import org.jclouds.domain.Location;
+import org.jclouds.io.ETagOutputStream;
 
 /**
  * Strategy for local operations related to container and blob
@@ -122,6 +124,8 @@ public interface LocalStorageStrategy {
      * @throws IOException
      */
     String putBlob(String containerName, Blob blob) throws IOException;
+
+    ETagOutputStream putBlobStreaming(String container, Blob blob, PutOptions options);
 
     /**
      * Remove blob named by the given key

--- a/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
@@ -83,6 +83,7 @@ import org.jclouds.http.HttpUtils;
 import org.jclouds.io.ByteStreams2;
 import org.jclouds.io.ContentMetadata;
 import org.jclouds.io.ContentMetadataCodec;
+import org.jclouds.io.ETagOutputStream;
 import org.jclouds.io.Payload;
 import org.jclouds.io.payloads.InputStreamPayload;
 import org.jclouds.logging.Logger;
@@ -528,6 +529,11 @@ public final class LocalBlobStore implements BlobStore {
    @Override
    public String putBlob(String containerName, Blob blob) {
       return putBlob(containerName, blob, PutOptions.NONE);
+   }
+
+   @Override
+   public ETagOutputStream putBlobStreaming(String container, Blob blob, PutOptions options) {
+      return storageStrategy.putBlobStreaming(container, blob, options);
    }
 
    @Override

--- a/blobstore/src/main/java/org/jclouds/blobstore/util/ForwardingBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/util/ForwardingBlobStore.java
@@ -44,6 +44,7 @@ import org.jclouds.blobstore.options.GetOptions;
 import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.blobstore.options.PutOptions;
 import org.jclouds.domain.Location;
+import org.jclouds.io.ETagOutputStream;
 import org.jclouds.io.Payload;
 
 public abstract class ForwardingBlobStore extends ForwardingObject
@@ -167,6 +168,11 @@ public abstract class ForwardingBlobStore extends ForwardingObject
    public String putBlob(String containerName, Blob blob,
          PutOptions putOptions) {
       return delegate().putBlob(containerName, blob, putOptions);
+   }
+
+   @Override
+   public ETagOutputStream putBlobStreaming(String containerName, Blob blob, PutOptions options) {
+      return delegate().putBlobStreaming(containerName, blob, options);
    }
 
    @Override

--- a/core/src/main/java/org/jclouds/http/HttpRequest.java
+++ b/core/src/main/java/org/jclouds/http/HttpRequest.java
@@ -61,6 +61,7 @@ public class HttpRequest extends HttpMessage {
       protected String method;
       protected URI endpoint;
       protected ImmutableList.Builder<HttpRequestFilter> filters = ImmutableList.<HttpRequestFilter>builder();
+      protected boolean returnOutputStream;
    
       /** 
        * @see HttpRequest#getMethod()
@@ -215,15 +216,21 @@ public class HttpRequest extends HttpMessage {
          return self();
       }
 
+      public T returnOutputStream(boolean returnOutputStream) {
+         this.returnOutputStream = returnOutputStream;
+         return self();
+      }
+
       public HttpRequest build() {
-         return new HttpRequest(method, endpoint, headers.build(), payload, filters.build());
+         return new HttpRequest(method, endpoint, headers.build(), payload, filters.build(), returnOutputStream);
       }
       
       public T fromHttpRequest(HttpRequest in) {
          return super.fromHttpMessage(in)
                      .method(in.getMethod())
                      .endpoint(in.getEndpoint())
-                     .filters(in.getFilters());
+                     .filters(in.getFilters())
+                     .returnOutputStream(in.returnOutputStream);
       }
    }
 
@@ -237,14 +244,16 @@ public class HttpRequest extends HttpMessage {
    private final String method;
    private final URI endpoint;
    private final List<HttpRequestFilter> filters;
+   private final boolean returnOutputStream;
 
    protected HttpRequest(String method, URI endpoint, Multimap<String, String> headers, @Nullable Payload payload,
-         Iterable<HttpRequestFilter> filters) {
+         Iterable<HttpRequestFilter> filters, boolean returnOutputStream) {
       super(headers, payload);
       this.method = checkNotNull(method, "method");
       this.endpoint = checkNotNull(endpoint, "endpoint");
       checkArgument(endpoint.getHost() != null, "endpoint.getHost() is null for %s", endpoint);
       this.filters = ImmutableList.<HttpRequestFilter> copyOf(checkNotNull(filters, "filters"));
+      this.returnOutputStream = returnOutputStream;
    }
 
    public String getRequestLine() {
@@ -267,6 +276,10 @@ public class HttpRequest extends HttpMessage {
 
    public List<HttpRequestFilter> getFilters() {
       return filters;
+   }
+
+   public boolean returnOutputStream() {
+      return returnOutputStream;
    }
    
    @Override

--- a/core/src/main/java/org/jclouds/http/functions/ReturnOutputStream.java
+++ b/core/src/main/java/org/jclouds/http/functions/ReturnOutputStream.java
@@ -14,16 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jclouds.http;
+package org.jclouds.http.functions;
+
+import javax.inject.Singleton;
+
+import org.jclouds.http.HttpResponse;
+import org.jclouds.io.ETagOutputStream;
+
+import com.google.common.base.Function;
 
 /**
- * Capable of invoking http commands.
+ * Simply returns the OutputStream of the response
  */
-public interface HttpCommandExecutorService {
-
-   /**
-    * Returns a {@code HttpResponse} from the server which responded to the
-    * {@code command}.
-    */
-   Object invoke(HttpCommand command);
+@Singleton
+public final class ReturnOutputStream implements Function<HttpResponse, ETagOutputStream> {
+   @Override
+   public ETagOutputStream apply(HttpResponse from) {
+      // TODO: throw exception instead?
+      return null;
+   }
 }

--- a/core/src/main/java/org/jclouds/http/internal/JavaUrlHttpCommandExecutorService.java
+++ b/core/src/main/java/org/jclouds/http/internal/JavaUrlHttpCommandExecutorService.java
@@ -29,6 +29,7 @@ import static org.jclouds.util.Closeables2.closeQuietly;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
 import java.net.ProtocolException;
@@ -168,7 +169,11 @@ public class JavaUrlHttpCommandExecutorService extends BaseHttpCommandExecutorSe
                } else {
                   setFixedLengthStreamingMode(connection, length);
                }
-               writePayloadToConnection(payload, length, connection);
+               if (request.returnOutputStream()) {
+                  connection.setDoOutput(true);
+               } else {
+                  writePayloadToConnection(payload, length, connection);
+               }
             } else {
                writeNothing(connection);
             }
@@ -302,6 +307,11 @@ public class JavaUrlHttpCommandExecutorService extends BaseHttpCommandExecutorSe
       } finally {
          closeQuietly(is);
       }
+   }
+
+   @Override
+   protected StreamingOutputStream prepareStreamingRequest(HttpURLConnection connection) throws IOException {
+      return new StreamingOutputStream(connection, connection.getOutputStream());
    }
 
    @Override

--- a/core/src/main/java/org/jclouds/http/internal/StreamingOutputStream.java
+++ b/core/src/main/java/org/jclouds/http/internal/StreamingOutputStream.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jclouds.http.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+
+import org.jclouds.io.ETagOutputStream;
+
+// TODO: collapse into ETagOutputStream and rename to HttpRequestOutputStream
+final class StreamingOutputStream extends ETagOutputStream {
+   private final HttpURLConnection connection;
+
+   StreamingOutputStream(HttpURLConnection connection, OutputStream os) {
+      super(os);
+      this.connection = connection;
+   }
+
+   @Override
+   public void close() throws IOException {
+      super.close();
+      InputStream is = connection.getInputStream();
+      try {
+         int responseCode = connection.getResponseCode();
+         setETag(connection.getHeaderField("ETag"));
+         // TODO: if not 2xx, throw HttpResponseException?
+      } finally {
+         is.close();
+         connection.disconnect();
+      }
+   }
+}

--- a/core/src/main/java/org/jclouds/io/ETagOutputStream.java
+++ b/core/src/main/java/org/jclouds/io/ETagOutputStream.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.io;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import java.io.FilterOutputStream;
+import java.io.OutputStream;
+
+import org.jclouds.javax.annotation.Nullable;
+
+/**
+ * ETagOutputStream wraps an OutputStream when a client writes to an HTTP
+ * server.  After clients close the stream, they can get the ETag from the
+ * server.
+ */
+public class ETagOutputStream extends FilterOutputStream {
+   @Nullable
+   private String eTag;
+
+   public ETagOutputStream(OutputStream os) {
+      super(os);
+   }
+
+   /** @return the HTTP response ETag or null */
+   @Nullable
+   public String getETag() {
+      return eTag;
+   }
+
+   public void setETag(String eTag) {
+      checkState(this.eTag == null);
+      this.eTag = checkNotNull(eTag);
+   }
+}

--- a/core/src/main/java/org/jclouds/rest/internal/GeneratedHttpRequest.java
+++ b/core/src/main/java/org/jclouds/rest/internal/GeneratedHttpRequest.java
@@ -60,7 +60,7 @@ public final class GeneratedHttpRequest extends HttpRequest {
       }
 
       public GeneratedHttpRequest build() {
-         return new GeneratedHttpRequest(method, endpoint, headers.build(), payload, filters.build(), invocation,
+         return new GeneratedHttpRequest(method, endpoint, headers.build(), payload, filters.build(), returnOutputStream, invocation,
                caller);
       }
 
@@ -78,9 +78,9 @@ public final class GeneratedHttpRequest extends HttpRequest {
    private final Optional<Invocation> caller;
 
    protected GeneratedHttpRequest(String method, URI endpoint, Multimap<String, String> headers,
-         @Nullable Payload payload, Iterable<HttpRequestFilter> filters, Invocation invocation,
+         @Nullable Payload payload, Iterable<HttpRequestFilter> filters, boolean returnOutputStream, Invocation invocation,
          Optional<Invocation> caller) {
-      super(method, endpoint, headers, payload, filters);
+      super(method, endpoint, headers, payload, filters, returnOutputStream);
       this.invocation = checkNotNull(invocation, "invocation");
       this.caller = checkNotNull(caller, "caller");
    }

--- a/core/src/main/java/org/jclouds/rest/internal/RestAnnotationProcessor.java
+++ b/core/src/main/java/org/jclouds/rest/internal/RestAnnotationProcessor.java
@@ -75,6 +75,7 @@ import org.jclouds.http.filters.StripExpectHeader;
 import org.jclouds.http.options.HttpRequestOptions;
 import org.jclouds.http.utils.QueryValue;
 import org.jclouds.io.ContentMetadataCodec;
+import org.jclouds.io.ETagOutputStream;
 import org.jclouds.io.Payload;
 import org.jclouds.io.PayloadEnclosing;
 import org.jclouds.io.Payloads;
@@ -319,7 +320,9 @@ public class RestAnnotationProcessor implements Function<Invocation, HttpRequest
       List<? extends Part> parts = getParts(invocation, ImmutableMultimap.<String, Object> builder()
             .putAll(tokenValues).putAll(formParams).build());
 
-      if (!parts.isEmpty()) {
+      if (invocation.getInvokable().getReturnType().getRawType().equals(ETagOutputStream.class)) {
+         requestBuilder.returnOutputStream(true);
+      } else if (!parts.isEmpty()) {
          if (!formParams.isEmpty()) {
             parts = newLinkedList(concat(transform(formParams.entries(), ENTRY_TO_PART), parts));
          }
@@ -361,6 +364,7 @@ public class RestAnnotationProcessor implements Function<Invocation, HttpRequest
       request = stripExpectHeaderIfContentZero(request);
 
       utils.checkRequestHasRequiredProperties(request);
+
       return request;
    }
 

--- a/core/src/main/java/org/jclouds/rest/internal/TransformerForRequest.java
+++ b/core/src/main/java/org/jclouds/rest/internal/TransformerForRequest.java
@@ -21,6 +21,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.net.URI;
@@ -42,6 +43,7 @@ import org.jclouds.http.functions.ParseURIFromListOrLocationHeaderIf20x;
 import org.jclouds.http.functions.ParseXMLWithJAXB;
 import org.jclouds.http.functions.ReleasePayloadAndReturn;
 import org.jclouds.http.functions.ReturnInputStream;
+import org.jclouds.http.functions.ReturnOutputStream;
 import org.jclouds.http.functions.ReturnStringIf2xx;
 import org.jclouds.http.functions.ReturnTrueIf2xx;
 import org.jclouds.http.functions.UnwrapOnlyJsonValue;
@@ -118,6 +120,8 @@ public class TransformerForRequest implements Function<HttpRequest, Function<Htt
             return Key.get(ReturnTrueIf2xx.class);
          } else if (rawReturnType.equals(InputStream.class)) {
             return Key.get(ReturnInputStream.class);
+         } else if (rawReturnType.equals(OutputStream.class)) {
+            return Key.get(ReturnOutputStream.class);
          } else if (rawReturnType.equals(HttpResponse.class)) {
             return Key.get(Class.class.cast(IdentityFunction.class));
          } else if (acceptHeaders.contains(APPLICATION_JSON)) {

--- a/core/src/test/java/org/jclouds/http/internal/TrackingJavaUrlHttpCommandExecutorService.java
+++ b/core/src/test/java/org/jclouds/http/internal/TrackingJavaUrlHttpCommandExecutorService.java
@@ -100,7 +100,7 @@ public class TrackingJavaUrlHttpCommandExecutorService extends JavaUrlHttpComman
    }
 
    @Override
-   public HttpResponse invoke(HttpCommand command) {
+   public Object invoke(HttpCommand command) {
       commandsInvoked.add(command);
       return super.invoke(command);
    }

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/AzureBlobClient.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/AzureBlobClient.java
@@ -72,8 +72,10 @@ import org.jclouds.blobstore.BlobStoreFallbacks.NullOnContainerNotFound;
 import org.jclouds.blobstore.BlobStoreFallbacks.NullOnKeyNotFound;
 import org.jclouds.blobstore.binders.BindMapToHeadersWithPrefix;
 import org.jclouds.http.functions.ParseETagHeader;
+import org.jclouds.http.functions.ReturnOutputStream;
 import org.jclouds.http.options.GetOptions;
 import org.jclouds.io.ContentMetadata;
+import org.jclouds.io.ETagOutputStream;
 import org.jclouds.io.Payload;
 import org.jclouds.rest.annotations.BinderParam;
 import org.jclouds.rest.annotations.Fallback;
@@ -337,6 +339,14 @@ public interface AzureBlobClient extends Closeable {
          @PathParam("name") @ParamParser(BlobName.class) @BinderParam(BindAzureBlobMetadataToRequest.class)
          AzureBlob object);
 
+   @Named("PutBlob")
+   @PUT
+   @Path("{container}/{name}")
+   @Headers(keys = EXPECT, values = "100-continue")
+   @ResponseParser(ReturnOutputStream.class)
+   ETagOutputStream putBlobStreaming(@PathParam("container") @ParamValidators(ContainerNameValidator.class) String container,
+         @PathParam("name") @ParamParser(BlobName.class) @BinderParam(BindAzureBlobMetadataToRequest.class)
+         AzureBlob object);
 
    /**
     * The Get Blob operation reads or downloads a blob from the system, including its metadata and

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/AzureBlobStore.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/AzureBlobStore.java
@@ -73,6 +73,7 @@ import org.jclouds.collect.Memoized;
 import org.jclouds.domain.Location;
 import org.jclouds.http.options.GetOptions;
 import org.jclouds.io.ContentMetadata;
+import org.jclouds.io.ETagOutputStream;
 import org.jclouds.io.MutableContentMetadata;
 import org.jclouds.io.PayloadSlicer;
 
@@ -244,6 +245,16 @@ public class AzureBlobStore extends BaseBlobStore {
          sync.setBlobTier(container, blob.getMetadata().getName(), AccessTier.fromTier(tier));
       }
       return eTag;
+   }
+
+   @Override
+   public ETagOutputStream putBlobStreaming(String container, Blob blob, PutOptions options) {
+      // TODO: multipart
+      // TODO: options
+      if (options.getBlobAccess() != BlobAccess.PRIVATE) {
+         throw new UnsupportedOperationException("blob access not supported by Azure");
+      }
+      return sync.putBlobStreaming(container, blob2AzureBlob.apply(blob));
    }
 
    @Override

--- a/providers/b2/src/main/java/org/jclouds/b2/features/ObjectApi.java
+++ b/providers/b2/src/main/java/org/jclouds/b2/features/ObjectApi.java
@@ -45,6 +45,8 @@ import org.jclouds.b2.domain.UploadUrlResponse;
 import org.jclouds.b2.filters.RequestAuthorization;
 import org.jclouds.b2.filters.RequestAuthorizationDownload;
 import org.jclouds.b2.functions.ParseB2ObjectFromResponse;
+import org.jclouds.http.functions.ReturnOutputStream;
+import org.jclouds.io.ETagOutputStream;
 import org.jclouds.rest.annotations.Fallback;
 import org.jclouds.rest.annotations.MapBinder;
 import org.jclouds.rest.annotations.PayloadParam;
@@ -68,6 +70,13 @@ public interface ObjectApi {
    @MapBinder(UploadFileBinder.class)
    @Consumes(APPLICATION_JSON)
    UploadFileResponse uploadFile(@PayloadParam("uploadUrl") UploadUrlResponse uploadUrl, @PayloadParam("fileName") String fileName, @Nullable @PayloadParam("contentSha1") String contentSha1, @PayloadParam("fileInfo") Map<String, String> fileInfo, Payload payload);
+
+   @Named("b2_upload_file")
+   @POST
+   @MapBinder(UploadFileBinder.class)
+   @Consumes(APPLICATION_JSON)
+   @ResponseParser(ReturnOutputStream.class)
+   ETagOutputStream uploadFileStreaming(@PayloadParam("uploadUrl") UploadUrlResponse uploadUrl, @PayloadParam("fileName") String fileName, @Nullable @PayloadParam("contentSha1") String contentSha1, @PayloadParam("fileInfo") Map<String, String> fileInfo, Payload payload);
 
    @Named("b2_delete_file_version")
    @POST


### PR DESCRIPTION
This allows clients to write their payloads via an OutputStream
instead of providing an InputStream during construction.  This can
avoid buffering in some situations although one must still provide the
Content-Length.