### PR TITLE
Fix an unexpected test failure in Windows path handling

### DIFF
--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImplTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImplTest.java
@@ -686,9 +686,21 @@ public class FilesystemStorageStrategyImplTest {
       }
    }
 
-   @Test
-   public void testDeletingInvalidPathFileEndsNormally() {
+   @DataProvider
+   public Object[][] getInvalidPathBlobKey() {
       String invalidPathBlobKey = "A<!:!@#$%^&*?]8 /\0";
+      // the JDK can't handle '/' in Windows file paths
+      if (TestUtils.isWindowsOs()) {
+         invalidPathBlobKey = invalidPathBlobKey.replace("/", "");
+      }
+
+      Object[][] result = new Object[1][1];
+      result[0][0] = invalidPathBlobKey;
+      return result;
+   }
+
+   @Test(dataProvider = "getInvalidPathBlobKey")
+   public void testDeletingInvalidPathFileEndsNormally(String invalidPathBlobKey) {
       try {
          storageStrategy.removeBlob(CONTAINER_NAME, invalidPathBlobKey);
       } catch (InvalidPathException ipe) {


### PR DESCRIPTION
See http://markmail.org/message/tahusme6svuhpew6.

From a quick local test, it seems that this test has been failing on Windows since it was added in 6452960c72a5f8, so I'm not sure if the test input was incorrectly constructed at the time, or if the actual functionality has been broken on Windows from the beginning.

@gaul Any light you could shed on that?