### PR TITLE
JCLOUDS-1333: Correct JDK 1.8 method overloading

### DIFF
--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/binders/BindAuthToJsonPayload.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/binders/BindAuthToJsonPayload.java
@@ -42,11 +42,6 @@ public class BindAuthToJsonPayload extends BindToJsonPayload implements MapBinde
       super(jsonBinder);
    }
 
-   @Override
-   public <R extends HttpRequest> R bindToRequest(R request, Object toBind) {
-      throw new IllegalStateException("BindAuthToJsonPayload needs parameters");
-   }
-
    protected void addCredentialsInArgsOrNull(GeneratedHttpRequest gRequest, Builder<String, Object> builder) {
       for (Object arg : Iterables.filter(gRequest.getInvocation().getArgs(), Predicates.notNull())) {
          if (arg.getClass().isAnnotationPresent(CredentialType.class)) {

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/options/CreateTenantOptions.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/options/CreateTenantOptions.java
@@ -88,7 +88,7 @@ public class CreateTenantOptions implements MapBinder {
          tenant.description = description;
       tenant.enabled = enabled;
 
-      return bindToRequest(request, ImmutableMap.of("tenant", tenant));
+      return bindToRequest(request, (Object) ImmutableMap.of("tenant", tenant));
    }
 
    /**

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/options/CreateUserOptions.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/options/CreateUserOptions.java
@@ -101,7 +101,7 @@ public class CreateUserOptions implements MapBinder{
          user.tenantId = tenant;
       user.enabled = enabled;
 
-      return bindToRequest(request, ImmutableMap.of("user", user));
+      return bindToRequest(request, (Object) ImmutableMap.of("user", user));
    }
 
    /**

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/options/UpdateTenantOptions.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/options/UpdateTenantOptions.java
@@ -86,7 +86,7 @@ public class UpdateTenantOptions implements MapBinder {
          tenant.name = name;
       tenant.enabled = enabled;
 
-      return bindToRequest(request, ImmutableMap.of("tenant", tenant));
+      return bindToRequest(request, (Object) ImmutableMap.of("tenant", tenant));
    }
 
    /**

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/options/UpdateUserOptions.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/options/UpdateUserOptions.java
@@ -93,7 +93,7 @@ public class UpdateUserOptions implements MapBinder{
          user.password = password;
       user.enabled = enabled;
 
-      return bindToRequest(request, ImmutableMap.of("user", user));
+      return bindToRequest(request, (Object) ImmutableMap.of("user", user));
    }
 
    /**

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/binders/BindSecurityGroupRuleToJsonPayload.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/binders/BindSecurityGroupRuleToJsonPayload.java
@@ -44,11 +44,6 @@ public class BindSecurityGroupRuleToJsonPayload extends BindToJsonPayload implem
    }
 
    @Override
-   public <R extends HttpRequest> R bindToRequest(R request, Object toBind) {
-      throw new IllegalStateException("BindCredentialsToJsonPayload needs parameters");
-   }
-
-   @Override
    public <R extends HttpRequest> R bindToRequest(R request, Map<String, Object> postParams) {
       Builder<String, Object> payload = ImmutableMap.builder();
       payload.putAll(postParams);

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/options/CreateServerOptions.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/options/CreateServerOptions.java
@@ -253,7 +253,7 @@ public class CreateServerOptions implements MapBinder {
          server.blockDeviceMappings = blockDeviceMappings;
       }
 
-      return bindToRequest(request, ImmutableMap.of("server", server));
+      return bindToRequest(request, (Object) ImmutableMap.of("server", server));
    }
 
    private static class NamedThingy extends ForwardingObject {


### PR DESCRIPTION
Newer JDK have a different resolution process, likely due to enhanced
target type inference.  Found via:

```
mvn test -Dmaven.compile.source=1.8 -Dmaven.compile.target=1.8
```