### PR TITLE
JCLOUDS-1368: Correct use of slicing algorithm

### DIFF
--- a/blobstore/src/main/java/org/jclouds/blobstore/internal/BaseBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/internal/BaseBlobStore.java
@@ -354,13 +354,23 @@ public abstract class BaseBlobStore implements BlobStore {
       MultipartUpload mpu = initiateMultipartUpload(container, blob.getMetadata(), overrides);
       try {
          long contentLength = blob.getMetadata().getContentMetadata().getContentLength();
+         // TODO: inject MultipartUploadSlicingAlgorithm to override default part size
          MultipartUploadSlicingAlgorithm algorithm = new MultipartUploadSlicingAlgorithm(
                getMinimumMultipartPartSize(), getMaximumMultipartPartSize(), getMaximumNumberOfParts());
          long partSize = algorithm.calculateChunkSize(contentLength);
          int partNumber = 1;
-         for (Payload payload : slicer.slice(blob.getPayload(), partSize)) {
+         // TODO: for InputStream payloads, this buffers all parts in-memory!
+         while (partNumber < algorithm.getParts()) {
+            Payload payload = slicer.slice(blob.getPayload(), algorithm.getCopied(), partSize);
             BlobUploader b =
                   new BlobUploader(mpu, partNumber++, payload);
+            parts.add(executor.submit(b));
+            algorithm.addCopied(partSize);
+         }
+         if (algorithm.getRemaining() != 0) {
+            Payload payload = slicer.slice(blob.getPayload(), algorithm.getCopied(), algorithm.getRemaining());
+            BlobUploader b =
+                  new BlobUploader(mpu, partNumber, payload);
             parts.add(executor.submit(b));
          }
          return completeMultipartUpload(mpu, Futures.getUnchecked(Futures.allAsList(parts)));

--- a/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/MultipartUploadSlicingAlgorithm.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/MultipartUploadSlicingAlgorithm.java
@@ -132,8 +132,7 @@ public final class MultipartUploadSlicingAlgorithm {
       this.copied = copied;
    }
 
-   @VisibleForTesting
-   protected int getParts() {
+   public int getParts() {
       return parts;
    }
 
@@ -141,7 +140,7 @@ public final class MultipartUploadSlicingAlgorithm {
       return ++part;
    }
 
-   protected void addCopied(long copied) {
+   public void addCopied(long copied) {
       this.copied += copied;
    }
 
@@ -156,8 +155,7 @@ public final class MultipartUploadSlicingAlgorithm {
       return chunkSize;
    }
 
-   @VisibleForTesting
-   protected long getRemaining() {
+   public long getRemaining() {
       return remaining;
    }
 

--- a/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/MultipartUploadSlicingAlgorithm.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/MultipartUploadSlicingAlgorithm.java
@@ -103,14 +103,10 @@ public final class MultipartUploadSlicingAlgorithm {
          unitPartSize = maximumPartSize;
          parts = (int)(length / unitPartSize);
       }
-      if (parts > maximumNumberOfParts) { // if splits in too many parts or
-                                         // cannot be split
-         unitPartSize = minimumPartSize; // take the minimum part size
-         parts = (int)(length / unitPartSize);
-      }
-      if (parts > maximumNumberOfParts) { // if still splits in too many parts
-         parts = maximumNumberOfParts - 1; // limit them. do not care about not
-                                          // covering
+      if (parts > maximumNumberOfParts) {
+         partSize = length / maximumNumberOfParts;
+         unitPartSize = partSize;
+         parts = maximumNumberOfParts;
       }
       long remainder = length % unitPartSize;
       if (remainder == 0 && parts > 0) {


### PR DESCRIPTION
`MultipartUploadSlicingAlgorithm` creates multiple equal-sized parts and
a remaining amount.  `BaseBlobStore.putMultipartBlob` used this
interface incorrectly, which could create more parts than intended
since the remaining size could be larger than the part size.  This
manifested with Google Cloud Storage which only allows 32 parts.