### PR TITLE
Remove Inject on constructors for abstract classes

### DIFF
--- a/apis/ec2/src/main/java/org/jclouds/ec2/xml/BaseReservationHandler.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/xml/BaseReservationHandler.java
@@ -22,8 +22,6 @@ import static org.jclouds.util.SaxUtils.equalsOrSuffix;
 import java.util.Date;
 import java.util.Set;
 
-import javax.inject.Inject;
-
 import org.jclouds.aws.util.AWSUtils;
 import org.jclouds.date.DateService;
 import org.jclouds.ec2.domain.Attachment;
@@ -45,8 +43,7 @@ public abstract class BaseReservationHandler<T> extends HandlerForGeneratedReque
    protected final DateService dateService;
    protected final Supplier<String> defaultRegion;
 
-   @Inject
-   public BaseReservationHandler(DateService dateService, @Region Supplier<String> defaultRegion) {
+   protected BaseReservationHandler(DateService dateService, @Region Supplier<String> defaultRegion) {
       this.dateService = dateService;
       this.defaultRegion = defaultRegion;
    }

--- a/blobstore/src/main/java/org/jclouds/blobstore/internal/BaseBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/internal/BaseBlobStore.java
@@ -32,7 +32,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 
-import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.jclouds.blobstore.BlobStore;
@@ -78,7 +77,6 @@ public abstract class BaseBlobStore implements BlobStore {
    protected final Supplier<Set<? extends Location>> locations;
    protected final PayloadSlicer slicer;
 
-   @Inject
    protected BaseBlobStore(BlobStoreContext context, BlobUtils blobUtils, Supplier<Location> defaultLocation,
          @Memoized Supplier<Set<? extends Location>> locations, PayloadSlicer slicer) {
       this.context = checkNotNull(context, "context");

--- a/core/src/main/java/org/jclouds/http/internal/BaseHttpCommandExecutorService.java
+++ b/core/src/main/java/org/jclouds/http/internal/BaseHttpCommandExecutorService.java
@@ -29,7 +29,6 @@ import java.net.ProtocolException;
 import java.util.Set;
 
 import javax.annotation.Resource;
-import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.jclouds.Constants;
@@ -67,7 +66,6 @@ public abstract class BaseHttpCommandExecutorService<Q> implements HttpCommandEx
 
    private final Set<String> idempotentMethods;
 
-   @Inject
    protected BaseHttpCommandExecutorService(HttpUtils utils, ContentMetadataCodec contentMetadataCodec,
          DelegatingRetryHandler retryHandler, IOExceptionRetryHandler ioRetryHandler,
          DelegatingErrorHandler errorHandler, HttpWire wire,

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/xml/BaseAWSReservationHandler.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/xml/BaseAWSReservationHandler.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Resource;
-import javax.inject.Inject;
 
 import org.jclouds.aws.ec2.domain.AWSRunningInstance;
 import org.jclouds.aws.ec2.domain.MonitoringState;
@@ -55,8 +54,7 @@ public abstract class BaseAWSReservationHandler<T> extends HandlerForGeneratedRe
    protected final DateService dateService;
    protected final Supplier<String> defaultRegion;
 
-   @Inject
-   public BaseAWSReservationHandler(DateService dateService, @Region Supplier<String> defaultRegion) {
+   protected BaseAWSReservationHandler(DateService dateService, @Region Supplier<String> defaultRegion) {
       this.dateService = dateService;
       this.defaultRegion = defaultRegion;
    }

--- a/providers/digitalocean2/src/main/java/org/jclouds/digitalocean2/functions/BaseToPagedIterable.java
+++ b/providers/digitalocean2/src/main/java/org/jclouds/digitalocean2/functions/BaseToPagedIterable.java
@@ -18,8 +18,6 @@ package org.jclouds.digitalocean2.functions;
 
 import java.net.URI;
 
-import javax.inject.Inject;
-
 import org.jclouds.collect.IterableWithMarker;
 import org.jclouds.collect.internal.Arg0ToPagedIterable;
 import org.jclouds.digitalocean2.DigitalOcean2Api;
@@ -39,7 +37,7 @@ public abstract class BaseToPagedIterable<T, O extends ListOptions> extends
    private final Function<URI, O> linkToOptions;
    protected final DigitalOcean2Api api;
 
-   @Inject protected BaseToPagedIterable(DigitalOcean2Api api, Function<URI, O> linkToOptions) {
+   protected BaseToPagedIterable(DigitalOcean2Api api, Function<URI, O> linkToOptions) {
       this.api = api;
       this.linkToOptions = linkToOptions;
    }

--- a/providers/packet/src/main/java/org/jclouds/packet/functions/BaseToPagedIterable.java
+++ b/providers/packet/src/main/java/org/jclouds/packet/functions/BaseToPagedIterable.java
@@ -16,8 +16,6 @@
  */
 package org.jclouds.packet.functions;
 
-import javax.inject.Inject;
-
 import org.jclouds.collect.IterableWithMarker;
 import org.jclouds.collect.internal.Arg0ToPagedIterable;
 import org.jclouds.packet.PacketApi;
@@ -38,7 +36,7 @@ public abstract class BaseToPagedIterable<T, O extends ListOptions> extends
    private final Function<Href, O> hrefToOptions;
    protected final PacketApi api;
 
-   @Inject protected BaseToPagedIterable(PacketApi api, Function<Href, O> hrefToOptions) {
+   protected BaseToPagedIterable(PacketApi api, Function<Href, O> hrefToOptions) {
       this.api = api;
       this.hrefToOptions = hrefToOptions;
    }

--- a/providers/profitbricks/src/main/java/org/jclouds/profitbricks/http/parser/firewall/BaseFirewallResponseHandler.java
+++ b/providers/profitbricks/src/main/java/org/jclouds/profitbricks/http/parser/firewall/BaseFirewallResponseHandler.java
@@ -16,8 +16,6 @@
  */
 package org.jclouds.profitbricks.http.parser.firewall;
 
-import com.google.inject.Inject;
-
 import org.jclouds.profitbricks.domain.Firewall;
 import org.jclouds.profitbricks.domain.ProvisioningState;
 import org.jclouds.profitbricks.http.parser.BaseProfitBricksResponseHandler;
@@ -32,8 +30,7 @@ public abstract class BaseFirewallResponseHandler<T> extends BaseProfitBricksRes
    protected boolean useFirewallRuleParser = false;
    protected Firewall.Builder builder;
 
-   @Inject
-   BaseFirewallResponseHandler(FirewallRuleListResponseHandler firewallRuleListResponseHandler) {
+   protected BaseFirewallResponseHandler(FirewallRuleListResponseHandler firewallRuleListResponseHandler) {
       this.builder = Firewall.builder();
       this.firewallRuleListResponseHandler = firewallRuleListResponseHandler;
    }

--- a/providers/profitbricks/src/main/java/org/jclouds/profitbricks/http/parser/firewall/rule/BaseFirewallRuleResponseHandler.java
+++ b/providers/profitbricks/src/main/java/org/jclouds/profitbricks/http/parser/firewall/rule/BaseFirewallRuleResponseHandler.java
@@ -19,16 +19,13 @@ package org.jclouds.profitbricks.http.parser.firewall.rule;
 import org.jclouds.profitbricks.domain.Firewall;
 import org.jclouds.profitbricks.domain.Firewall.Protocol;
 
-import com.google.inject.Inject;
-
 import org.jclouds.profitbricks.http.parser.BaseProfitBricksResponseHandler;
 
 public abstract class BaseFirewallRuleResponseHandler<T> extends BaseProfitBricksResponseHandler<T> {
 
    protected Firewall.Rule.Builder builder;
 
-   @Inject
-   BaseFirewallRuleResponseHandler() {
+   protected BaseFirewallRuleResponseHandler() {
       this.builder = Firewall.Rule.builder();
    }
 

--- a/providers/profitbricks/src/main/java/org/jclouds/profitbricks/http/parser/storage/BaseStorageResponseHandler.java
+++ b/providers/profitbricks/src/main/java/org/jclouds/profitbricks/http/parser/storage/BaseStorageResponseHandler.java
@@ -19,8 +19,6 @@ package org.jclouds.profitbricks.http.parser.storage;
 import java.util.Date;
 import java.util.List;
 
-import com.google.inject.Inject;
-
 import org.jclouds.date.DateService;
 import org.jclouds.profitbricks.domain.ProvisioningState;
 import org.jclouds.profitbricks.domain.Storage;
@@ -36,8 +34,7 @@ public abstract class BaseStorageResponseHandler<T> extends BaseProfitBricksResp
    protected Storage.Builder builder;
    protected List<String> serverIds;
 
-   @Inject
-   BaseStorageResponseHandler(DateService dateService) {
+   protected BaseStorageResponseHandler(DateService dateService) {
       this.dateService = dateService;
       this.builder = Storage.builder();
       this.serverIds = Lists.newArrayList();


### PR DESCRIPTION
This is not meaningful since these classes cannot be instantiated.
Found via error-prone.