### PR TITLE
Increases session interval from 60 seconds to a higher value

### DIFF
--- a/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/AzureComputeProviderMetadata.java
+++ b/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/AzureComputeProviderMetadata.java
@@ -17,6 +17,7 @@
 package org.jclouds.azurecompute.arm;
 
 import static org.jclouds.Constants.PROPERTY_MAX_RATE_LIMIT_WAIT;
+import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import static org.jclouds.azurecompute.arm.config.AzureComputeProperties.API_VERSION_PREFIX;
 import static org.jclouds.azurecompute.arm.config.AzureComputeProperties.DEFAULT_SUBNET_ADDRESS_PREFIX;
 import static org.jclouds.azurecompute.arm.config.AzureComputeProperties.DEFAULT_VNET_ADDRESS_SPACE_PREFIX;
@@ -90,6 +91,7 @@ public class AzureComputeProviderMetadata extends BaseProviderMetadata {
       properties.put(TIMEOUT_NODE_TERMINATED, 60 * 10 * 1000);
       // Default max wait in rate limit: 5m30s
       properties.put(PROPERTY_MAX_RATE_LIMIT_WAIT, 330000);
+      properties.put(PROPERTY_SESSION_INTERVAL, 300);
       properties.put(RESOURCE, "https://management.azure.com/");
       properties.put(CREDENTIAL_TYPE, CLIENT_CREDENTIALS_SECRET.toString());
       // Set a default Oauth endpoint for Azure, fill in the tenantId based on the value supplied


### PR DESCRIPTION
To avoid problems with the cache, and specifically running the AzureComputeImageExtensionLiveTest suite.

ARM is quite slow and it takes usually more than one minute (default value) for certain operations. The testImageIsCachedAfterBeingCreated in that suite fails often since it takes longer than one minute to destroy the created node in testCreateImage and cache does not contain the image.

It should be safe to increase this value in the provider metadata. 5 minutes looks good but open to discuss

Would be good to add this also to https://github.com/danielestevez/jclouds/blob/83c0a3c7b255ec744c6150ce76c40e8301280c79/providers/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/internal/AzureLiveTestUtils.java ?

