### PR TITLE
Protects from NPE since SecurityGroup.getLocation() is nullable

### DIFF
--- a/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/extensions/AzureComputeSecurityGroupExtension.java
+++ b/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/extensions/AzureComputeSecurityGroupExtension.java
@@ -116,7 +116,7 @@ public class AzureComputeSecurityGroupExtension implements SecurityGroupExtensio
       return ImmutableSet.copyOf(filter(securityGroups, new Predicate<SecurityGroup>() {
          @Override
          public boolean apply(SecurityGroup input) {
-            return locations.contains(input.getLocation().getId());
+            return input.getLocation() != null && locations.contains(input.getLocation().getId());
          }
       }));
    }


### PR DESCRIPTION
Right now running the AzureComputeSecurityGroupExtensionLiveTest will fail with a NPE if you have any securityGroup in you subscription in any location not included in Set<String> locations
