### PR TITLE
Fixes for jclouds openstack swift tests.

### DIFF
--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/features/ObjectApi.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/features/ObjectApi.java
@@ -172,7 +172,6 @@ public interface ObjectApi {
    @Path("/{objectName}")
    @ResponseParser(ParseObjectFromResponse.class)
    @Fallback(NullOnNotFoundOr404.class)
-   @QueryParams(keys = "format", values = "json")
    @Nullable
    SwiftObject get(@PathParam("objectName") String objectName);
 

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/ContainerApiLiveTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/ContainerApiLiveTest.java
@@ -43,7 +43,7 @@ import com.google.common.collect.ImmutableMultimap;
 /**
  * Provides live tests for the {@link ContainerApi}.
  */
-@Test(groups = "live", testName = "ContainerApiLiveTest")
+@Test(groups = "live", testName = "ContainerApiLiveTest", singleThreaded = true)
 public class ContainerApiLiveTest extends BaseSwiftApiLiveTest {
 
    private String name = getClass().getSimpleName();
@@ -65,6 +65,7 @@ public class ContainerApiLiveTest extends BaseSwiftApiLiveTest {
          assertEquals(container.getMetadata().get("web-error"), "__error.html");
 
          assertTrue(getApi().getContainerApi(regionId).deleteIfEmpty(name));
+         assertTrue(getApi().getContainerApi(regionId).create(name));
       }
    }
 
@@ -133,20 +134,21 @@ public class ContainerApiLiveTest extends BaseSwiftApiLiveTest {
          assertEquals(updatedContainer.getMetadata().get("web-error"), "__error.html");
 
          assertTrue(getApi().getContainerApi(regionId).deleteIfEmpty(name));
+         assertTrue(getApi().getContainerApi(regionId).create(name));
       }
    }
 
    public void testUpdateContainer() throws Exception {
       for (String regionId : regions) {
          ContainerApi containerApi = getApi().getContainerApi(regionId);
-         assertThat(containerApi.create(name)).isTrue();
-
+         // The container should exist, as it was created in the setup() method
          assertThat(containerApi.get(name).getAnybodyRead().get()).isFalse();
 
          containerApi.update(name, new UpdateContainerOptions().anybodyRead());
          assertThat(containerApi.get(name).getAnybodyRead().get()).isTrue();
 
          assertThat(containerApi.deleteIfEmpty(name)).isTrue();
+         assertThat(containerApi.create(name)).isTrue();
       }
    }
 

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/ObjectApiLiveTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/ObjectApiLiveTest.java
@@ -214,6 +214,7 @@ public class ObjectApiLiveTest extends BaseSwiftApiLiveTest {
             if (header.getKey().equals("Last-Modified"))continue;
             if (header.getKey().equals("X-Trans-Id"))continue;
             if (header.getKey().equals("X-Timestamp"))continue;
+            if (header.getKey().equals("X-Openstack-Request-Id"))continue;
             assertTrue(destHeaders.containsEntry(header.getKey(), header.getValue()), "Could not find: " + header);
          }
          assertEquals(destSwiftObject.getPayload().getContentMetadata().getContentDisposition(), "attachment; filename=\"updatedname.txt\"");


### PR DESCRIPTION
The ContainerApiLiveTest class has tests that mostly assume that a
single test container always exists. They collide on changes to the
state of the container. Some of the tests, though, assume the
container does _not_ exist and attempt to create it and subsequently
delete it. The change in this patch makes their behavior uniform with
respect to that test container: assume it exists and if the test tries
to delete it or mutate it, delete the container and create it at the
end of the test.

The fix in ObjectApi is for the Object GET requests. Currently,
jclouds passes "format=json", which is not a supported query parameter
for object GET.

Lastly, ObjectApiLiveTest that test server-side copy should ignore the
X-Openstack-Request-ID header, as its value will change between the
two requests.