### PR TITLE
Allow jclouds to provision SoftLayer instances with a private image.

### DIFF
--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/compute/strategy/SoftLayerComputeServiceAdapter.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/compute/strategy/SoftLayerComputeServiceAdapter.java
@@ -158,7 +158,7 @@ public class SoftLayerComputeServiceAdapter implements
 
       // set operating system or blockDeviceTemplateGroup
       Optional<OperatingSystem> optionalOperatingSystem = tryExtractOperatingSystemFrom(imageId);
-      if (optionalOperatingSystem != null) {
+      if (optionalOperatingSystem.isPresent()) {
          virtualGuestBuilder.operatingSystem(optionalOperatingSystem.get());
       // the imageId specified is an id of a public/private/flex image
       } else {


### PR DESCRIPTION
Fix JCLOUDS-1410.

https://issues.apache.org/jira/browse/JCLOUDS-1410

If possible, can this be backported to 2.0.x?