### PR TITLE
Upgrade auto-service to 1.0rc3 and make dependency optional

### DIFF
--- a/apis/docker/pom.xml
+++ b/apis/docker/pom.xml
@@ -64,6 +64,7 @@
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>

--- a/apis/rackspace-cloudfiles/pom.xml
+++ b/apis/rackspace-cloudfiles/pom.xml
@@ -120,6 +120,7 @@
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -230,7 +230,7 @@
     <assertj-core.version>1.7.0</assertj-core.version>
     <assertj-guava.version>1.3.0</assertj-guava.version>
     <auto-factory.version>0.1-beta1</auto-factory.version>
-    <auto-service.version>1.0-rc2</auto-service.version>
+    <auto-service.version>1.0-rc3</auto-service.version>
     <auto-value.version>1.4.1</auto-value.version>
     <java-xmlbuilder.version>1.1</java-xmlbuilder.version>
     <osgi.version>4.2.0</osgi.version>

--- a/providers/digitalocean2/pom.xml
+++ b/providers/digitalocean2/pom.xml
@@ -124,6 +124,7 @@
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
   </dependencies>
   <profiles>

--- a/providers/google-cloud-storage/pom.xml
+++ b/providers/google-cloud-storage/pom.xml
@@ -80,6 +80,7 @@
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.google.auto.value</groupId>

--- a/providers/google-compute-engine/pom.xml
+++ b/providers/google-compute-engine/pom.xml
@@ -91,6 +91,7 @@
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.google.auto.value</groupId>

--- a/providers/packet/pom.xml
+++ b/providers/packet/pom.xml
@@ -50,6 +50,7 @@
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.google.auto.value</groupId>

--- a/providers/profitbricks/pom.xml
+++ b/providers/profitbricks/pom.xml
@@ -60,6 +60,7 @@
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.google.auto.value</groupId>

--- a/providers/rackspace-cloudfiles-uk/pom.xml
+++ b/providers/rackspace-cloudfiles-uk/pom.xml
@@ -120,6 +120,7 @@
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/providers/rackspace-cloudfiles-us/pom.xml
+++ b/providers/rackspace-cloudfiles-us/pom.xml
@@ -120,6 +120,7 @@
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This makes dependencies consistent and eliminates warnings of the
form:

```
$M2_HOME/repository/org/apache/jclouds/driver/jclouds-slf4j/2.1.0-SNAPSHOT/jclouds-slf4j-2.1.0-SNAPSHOT.jar(org/jclouds/logging/slf4j/config/SLF4JLoggingModule.class): warning: Cannot find annotation method 'value()' in type 'AutoService': class file for com.google.auto.service.AutoService not found
```

Reference:

https://github.com/google/auto/tree/master/service#download