### PR TITLE
 JCLOUDS-1337: other putBlob portable storage tiers 

### DIFF
--- a/apis/atmos/src/main/java/org/jclouds/atmos/blobstore/functions/ObjectToBlobMetadata.java
+++ b/apis/atmos/src/main/java/org/jclouds/atmos/blobstore/functions/ObjectToBlobMetadata.java
@@ -29,6 +29,7 @@ import org.jclouds.atmos.filters.ShareUrl;
 import org.jclouds.atmos.functions.AtmosObjectName;
 import org.jclouds.blobstore.domain.MutableBlobMetadata;
 import org.jclouds.blobstore.domain.StorageType;
+import org.jclouds.blobstore.domain.Tier;
 import org.jclouds.blobstore.domain.internal.MutableBlobMetadataImpl;
 import org.jclouds.http.HttpUtils;
 
@@ -78,6 +79,7 @@ public class ObjectToBlobMetadata implements Function<AtmosObject, MutableBlobMe
       }
       to.setUserMetadata(lowerKeyMetadata);
       to.setSize(from.getContentMetadata().getContentLength());
+      to.setTier(Tier.STANDARD);
       return to;
    }
 }

--- a/apis/atmos/src/test/java/org/jclouds/atmos/blobstore/integration/AtmosIntegrationLiveTest.java
+++ b/apis/atmos/src/test/java/org/jclouds/atmos/blobstore/integration/AtmosIntegrationLiveTest.java
@@ -17,6 +17,7 @@
 package org.jclouds.atmos.blobstore.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
@@ -24,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobMetadata;
+import org.jclouds.blobstore.domain.Tier;
 import org.jclouds.blobstore.integration.internal.BaseBlobIntegrationTest;
 import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
@@ -196,5 +198,41 @@ public class AtmosIntegrationLiveTest extends BaseBlobIntegrationTest {
    @Test(groups = { "integration", "live" }, expectedExceptions = UnsupportedOperationException.class)
    public void testCopyIfNoneMatchNegative() throws Exception {
       super.testCopyIfNoneMatchNegative();
+   }
+
+   @Test(groups = { "integration", "live" })
+   public void testPutBlobTierStandardMultipart() throws Exception {
+      try {
+         super.testPutBlobTierStandardMultipart();
+         failBecauseExceptionWasNotThrown(UnsupportedOperationException.class);
+      } catch (UnsupportedOperationException uoe) {
+         throw new SkipException("Atmos does not support multipart", uoe);
+      }
+   }
+
+   @Test(groups = { "integration", "live" })
+   public void testPutBlobTierInfrequentMultipart() throws Exception {
+      try {
+         super.testPutBlobTierInfrequentMultipart();
+         failBecauseExceptionWasNotThrown(UnsupportedOperationException.class);
+      } catch (UnsupportedOperationException uoe) {
+         throw new SkipException("Atmos does not support multipart", uoe);
+      }
+   }
+
+   @Test(groups = { "integration", "live" })
+   public void testPutBlobTierArchiveMultipart() throws Exception {
+      try {
+         super.testPutBlobTierArchiveMultipart();
+         failBecauseExceptionWasNotThrown(UnsupportedOperationException.class);
+      } catch (UnsupportedOperationException uoe) {
+         throw new SkipException("Atmos does not support multipart", uoe);
+      }
+   }
+
+   @Override
+   protected void checkTier(BlobMetadata metadata, Tier expected) {
+      // Atmos maps all tiers to STANDARD
+      assertThat(metadata.getTier()).isEqualTo(Tier.STANDARD);
    }
 }

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/blobstore/functions/ToBlobMetadata.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/blobstore/functions/ToBlobMetadata.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.jclouds.blobstore.domain.MutableBlobMetadata;
 import org.jclouds.blobstore.domain.StorageType;
+import org.jclouds.blobstore.domain.Tier;
 import org.jclouds.blobstore.domain.internal.MutableBlobMetadataImpl;
 import org.jclouds.openstack.swift.v1.domain.Container;
 import org.jclouds.openstack.swift.v1.domain.SwiftObject;
@@ -59,6 +60,7 @@ public class ToBlobMetadata implements Function<SwiftObject, MutableBlobMetadata
          to.setType(StorageType.BLOB);
       }
       to.setSize(from.getPayload().getContentMetadata().getContentLength());
+      to.setTier(Tier.STANDARD);
       return to;
    }
 

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftBlobIntegrationLiveTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/blobstore/integration/SwiftBlobIntegrationLiveTest.java
@@ -23,6 +23,8 @@ import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CRED
 import java.util.Properties;
 
 import org.jclouds.blobstore.domain.Blob;
