### PR TITLE
Specify jsr305

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -254,6 +254,11 @@
         <version>${guava.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>1.3.9</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-assistedinject</artifactId>
         <version>${guice.version}</version>
@@ -366,6 +371,10 @@
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
       <version>2.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This eliminates warnings of the form:

```
/home/gaul/.m2/repository/com/google/guava/guava/18.0/guava-18.0.jar(com/google/common/util/concurrent/Monitor.class): warning: Cannot find annotation method 'value()' in type 'GuardedBy'
```