### PR TITLE
JCLOUDS-1333: Require JDK 1.8

### DIFF
--- a/apis/filesystem/pom.xml
+++ b/apis/filesystem/pom.xml
@@ -32,9 +32,6 @@
   <packaging>bundle</packaging>
 
   <properties>
-    <!-- This api has been written in a manner which requires Java language level 7. -->
-    <maven.compile.source>1.7</maven.compile.source>
-    <maven.compile.target>1.7</maven.compile.target>
     <jclouds.osgi.export>org.jclouds.filesystem*;version="${project.version}"</jclouds.osgi.export>
     <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
@@ -101,17 +98,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java17</artifactId>
-            <version>1.0</version>
-          </signature>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -217,13 +217,13 @@
   </developers>
 
   <properties>
-    <maven.compile.source>1.6</maven.compile.source>
-    <maven.compile.target>1.6</maven.compile.target>
-    <jdk.version>1.7</jdk.version>
+    <maven.compile.source>1.8</maven.compile.source>
+    <maven.compile.target>1.8</maven.compile.target>
+    <jdk.version>1.8</jdk.version>
     <maven.compile.deprecation>true</maven.compile.deprecation>
     <maven.site.url.base>gitsite:git@github.com/jclouds/jclouds-maven-site.git</maven.site.url.base>
-    <guava.version>18.0</guava.version>
-    <guava.osgi.import>com.google.common.*;version="[18.0,24.0.0)"</guava.osgi.import>
+    <guava.version>21.0</guava.version>
+    <guava.osgi.import>com.google.common.*;version="[21.0,25.0)"</guava.osgi.import>
     <guice.version>3.0</guice.version>
     <okhttp.version>2.2.0</okhttp.version>
     <okio.osgi.import>okio;version="[1.2.0,1.3)"</okio.osgi.import>
@@ -634,8 +634,8 @@
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java16</artifactId>
-            <version>1.1</version>
+            <artifactId>java18</artifactId>
+            <version>1.0</version>
           </signature>
         </configuration>
       </plugin>
@@ -717,7 +717,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[1.6,)</version>
+                  <version>[1.8,)</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
                   <version>[3.0.2,)</version>
@@ -1279,7 +1279,8 @@
             <groupId>org.gaul</groupId>
             <artifactId>modernizer-maven-plugin</artifactId>
             <configuration>
-              <javaVersion>${maven.compile.source}</javaVersion>
+              <!-- TODO: fix violations and bump to 1.8 -->
+              <javaVersion>1.6</javaVersion>
               <!-- in jclouds-project use the local file. ${project.basedir}
                 required here as 1.1.0 of the modernizer plugin can't find the
                 exclusions file otherwise -->
@@ -1328,7 +1329,8 @@
               </dependency>
             </dependencies>
             <configuration>
-              <javaVersion>${maven.compile.source}</javaVersion>
+              <!-- TODO: fix violations and bump to 1.8 -->
+              <javaVersion>1.6</javaVersion>
               <exclusionsFile>resources/modernizer_exclusions.txt</exclusionsFile>
             </configuration>
           </plugin>


### PR DESCRIPTION
This requires Guava 21 and allows use with later releases.  This also
sets modernizer to JDK 1.6 to work around the many new violations.