### PR TITLE
[JCLOUDS-1354] avoid memory leak by reusing BouncyCastleProvider

### DIFF
--- a/drivers/bouncycastle/src/main/java/org/jclouds/encryption/bouncycastle/BouncyCastleCrypto.java
+++ b/drivers/bouncycastle/src/main/java/org/jclouds/encryption/bouncycastle/BouncyCastleCrypto.java
@@ -17,6 +17,8 @@
 package org.jclouds.encryption.bouncycastle;
 
 import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
 import java.security.cert.CertificateException;
 
 import javax.crypto.Cipher;
@@ -29,8 +31,23 @@ import org.jclouds.encryption.internal.JCECrypto;
 @Singleton
 public class BouncyCastleCrypto extends JCECrypto {
 
+    /* The only instance of BouncyCastleProvider we'll ever use in JClouds contexts.
+     * It may even be an already registered instance.
+     * See https://issues.apache.org/jira/browse/JCLOUDS-1354
+     */
+    private static final BouncyCastleProvider BC_PROVIDER;
+    static {
+        final BouncyCastleProvider myBCProvider = new BouncyCastleProvider();
+        final Provider installedProvider = Security.getProvider(myBCProvider.getName());
+        if (installedProvider != null && installedProvider.getClass().equals(BouncyCastleProvider.class)) {
+            BC_PROVIDER = (BouncyCastleProvider) installedProvider;
+        } else {
+            BC_PROVIDER = myBCProvider;
+        }
+    }
+
    public BouncyCastleCrypto() throws NoSuchAlgorithmException, CertificateException {
-      super(new BouncyCastleProvider());
+      super(BC_PROVIDER);
    }
 
    


### PR DESCRIPTION
See [JCLOUDS-1354](https://issues.apache.org/jira/browse/JCLOUDS-1354).  Reuse a single instance of `BouncyCastleProvider`, because every instance used at least once will be retained forever in the JCE providers map (in `javax.crypto.JceSecurity` - see also [JDK-8168469](https://bugs.openjdk.java.net/browse/JDK-8168469)).