### PR TITLE
Fixes/adds fields primary for NetworkInterfaceCard

### DIFF
--- a/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/IpConfiguration.java
+++ b/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/IpConfiguration.java
@@ -17,9 +17,10 @@
 
 package org.jclouds.azurecompute.arm.domain;
 
-import com.google.auto.value.AutoValue;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
 
 @AutoValue
 public abstract class IpConfiguration {
@@ -34,18 +35,15 @@ public abstract class IpConfiguration {
    public abstract String etag();
 
    @Nullable
-   public abstract Boolean primary();
-
-   @Nullable
    public abstract IpConfigurationProperties properties();
 
-   @SerializedNames({"name", "id", "etag", "primary", "properties"})
-   public static IpConfiguration create(final String name, final String id, final String etag, final Boolean primary, final IpConfigurationProperties properties) {
+   @SerializedNames({ "name", "id", "etag", "properties" })
+   public static IpConfiguration create(final String name, final String id, final String etag,
+         final IpConfigurationProperties properties) {
       return builder()
               .name(name)
               .id(id)
               .etag(etag)
-              .primary(primary)
               .properties(properties)
               .build();
    }
@@ -61,7 +59,6 @@ public abstract class IpConfiguration {
       public abstract Builder name(String name);
       public abstract Builder id(String id);
       public abstract Builder etag(String etag);
-      public abstract Builder primary(Boolean primary);
       public abstract Builder properties(IpConfigurationProperties properties);
       public abstract IpConfiguration build();
    }

--- a/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/IpConfigurationProperties.java
+++ b/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/IpConfigurationProperties.java
@@ -18,11 +18,11 @@ package org.jclouds.azurecompute.arm.domain;
 
 import java.util.List;
 
-import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
-
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 
 @AutoValue
 public abstract class IpConfigurationProperties implements Provisionable {
@@ -48,11 +48,15 @@ public abstract class IpConfigurationProperties implements Provisionable {
    @Nullable
    public abstract List<IdReference> loadBalancerInboundNatRules();
 
-   @SerializedNames({ "provisioningState", "privateIPAddress", "privateIPAllocationMethod", "subnet",
-         "publicIPAddress", "loadBalancerBackendAddressPools", "loadBalancerInboundNatRules" })
+   @Nullable
+   public abstract Boolean primary();
+
+   @SerializedNames({ "provisioningState", "privateIPAddress", "privateIPAllocationMethod", "subnet", "publicIPAddress",
+         "loadBalancerBackendAddressPools", "loadBalancerInboundNatRules", "primary" })
    public static IpConfigurationProperties create(final String provisioningState, final String privateIPAddress,
          final String privateIPAllocationMethod, final IdReference subnet, final IdReference publicIPAddress,
-         List<IdReference> loadBalancerBackendAddressPools, List<IdReference> loadBalancerInboundNatRules) {
+         List<IdReference> loadBalancerBackendAddressPools, List<IdReference> loadBalancerInboundNatRules,
+         final Boolean primary) {
 
       return builder()
               .provisioningState(provisioningState)
@@ -61,7 +65,7 @@ public abstract class IpConfigurationProperties implements Provisionable {
               .subnet(subnet)
               .publicIPAddress(publicIPAddress)
               .loadBalancerBackendAddressPools(loadBalancerBackendAddressPools)
-              .loadBalancerInboundNatRules(loadBalancerInboundNatRules)
+            .loadBalancerInboundNatRules(loadBalancerInboundNatRules).primary(primary)
               .build();
    }
    
@@ -82,10 +86,12 @@ public abstract class IpConfigurationProperties implements Provisionable {
       public abstract Builder subnet(IdReference subnet);
 
       public abstract Builder publicIPAddress(IdReference publicIPAddress);
-      
+
       public abstract Builder loadBalancerBackendAddressPools(List<IdReference> loadBalancerBackendAddressPools);
       
       public abstract Builder loadBalancerInboundNatRules(List<IdReference> loadBalancerInboundNatRules);
+
+      public abstract Builder primary(Boolean primary);
       
       abstract List<IdReference> loadBalancerBackendAddressPools();
       

--- a/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/NetworkInterfaceCardProperties.java
+++ b/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/NetworkInterfaceCardProperties.java
@@ -16,12 +16,13 @@
  */
 package org.jclouds.azurecompute.arm.domain;
 
-import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
+import java.util.List;
+
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
 
-import java.util.List;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 
 @AutoValue
 public abstract class NetworkInterfaceCardProperties implements Provisionable {
@@ -32,17 +33,20 @@ public abstract class NetworkInterfaceCardProperties implements Provisionable {
    @Nullable public abstract List<IpConfiguration> ipConfigurations();
    @Nullable public abstract IdReference networkSecurityGroup();
 
+   @Nullable
+   public abstract Boolean primary();
+
    @SerializedNames({"provisioningState", "resourceGuid", "enableIPForwarding", "ipConfigurations",
-      "networkSecurityGroup"})
+         "networkSecurityGroup", "primary" })
    public static NetworkInterfaceCardProperties create(final String provisioningState, final String resourceGuid,
          final Boolean enableIPForwarding, final List<IpConfiguration> ipConfigurations,
-         final IdReference networkSecurityGroup) {
+         final IdReference networkSecurityGroup, final Boolean primary) {
       NetworkInterfaceCardProperties.Builder builder = NetworkInterfaceCardProperties.builder()
               .provisioningState(provisioningState)
               .resourceGuid(resourceGuid)
               .enableIPForwarding(enableIPForwarding)
               .ipConfigurations(ipConfigurations == null ? null : ImmutableList.copyOf(ipConfigurations))
-              .networkSecurityGroup(networkSecurityGroup);
+            .networkSecurityGroup(networkSecurityGroup).primary(primary);
 
       return builder.build();
    }
@@ -64,6 +68,9 @@ public abstract class NetworkInterfaceCardProperties implements Provisionable {
       public abstract Builder enableIPForwarding(Boolean enableIPForwarding);
       public abstract Builder ipConfigurations(List<IpConfiguration> ipConfigurations);
       public abstract Builder networkSecurityGroup(IdReference networkSecurityGroup);
+
+      public abstract Builder primary(Boolean primary);
+
 
       abstract List<IpConfiguration> ipConfigurations();
       abstract NetworkInterfaceCardProperties autoBuild();

--- a/providers/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/NetworkInterfaceCardApiLiveTest.java
+++ b/providers/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/NetworkInterfaceCardApiLiveTest.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.azurecompute.arm.features;
 
+import static java.lang.Boolean.TRUE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -66,12 +67,10 @@ public class NetworkInterfaceCardApiLiveTest extends BaseAzureComputeApiLiveTest
    @Test
    public void createNetworkInterfaceCard() {
       //Create properties object
-      final NetworkInterfaceCardProperties networkInterfaceCardProperties =
-              NetworkInterfaceCardProperties.builder().ipConfigurations(
-                      Arrays.asList(IpConfiguration.builder()
-                              .name("myipconfig")
-                              .properties(IpConfigurationProperties.builder()
-                                      .privateIPAllocationMethod("Dynamic")
+      final NetworkInterfaceCardProperties networkInterfaceCardProperties = NetworkInterfaceCardProperties.builder()
+            .ipConfigurations(Arrays.asList(IpConfiguration.builder().name("myipconfig")
+                        .properties(IpConfigurationProperties.builder().privateIPAllocationMethod("Dynamic").primary
+                                    (TRUE)
                                       .subnet(IdReference.create(subnetId)).build()
                               ).build()
                       )).build();
@@ -84,6 +83,7 @@ public class NetworkInterfaceCardApiLiveTest extends BaseAzureComputeApiLiveTest
       assertTrue(nic.properties().ipConfigurations().size() > 0);
       assertEquals(nic.properties().ipConfigurations().get(0).name(), "myipconfig");
       assertEquals(nic.properties().ipConfigurations().get(0).properties().privateIPAllocationMethod(), "Dynamic");
+      assertTrue(nic.properties().ipConfigurations().get(0).properties().primary());
       assertEquals(nic.properties().ipConfigurations().get(0).properties().subnet().id(), subnetId);
       assertEquals(nic.tags().get("jclouds"), "livetest");
    }

--- a/providers/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/VirtualMachineApiLiveTest.java
+++ b/providers/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/VirtualMachineApiLiveTest.java
@@ -21,6 +21,7 @@ import static org.jclouds.util.Predicates2.retry;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.util.Strings.isNullOrEmpty;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -39,8 +40,12 @@ import org.jclouds.azurecompute.arm.domain.ManagedDiskParameters;
 import org.jclouds.azurecompute.arm.domain.NetworkInterfaceCard;
 import org.jclouds.azurecompute.arm.domain.NetworkInterfaceCardProperties;
 import org.jclouds.azurecompute.arm.domain.NetworkProfile;
+import org.jclouds.azurecompute.arm.domain.NetworkProfile.NetworkInterface;
+import org.jclouds.azurecompute.arm.domain.NetworkProfile.NetworkInterface.NetworkInterfaceProperties;
 import org.jclouds.azurecompute.arm.domain.OSDisk;
 import org.jclouds.azurecompute.arm.domain.OSProfile;
+import org.jclouds.azurecompute.arm.domain.OSProfile.WindowsConfiguration.WinRM.Protocol;
+import org.jclouds.azurecompute.arm.domain.OSProfile.WindowsConfiguration.WinRM.ProtocolListener;
 import org.jclouds.azurecompute.arm.domain.ResourceDefinition;
 import org.jclouds.azurecompute.arm.domain.Secrets;
 import org.jclouds.azurecompute.arm.domain.StorageAccountType;
@@ -53,15 +58,10 @@ import org.jclouds.azurecompute.arm.domain.VirtualMachine;
 import org.jclouds.azurecompute.arm.domain.VirtualMachineInstance;
 import org.jclouds.azurecompute.arm.domain.VirtualMachineInstance.PowerState;
 import org.jclouds.azurecompute.arm.domain.VirtualMachineProperties;
-import org.jclouds.azurecompute.arm.domain.NetworkProfile.NetworkInterface;
-import org.jclouds.azurecompute.arm.domain.NetworkProfile.NetworkInterface.NetworkInterfaceProperties;
-import org.jclouds.azurecompute.arm.domain.OSProfile.WindowsConfiguration.WinRM.Protocol;
-import org.jclouds.azurecompute.arm.domain.OSProfile.WindowsConfiguration.WinRM.ProtocolListener;
 import org.jclouds.azurecompute.arm.functions.ParseJobStatus;
 import org.jclouds.azurecompute.arm.internal.BaseAzureComputeApiLiveTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import static org.testng.util.Strings.isNullOrEmpty;
 
 import com.beust.jcommander.internal.Lists;
 import com.google.common.base.Predicate;
@@ -291,10 +291,10 @@ public class VirtualMachineApiLiveTest extends BaseAzureComputeApiLiveTest {
    private NetworkInterfaceCard createNetworkInterfaceCard(final String resourceGroupName, String networkInterfaceCardName, String locationName, String ipConfigurationName) {
       //Create properties object
       final NetworkInterfaceCardProperties networkInterfaceCardProperties = NetworkInterfaceCardProperties
-            .builder()
-            .ipConfigurations(
-                  Arrays.asList(IpConfiguration.create(ipConfigurationName, null, null, null, IpConfigurationProperties
-                        .create(null, null, "Dynamic", IdReference.create(subnetId), null, null, null)))).build();
+            .builder().ipConfigurations(Arrays.asList(IpConfiguration.create(ipConfigurationName, null, null,
+                  IpConfigurationProperties
+                        .create(null, null, "Dynamic", IdReference.create(subnetId), null, null, null, Boolean.TRUE))))
+            .build();
 
       final Map<String, String> tags = ImmutableMap.of("jclouds", "livetest");
       return api.getNetworkInterfaceCardApi(resourceGroupName).createOrUpdate(networkInterfaceCardName, locationName, networkInterfaceCardProperties, tags);

--- a/providers/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/VirtualMachineScaleSetApiLiveTest.java
+++ b/providers/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/VirtualMachineScaleSetApiLiveTest.java
@@ -16,7 +16,18 @@
  */
 package org.jclouds.azurecompute.arm.features;
 
-import com.google.common.collect.ImmutableMap;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.jclouds.azurecompute.arm.domain.Extension;
 import org.jclouds.azurecompute.arm.domain.ExtensionProfile;
 import org.jclouds.azurecompute.arm.domain.ExtensionProfileSettings;
@@ -51,17 +62,7 @@ import org.jclouds.azurecompute.arm.internal.BaseAzureComputeApiLiveTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Arrays;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import com.google.common.collect.ImmutableMap;
 
 @Test(groups = "live", testName = "VirtualMachineScaleSetApiLiveTest")
 public class VirtualMachineScaleSetApiLiveTest extends BaseAzureComputeApiLiveTest {
@@ -249,10 +250,9 @@ public class VirtualMachineScaleSetApiLiveTest extends BaseAzureComputeApiLiveTe
    private NetworkInterfaceCard createNetworkInterfaceCard(final String resourceGroupName, String networkInterfaceCardName, String locationName, String ipConfigurationName) {
       //Create properties object
       final NetworkInterfaceCardProperties networkInterfaceCardProperties = NetworkInterfaceCardProperties
-         .builder()
-         .ipConfigurations(
-            Arrays.asList(IpConfiguration.create(ipConfigurationName, null, null, null, IpConfigurationProperties
-               .create(null, null, "Dynamic", IdReference.create(subnetId), null, null, null)))).build();
+         .builder().ipConfigurations(Arrays.asList(IpConfiguration.create(ipConfigurationName, null, null,
+                  IpConfigurationProperties
+                        .create(null, null, "Dynamic", IdReference.create(subnetId), null, null, null, null)))).build();
 
       final Map<String, String> tags = ImmutableMap.of("jclouds", "livetest");
       return api.getNetworkInterfaceCardApi(resourceGroupName).createOrUpdate(networkInterfaceCardName, locationName, networkInterfaceCardProperties, tags);

--- a/providers/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/VirtualMachineScaleSetApiMockTest.java
+++ b/providers/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/VirtualMachineScaleSetApiMockTest.java
@@ -16,7 +16,18 @@
  */
 package org.jclouds.azurecompute.arm.features;
 
-import com.google.common.collect.ImmutableMap;
+import static com.google.common.collect.Iterables.isEmpty;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.jclouds.azurecompute.arm.domain.DataDisk;
 import org.jclouds.azurecompute.arm.domain.Extension;
 import org.jclouds.azurecompute.arm.domain.ExtensionProfile;
@@ -49,17 +60,7 @@ import org.jclouds.azurecompute.arm.domain.VirtualMachineScaleSetVirtualMachineP
 import org.jclouds.azurecompute.arm.internal.BaseAzureComputeApiMockTest;
 import org.testng.annotations.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static com.google.common.collect.Iterables.isEmpty;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import com.google.common.collect.ImmutableMap;
 
 
 @Test(groups = "unit", testName = "VirtualMachineScaleSetAPIMockTest", singleThreaded = true)
@@ -349,9 +350,9 @@ public class VirtualMachineScaleSetApiMockTest extends BaseAzureComputeApiMockTe
                       IdReference.create(
                               "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxx/resourceGroups/" +
                                       "jcloud-eastus/providers/" +
-                                      "Microsoft.Network/virtualNetworks/" +
-                                      "jclouds-eastus-virtualNetworkName/subnets/" +
-                                      "jclouds-eastus-subnet")
+                                      "Microsoft.Network/virtualNetworks/" + "jclouds-eastus-virtualNetworkName"
+                                    + "/subnets/"
+                                    + "jclouds-eastus-subnet"), Boolean.TRUE
               );
 
       Map<String, String> tags = ImmutableMap.of("jclouds", "livetest");

--- a/providers/azurecompute-arm/src/test/resources/createnetworkinterfacecard.json
+++ b/providers/azurecompute-arm/src/test/resources/createnetworkinterfacecard.json
@@ -1,35 +1,50 @@
 {
-  "name": "myNic",
-  "id": "/subscriptions/12345678-2749-4e68-9dcf-123456789abc/resourceGroups/azurearmtesting/providers/Microsoft.Network/networkInterfaces/myNic",
-  "etag": "W/\"6b51f6e7-232b-4289-b740-04a996929f5e\"",
-  "type": "Microsoft.Network/networkInterfaces",
-  "location": "northeurope",
+  "name": "myusualvm607",
+  "id": "/subscriptions/bd81406c-6028-4037-9f03-9a3af4ff725d/resourceGroups/abiquo-eastus/providers/Microsoft.Network/networkInterfaces/myusualvm607",
+  "etag": "W/\"01f72f0f-a12f-426a-bf9a-25d09be49cee\"",
+  "location": "eastus",
   "tags": {
     "mycustomtag": "foobar"
   },
   "properties": {
     "provisioningState": "Succeeded",
-    "resourceGuid": "f3465472-536f-49e7-9e9c-fa91b971a618",
+    "resourceGuid": "40a46008-5368-4e9f-ba39-a87b76ea047d",
     "ipConfigurations": [
       {
-        "name": "myip1",
-        "id": "/subscriptions/12345678-2749-4e68-9dcf-123456789abc/resourceGroups/azurearmtesting/providers/Microsoft.Network/networkInterfaces/myNic/ipConfigurations/myip1",
-        "etag": "W/\"6b51f6e7-232b-4289-b740-04a996929f5e\"",
+        "name": "ipconfig1",
+        "id": "/subscriptions/bd81406c-6028-4037-9f03-9a3af4ff725d/resourceGroups/abiquo-eastus/providers/Microsoft.Network/networkInterfaces/myusualvm607/ipConfigurations/ipconfig1",
+        "etag": "W/\"01f72f0f-a12f-426a-bf9a-25d09be49cee\"",
         "properties": {
           "provisioningState": "Succeeded",
-          "privateIPAddress": "10.2.0.4",
+          "privateIPAddress": "192.168.0.4",
           "privateIPAllocationMethod": "Dynamic",
-          "subnet": {
-            "id": "/subscriptions/12345678-2749-4e68-9dcf-123456789abc/resourceGroups/azurearmtesting/providers/Microsoft.Network/virtualNetworks/myvirtualnetwork/subnets/mysubnet"
+          "publicIPAddress": {
+            "id": "/subscriptions/bd81406c-6028-4037-9f03-9a3af4ff725d/resourceGroups/abiquo-eastus/providers/Microsoft.Network/publicIPAddresses/myusualvm-ip"
           },
-          "primary": true
+          "subnet": {
+            "id": "/subscriptions/bd81406c-6028-4037-9f03-9a3af4ff725d/resourceGroups/abiquo-eastus/providers/Microsoft.Network/virtualNetworks/abqvnet-bf0tuznt0x/subnets/abqsubnet-reauuik6qx"
+          },
+          "primary": true,
+          "privateIPAddressVersion": "IPv4",
+          "isInUseWithService": false
         }
       }
     ],
     "dnsSettings": {
       "dnsServers": [],
-      "appliedDnsServers": []
+      "appliedDnsServers": [],
+      "internalDomainNameSuffix": "zqh4yoheybzejmruwtgyl2semg.bx.internal.cloudapp.net"
     },
-    "enableIPForwarding": false
-  }
+    "macAddress": "00-0D-3A-17-A4-C9",
+    "enableAcceleratedNetworking": false,
+    "enableIPForwarding": false,
+    "networkSecurityGroup": {
+      "id": "/subscriptions/bd81406c-6028-4037-9f03-9a3af4ff725d/resourceGroups/abiquo-eastus/providers/Microsoft.Network/networkSecurityGroups/myusualvm-nsg"
+    },
+    "primary": true,
+    "virtualMachine": {
+      "id": "/subscriptions/bd81406c-6028-4037-9f03-9a3af4ff725d/resourceGroups/abiquo-eastus/providers/Microsoft.Compute/virtualMachines/myusualvm"
+    }
+  },
+  "type": "Microsoft.Network/networkInterfaces"
 }

--- a/providers/azurecompute-arm/src/test/resources/getnetworkinterfacecard.json
+++ b/providers/azurecompute-arm/src/test/resources/getnetworkinterfacecard.json
@@ -26,6 +26,7 @@
         }
       }
     ],
+    "primary": true,
     "dnsSettings": {
       "dnsServers": [],
       "appliedDnsServers": []


### PR DESCRIPTION
* Field 'primary' was missing in NetworkInterfaceCardProperties
* Field 'primary' was misplaced in IpConfiguration instead of IpConfigurationProperties

This causes problems when using the provider to configure multiple IPs per NIC and multiple NICs per VirtualMachine


Check https://docs.microsoft.com/en-us/rest/api/virtualnetwork/networkinterfaces/get#networkinterface