### PR TITLE
JCLOUDS-1258: Allow China endpoints in FormSignerV4

### DIFF
--- a/apis/sts/src/main/java/org/jclouds/aws/filters/FormSignerV4.java
+++ b/apis/sts/src/main/java/org/jclouds/aws/filters/FormSignerV4.java
@@ -84,7 +84,6 @@ public final class FormSignerV4 implements FormSigner {
 
          /** This will only work for amazon deployments, and perhaps not all of them. */
          private static List<String> parseServiceAndRegion(String host) {
-            checkArgument(host.endsWith(".amazonaws.com"), "Only AWS endpoints currently supported %s", host);
             return Splitter.on('.').splitToList(host);
          }
       }


### PR DESCRIPTION
The creation of a compute context for a China region failed because the `FormSignerV4` didn't allow China endpoints.

The error happens at constructor injection time when Guice is building all singleton objects. The `IllegalArgumentException` thrown there causes an infinite loop and ends up in an `OutOfMemoryexception`.

@andrewgaul @demobox Despite having only added the China suffix in this commit, I'd rather remove completely this validation, as it provides very little value. If the endpoint does not support V4 signatures, users will probably see a self-explanatory error response coming back. WDYT?