### PR TITLE
Fix case sensitivity of blobstore metadata

### DIFF
--- a/blobstore/src/main/java/org/jclouds/blobstore/functions/ParseSystemAndUserMetadataFromHeaders.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/functions/ParseSystemAndUserMetadataFromHeaders.java
@@ -56,7 +56,7 @@ public class ParseSystemAndUserMetadataFromHeaders implements Function<HttpRespo
             @Named(PROPERTY_USER_METADATA_PREFIX) String metadataPrefix) {
       this.metadataFactory = checkNotNull(metadataFactory, "metadataFactory");
       this.dateParser = checkNotNull(dateParser, "dateParser");
-      this.metadataPrefix = checkNotNull(metadataPrefix, "metadataPrefix");
+      this.metadataPrefix = checkNotNull(metadataPrefix, "metadataPrefix").toLowerCase();
    }
 
    public MutableBlobMetadata apply(HttpResponse from) {
@@ -77,7 +77,7 @@ public class ParseSystemAndUserMetadataFromHeaders implements Function<HttpRespo
    @VisibleForTesting
    void addUserMetadataTo(HttpResponse from, MutableBlobMetadata metadata) {
       for (Entry<String, String> header : from.getHeaders().entries()) {
-         if (header.getKey() != null && header.getKey().startsWith(metadataPrefix))
+         if (header.getKey() != null && header.getKey().toLowerCase().startsWith(metadataPrefix))
             metadata.getUserMetadata().put((header.getKey().substring(metadataPrefix.length())).toLowerCase(),
                      header.getValue());
       }


### PR DESCRIPTION
HTTP headers are case insensitive by nature (see RFC 2616). When addUserMetadataTo check if this is indeed a user metadata header, it must properly ignore case.
The fix make sure that both metadataPrefix and the header key are compared with toLowerCase().

This solves issue with minio metadata read