### PR TITLE
JCLOUDS-1271: Remove BlobStore.signRemoveBlob

### DIFF
--- a/apis/atmos/src/main/java/org/jclouds/atmos/blobstore/AtmosBlobRequestSigner.java
+++ b/apis/atmos/src/main/java/org/jclouds/atmos/blobstore/AtmosBlobRequestSigner.java
@@ -111,15 +111,6 @@ public class AtmosBlobRequestSigner implements BlobRequestSigner {
       throw new UnsupportedOperationException();
    }
 
-   @Deprecated
-   @Override
-   public HttpRequest signRemoveBlob(String container, String name) {
-      checkNotNull(container, "container");
-      checkNotNull(name, "name");
-      return cleanRequest(processor.apply(Invocation.create(deleteMethod,
-            ImmutableList.<Object> of(getPath(container, name)))));
-   }
-
    private String getPath(String container, String name) {
       return checkNotNull(container, "container") + "/" + checkNotNull(name, "name");
    }

--- a/apis/atmos/src/test/java/org/jclouds/atmos/blobstore/AtmosBlobRequestSignerTest.java
+++ b/apis/atmos/src/test/java/org/jclouds/atmos/blobstore/AtmosBlobRequestSignerTest.java
@@ -66,20 +66,6 @@ public class AtmosBlobRequestSignerTest extends BaseRestAnnotationProcessingTest
       assertEquals(request.getFilters().size(), 0);
    }
 
