### PR TITLE
Fix GCE live tests

### DIFF
--- a/providers/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/DiskType.java
+++ b/providers/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/DiskType.java
@@ -38,7 +38,7 @@ public abstract class DiskType {
 
    @Nullable public abstract Deprecated deprecated();
 
-   public abstract URI zone();
+   @Nullable public abstract URI zone();
 
    public abstract URI selfLink();
 


### PR DESCRIPTION
It looks like the zone parameter no longer comes in the responses.