+import org.jclouds.blobstore.domain.BlobMetadata;
+import org.jclouds.blobstore.domain.Tier;
 import org.jclouds.blobstore.integration.internal.BaseBlobIntegrationTest;
 import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
@@ -128,5 +130,11 @@ public class SwiftBlobIntegrationLiveTest extends BaseBlobIntegrationTest {
    @Override
    protected long getMinimumMultipartBlobSize() {
       return 1;
+   }
+
+   @Override
+   protected void checkTier(BlobMetadata metadata, Tier expected) {
+      // Swift maps all tiers to STANDARD
+      assertThat(metadata.getTier()).isEqualTo(Tier.STANDARD);
    }
 }

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
@@ -787,10 +787,14 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
             .tier(tier)
             .build();
          blobStore.putBlob(containerName, blob, options);
-         assertThat(blobStore.blobMetadata(containerName, blobName).getTier()).isEqualTo(tier);
+         checkTier(blobStore.blobMetadata(containerName, blobName), tier);
       } finally {
          returnContainer(containerName);
       }
+   }
+
+   protected void checkTier(BlobMetadata metadata, Tier expected) {
+      assertThat(metadata.getTier()).isEqualTo(expected);
    }
 
    protected void checkUserMetadata(Map<String, String> userMetadata1, Map<String, String> userMetadata2) {

--- a/providers/b2/src/main/java/org/jclouds/b2/blobstore/B2BlobStore.java
+++ b/providers/b2/src/main/java/org/jclouds/b2/blobstore/B2BlobStore.java
@@ -55,6 +55,7 @@ import org.jclouds.blobstore.domain.MutableBlobMetadata;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.domain.StorageType;
+import org.jclouds.blobstore.domain.Tier;
 import org.jclouds.blobstore.domain.internal.BlobImpl;
 import org.jclouds.blobstore.domain.internal.BlobMetadataImpl;
 import org.jclouds.blobstore.domain.internal.MutableBlobMetadataImpl;
@@ -454,6 +455,7 @@ public final class B2BlobStore extends BaseBlobStore {
       contentMetadata.setContentType(b2Object.contentType());
       metadata.setContentMetadata(contentMetadata);
       metadata.setUserMetadata(b2Object.fileInfo());
+      metadata.setTier(Tier.STANDARD);
       try {
          metadata.setPublicUri(URI.create(auth.get().downloadUrl() + "/file/" + container + "/" +
                URLEncoder.encode(b2Object.fileName(), "UTF-8")));

--- a/providers/b2/src/test/java/org/jclouds/b2/blobstore/integration/B2BlobIntegrationLiveTest.java
+++ b/providers/b2/src/test/java/org/jclouds/b2/blobstore/integration/B2BlobIntegrationLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.b2.blobstore.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 import java.io.IOException;
@@ -24,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.domain.BlobBuilder.PayloadBlobBuilder;
+import org.jclouds.blobstore.domain.Tier;
 import org.jclouds.blobstore.integration.internal.BaseBlobIntegrationTest;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
@@ -240,5 +242,41 @@ public final class B2BlobIntegrationLiveTest extends BaseBlobIntegrationTest {
       } catch (IllegalArgumentException iae) {
          throw new SkipException("B2 requires at least two parts", iae);
       }
+   }
+
+   @Test(groups = { "integration", "live" })
+   public void testPutBlobTierStandardMultipart() throws Exception {
+      try {
+         super.testPutBlobTierStandardMultipart();
+         failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+      } catch (IllegalArgumentException iae) {
+         throw new SkipException("B2 requires at least two parts", iae);
+      }
+   }
+
+   @Test(groups = { "integration", "live" })
+   public void testPutBlobTierInfrequentMultipart() throws Exception {
+      try {
+         super.testPutBlobTierInfrequentMultipart();
+         failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+      } catch (IllegalArgumentException iae) {
+         throw new SkipException("B2 requires at least two parts", iae);
+      }
+   }
+
+   @Test(groups = { "integration", "live" })
+   public void testPutBlobTierArchiveMultipart() throws Exception {
+      try {
+         super.testPutBlobTierArchiveMultipart();
+         failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+      } catch (IllegalArgumentException iae) {
+         throw new SkipException("B2 requires at least two parts", iae);
+      }
+   }
+
+   @Override
+   protected void checkTier(BlobMetadata metadata, Tier expected) {
+      // B2 maps all tiers to STANDARD
+      assertThat(metadata.getTier()).isEqualTo(Tier.STANDARD);
    }
 }


### PR DESCRIPTION
These providers map all storage tiers to `STANDARD`.