-   public void testSignRemoveBlob() throws ArrayIndexOutOfBoundsException, SecurityException, IllegalArgumentException,
-            NoSuchMethodException, IOException {
-      HttpRequest request = signer.signRemoveBlob("container", "name");
-
-      assertRequestLineEquals(request,
-               "DELETE https://accesspoint.atmosonline.com/rest/namespace/container/name HTTP/1.1");
-      assertNonPayloadHeadersEqual(
-               request,
-               "Accept: */*\nDate: Thu, 05 Jun 2008 16:38:19 GMT\nx-emc-signature: cPnxwSdWfIjChx8sox+43U9oo20=\nx-emc-uid: identity\n");
-      assertPayloadEquals(request, null, null, false);
-
-      assertEquals(request.getFilters().size(), 0);
-   }
-
    public void testSignPutBlob() throws ArrayIndexOutOfBoundsException, SecurityException, IllegalArgumentException,
             NoSuchMethodException, IOException {
       HashCode hashCode = HashCode.fromBytes(new byte[16]);

--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/FilesystemBlobStoreTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/FilesystemBlobStoreTest.java
@@ -806,14 +806,6 @@ public class FilesystemBlobStoreTest {
                 .build();
         assertEquals(expected, request);
 
-        request = signer.signRemoveBlob(containerName, blobName);
-        expected = HttpRequest.builder()
-                .method("DELETE")
-                .endpoint(endPoint)
-                .headers(request.getHeaders())
-                .build();
-        assertEquals(expected, request);
-
         Blob blob = blobStore.blobBuilder(blobName).forSigning().build();
         request = signer.signPutBlob(containerName, blob);
         expected = HttpRequest.builder()

--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/blobstore/RegionScopedTemporaryUrlBlobSigner.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/blobstore/RegionScopedTemporaryUrlBlobSigner.java
@@ -88,12 +88,6 @@ public class RegionScopedTemporaryUrlBlobSigner implements BlobRequestSigner {
       return sign("PUT", container, blob.getMetadata().getName(), GetOptions.NONE, timestamp.get() + timeInSeconds);
    }
 
-   @Deprecated
-   @Override
-   public HttpRequest signRemoveBlob(String container, String name) {
-      return sign("DELETE", container, name, GetOptions.NONE, timestamp.get() + DEFAULT_SIGNING_TIMEOUT);
-   }
-
    private HttpRequest sign(String method, String container, String name, GetOptions options, long expires) {
       checkNotNull(container, "container");
       checkNotNull(name, "name");

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobRequestSigner.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobRequestSigner.java
@@ -95,14 +95,6 @@ public class S3BlobRequestSigner<T extends S3Client> implements BlobRequestSigne
       return cleanRequest(authSigner.signForTemporaryAccess(request, timeInSeconds));
    }
 
-   @Deprecated
-   @Override
-   public HttpRequest signRemoveBlob(String container, String name) {
-      checkNotNull(container, "container");
-      checkNotNull(name, "name");
-      return cleanRequest(processor.apply(Invocation.create(deleteMethod, ImmutableList.<Object> of(container, name))));
-   }
-
    @Override
    public HttpRequest signGetBlob(String container, String name, org.jclouds.blobstore.options.GetOptions options) {
       checkNotNull(container, "container");

--- a/blobstore/src/main/java/org/jclouds/blobstore/BlobRequestSigner.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/BlobRequestSigner.java
@@ -61,20 +61,6 @@ public interface BlobRequestSigner {
    HttpRequest signGetBlob(String container, String name, GetOptions options);
 
    /**
-    * gets a signed request, including headers as necessary, to delete a blob from an external
-    * client.
-    * 
-    * @param container
-    *           container where the blob resides
-    * @param directory
-    *           full path to the blob
-    * @throws UnsupportedOperationException
-    *            if not supported by the provider
-    */
-   @Deprecated
-   HttpRequest signRemoveBlob(String container, String name);
-
-   /**
     * gets a signed request, including headers as necessary, to upload a blob from an external
     * client.
     * 

--- a/blobstore/src/main/java/org/jclouds/blobstore/LocalBlobRequestSigner.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/LocalBlobRequestSigner.java
@@ -75,14 +75,6 @@ public class LocalBlobRequestSigner implements BlobRequestSigner {
       throw new UnsupportedOperationException();
    }
 
-   @Deprecated
-   @Override
-   public HttpRequest signRemoveBlob(String container, String name) {
-      HttpRequest request = HttpRequest.builder().method("DELETE").endpoint(String.format("%s/%s/%s", endpoint.get(), container,
-               name)).build();
-      return basicAuth.filter(request);
-   }
-
    @Override
    public HttpRequest signGetBlob(String container, String name, GetOptions options) {
       HttpRequest request = HttpRequest.builder().method("GET").endpoint(

--- a/blobstore/src/main/java/org/jclouds/blobstore/internal/RequestSigningUnsupported.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/internal/RequestSigningUnsupported.java
@@ -41,12 +41,6 @@ public class RequestSigningUnsupported implements BlobRequestSigner {
       throw new UnsupportedOperationException();
    }
 
-   @Deprecated
-   @Override
-   public HttpRequest signRemoveBlob(String container, String name) {
-      throw new UnsupportedOperationException();
-   }
-
    @Override
    public HttpRequest signPutBlob(String container, Blob blob) {
       throw new UnsupportedOperationException();

--- a/blobstore/src/test/java/org/jclouds/blobstore/TransientBlobRequestSignerTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/TransientBlobRequestSignerTest.java
@@ -61,17 +61,6 @@ public class TransientBlobRequestSignerTest extends BaseRestAnnotationProcessing
       assertEquals(request.getFilters().size(), 0);
    }
 
-   public void testSignRemoveBlob() throws ArrayIndexOutOfBoundsException, SecurityException, IllegalArgumentException,
-            NoSuchMethodException, IOException {
-      HttpRequest request = signer.signRemoveBlob(containerName, blobName);
-
-      assertRequestLineEquals(request, "DELETE " + fullUrl + " HTTP/1.1");
-      assertNonPayloadHeadersEqual(request, "Authorization: Basic aWRlbnRpdHk6Y3JlZGVudGlhbA==\n");
-      assertPayloadEquals(request, null, null, false);
-
-      assertEquals(request.getFilters().size(), 0);
-   }
-
    public void testSignPutBlob() throws ArrayIndexOutOfBoundsException, SecurityException, IllegalArgumentException,
             NoSuchMethodException, IOException {
       HashCode hashCode = HashCode.fromBytes(new byte[16]);

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobSignerLiveTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobSignerLiveTest.java
@@ -193,26 +193,6 @@ public class BaseBlobSignerLiveTest extends BaseBlobStoreIntegrationTest {
        testSignPutUrlWithTime(-getSignedUrlTimeout());
    }
 
-   @Test
-   public void testSignRemoveUrl() throws Exception {
-      String name = "hello";
-      String text = "fooooooooooooooooooooooo";
-
-      Blob blob = view.getBlobStore().blobBuilder(name).payload(text).contentType("text/plain").build();
-      String container = getContainerName();
-      try {
-         view.getBlobStore().putBlob(container, blob);
-         awaitConsistency();
-         assertConsistencyAwareContainerSize(container, 1);
-         HttpRequest request = view.getSigner().signRemoveBlob(container, name);
-         assertEquals(request.getFilters().size(), 0);
-         view.utils().http().invoke(request);
-         assert !view.getBlobStore().blobExists(container, name);
-      } finally {
-         returnContainer(container);
-      }
-   }
-
    protected void awaitConsistency() {
       if (view.getConsistencyModel() == ConsistencyModel.EVENTUAL) {
          Uninterruptibles.sleepUninterruptibly(AWAIT_CONSISTENCY_TIMEOUT_SECONDS, TimeUnit.SECONDS);

--- a/blobstore/src/test/java/org/jclouds/blobstore/internal/BaseBlobSignerExpectTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/internal/BaseBlobSignerExpectTest.java
@@ -79,12 +79,6 @@ public abstract class BaseBlobSignerExpectTest extends BaseRestApiExpectTest<Blo
    protected abstract HttpRequest getBlobWithOptions();
 
    @Test
-   public void testSignRemoveBlob() {
-      BlobStore removeBlob = requestsSendResponses(init());
-      assertEquals(removeBlob.getContext().getSigner().signRemoveBlob(container, name), removeBlob());
-   }
-
-   @Test
    public void testSignPutBlob() throws Exception {
       HashCode hashCode = HashCode.fromBytes(new byte[16]);
       BlobStore signPutBlob = requestsSendResponses(init());

--- a/providers/aws-s3/src/test/java/org/jclouds/aws/s3/blobstore/AWSS3BlobSignerV4ExpectTest.java
+++ b/providers/aws-s3/src/test/java/org/jclouds/aws/s3/blobstore/AWSS3BlobSignerV4ExpectTest.java
@@ -136,11 +136,6 @@ public class AWSS3BlobSignerV4ExpectTest extends S3BlobSignerExpectTest {
    }
 
    @Override
-   public void testSignRemoveBlob() {
-      throw new SkipException("skip testSignRemoveBlob");
-   }
-
-   @Override
    protected Module createModule() {
       return new TestAWSS3SignerV4HttpApiModule();
    }

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/AzureBlobRequestSigner.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/AzureBlobRequestSigner.java
@@ -90,8 +90,6 @@ public class AzureBlobRequestSigner implements BlobRequestSigner {
             blob.getMetadata().getContentMetadata().getContentLength());
    }
 
-   @Deprecated
-   @Override
    public HttpRequest signRemoveBlob(String container, String name) {
       checkNotNull(container, "container");
       checkNotNull(name, "name");

--- a/providers/azureblob/src/test/java/org/jclouds/azureblob/blobstore/AzureBlobRequestSignerTest.java
+++ b/providers/azureblob/src/test/java/org/jclouds/azureblob/blobstore/AzureBlobRequestSignerTest.java
@@ -50,7 +50,7 @@ public class AzureBlobRequestSignerTest extends BaseRestAnnotationProcessingTest
       credential = "aaaabbbb"; 
    }
    
-   private BlobRequestSigner signer;
+   private AzureBlobRequestSigner signer;
    private Factory blobFactory;
 
    public void testSignGetBlob() throws ArrayIndexOutOfBoundsException, SecurityException, IllegalArgumentException,
@@ -102,7 +102,7 @@ public class AzureBlobRequestSignerTest extends BaseRestAnnotationProcessingTest
    protected void setupFactory() throws IOException {
       super.setupFactory();
       this.blobFactory = injector.getInstance(Blob.Factory.class);
-      this.signer = injector.getInstance(BlobRequestSigner.class);
+      this.signer = (AzureBlobRequestSigner) injector.getInstance(BlobRequestSigner.class);
    }
 
    @Override

--- a/providers/b2/src/test/java/org/jclouds/b2/blobstore/integration/B2BlobSignerLiveTest.java
+++ b/providers/b2/src/test/java/org/jclouds/b2/blobstore/integration/B2BlobSignerLiveTest.java
@@ -99,14 +99,4 @@ public final class B2BlobSignerLiveTest extends BaseBlobSignerLiveTest {
          throw new SkipException("unsupported by B2", uoe);
       }
    }
-
-   @Test
-   public void testSignRemoveUrl() throws Exception {
-      try {
-         super.testSignRemoveUrl();
-         failBecauseExceptionWasNotThrown(UnsupportedOperationException.class);
-      } catch (UnsupportedOperationException uoe) {
-         throw new SkipException("unsupported by B2", uoe);
-      }
-   }
 }

--- a/providers/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/GoogleCloudStorageBlobRequestSigner.java
+++ b/providers/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/GoogleCloudStorageBlobRequestSigner.java
@@ -98,12 +98,6 @@ public final class GoogleCloudStorageBlobRequestSigner implements BlobRequestSig
       return sign("PUT", container, blob.getMetadata().getName(), GetOptions.NONE, timestamp.get() + timeInSeconds, null);
    }
 
-   @Deprecated
-   @Override
-   public HttpRequest signRemoveBlob(String container, String name) {
-      throw new UnsupportedOperationException();
-   }
-
    private HttpRequest sign(String method, String container, String name, GetOptions options, long expires, String contentType) {
       checkNotNull(container, "container");
       checkNotNull(name, "name");

--- a/providers/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/blobstore/integration/GoogleCloudStorageBlobSignerLiveTest.java
+++ b/providers/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/blobstore/integration/GoogleCloudStorageBlobSignerLiveTest.java
@@ -17,20 +17,11 @@
 package org.jclouds.googlecloudstorage.blobstore.integration;
 
 import org.jclouds.blobstore.integration.internal.BaseBlobSignerLiveTest;
-import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 @Test(groups = { "live" })
 public class GoogleCloudStorageBlobSignerLiveTest extends BaseBlobSignerLiveTest {
    public GoogleCloudStorageBlobSignerLiveTest() {
       provider = "google-cloud-storage";
-   }
-
-   public void testSignRemoveUrl() throws Exception {
-      try {
-         super.testSignRemoveUrl();
-      } catch (UnsupportedOperationException uoe) {
-         throw new SkipException("not yet implemented in GCS", uoe);
-      }
    }
 }


### PR DESCRIPTION
Most providers never supported this functionality and the portable
abstraction should not have included it.