### PR TITLE
Removes check for group name when deleting

### DIFF
--- a/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/strategy/CleanupResources.java
+++ b/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/strategy/CleanupResources.java
@@ -158,12 +158,12 @@ public class CleanupResources {
    }
 
    public boolean cleanupSecurityGroupIfOrphaned(String resourceGroup, String group) {
-      String name = namingConvention.create().sharedNameForGroup(group);
       NetworkSecurityGroupApi sgapi = api.getNetworkSecurityGroupApi(resourceGroup);
 
       boolean deleted = false;
 
       try {
+         String name = namingConvention.create().sharedNameForGroup(group);
          NetworkSecurityGroup securityGroup = sgapi.get(name);
          if (securityGroup != null) {
             List<NetworkInterfaceCard> nics = securityGroup.properties().networkInterfaces();


### PR DESCRIPTION
This currently fails if you use a securityGroup with Upper case letters in your subscription.
Naming check shouldn't be needed in a delete operation.