### PR TITLE
Improve Jetty installation for live tests

### DIFF
--- a/compute/src/test/java/org/jclouds/compute/JettyStatements.java
+++ b/compute/src/test/java/org/jclouds/compute/JettyStatements.java
@@ -16,16 +16,16 @@
  */
 package org.jclouds.compute;
 
-import static org.jclouds.scriptbuilder.domain.Statements.exec;
-import static org.jclouds.scriptbuilder.domain.Statements.extractTargzAndFlattenIntoDirectory;
-import static org.jclouds.scriptbuilder.domain.Statements.literal;
-
-import java.net.URI;
-
 import org.jclouds.scriptbuilder.domain.Statement;
 import org.jclouds.scriptbuilder.domain.StatementList;
 import org.jclouds.scriptbuilder.statements.java.InstallJDK;
 import org.jclouds.scriptbuilder.statements.login.AdminAccess;
+
+import java.net.URI;
+
+import static org.jclouds.scriptbuilder.domain.Statements.exec;
+import static org.jclouds.scriptbuilder.domain.Statements.extractTargzAndFlattenIntoDirectory;
+import static org.jclouds.scriptbuilder.domain.Statements.literal;
 
 public class JettyStatements {
 
@@ -45,14 +45,15 @@ public class JettyStatements {
             AdminAccess.builder().adminUsername("web").build(),
             InstallJDK.fromOpenJDK(),
             authorizePortInIpTables(),
-            extractTargzAndFlattenIntoDirectory(JETTY_URL, JETTY_HOME),
-            exec("chown -R web " + JETTY_HOME));
+            exec("sudo mkdir -p " + JETTY_HOME),
+            exec("chown -R web " + JETTY_HOME),
+            extractTargzAndFlattenIntoDirectory(JETTY_URL, JETTY_HOME));
    }
 
    private static Statement authorizePortInIpTables() {
       return new StatementList(
-            exec("iptables -I INPUT 1 -p tcp --dport " + port + " -j ACCEPT"),
-            exec("iptables-save"));
+            exec("sudo iptables -I INPUT 1 -p tcp --dport " + port + " -j ACCEPT"),
+            exec("sudo iptables-save"));
    }
    
    public static Statement start() {

--- a/compute/src/test/java/org/jclouds/compute/JettyStatements.java
+++ b/compute/src/test/java/org/jclouds/compute/JettyStatements.java
@@ -30,7 +30,7 @@ import static org.jclouds.scriptbuilder.domain.Statements.literal;
 public class JettyStatements {
 
    public static final URI JETTY_URL = URI.create(System.getProperty("test.jetty-url",
-         "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.12.v20180830/jetty-distribution-9.4.12.v20180830.tar.gz));
+         "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.12.v20180830/jetty-distribution-9.4.12.v20180830.tar.gz"));
 
    public static final String JETTY_HOME = "/usr/local/jetty";
    

--- a/compute/src/test/java/org/jclouds/compute/JettyStatements.java
+++ b/compute/src/test/java/org/jclouds/compute/JettyStatements.java
@@ -30,7 +30,7 @@ import static org.jclouds.scriptbuilder.domain.Statements.literal;
 public class JettyStatements {
 
    public static final URI JETTY_URL = URI.create(System.getProperty("test.jetty-url",
-         "http://archive.eclipse.org/jetty/8.1.8.v20121106/dist/jetty-distribution-8.1.8.v20121106.tar.gz"));
+         "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.12.v20180830/jetty-distribution-9.4.12.v20180830.tar.gz));
 
    public static final String JETTY_HOME = "/usr/local/jetty";
    

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -234,7 +234,7 @@
     <auto-service.version>1.0-rc3</auto-service.version>
     <auto-value.version>1.4.1</auto-value.version>
     <java-xmlbuilder.version>1.1</java-xmlbuilder.version>
-    <jetty.version>9.4.12.v20180830</jetty.version>
+    <jetty.version>9.3.24.v20180605</jetty.version>
     <osgi.version>4.2.0</osgi.version>
     <osgi.compendium.version>${osgi.version}</osgi.compendium.version>
     <http.proxyHost />

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -234,7 +234,7 @@
     <auto-service.version>1.0-rc3</auto-service.version>
     <auto-value.version>1.4.1</auto-value.version>
     <java-xmlbuilder.version>1.1</java-xmlbuilder.version>
-    <jetty.version>9.3.24.v20180605</jetty.version>
+    <jetty.version>9.2.22.v20170606</jetty.version>
     <osgi.version>4.2.0</osgi.version>
     <osgi.compendium.version>${osgi.version}</osgi.compendium.version>
     <http.proxyHost />

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -234,6 +234,7 @@
     <auto-service.version>1.0-rc3</auto-service.version>
     <auto-value.version>1.4.1</auto-value.version>
     <java-xmlbuilder.version>1.1</java-xmlbuilder.version>
+    <jetty.version>9.4.12.v20180830</jetty.version>
     <osgi.version>4.2.0</osgi.version>
     <osgi.compendium.version>${osgi.version}</osgi.compendium.version>
     <http.proxyHost />
@@ -282,12 +283,12 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>8.1.8.v20121106</version>
+        <version>${jetty.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>8.1.8.v20121106</version>
+        <version>${jetty.version}</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.okhttp</groupId>

--- a/scriptbuilder/src/main/resources/functions/installOpenJDK.sh
+++ b/scriptbuilder/src/main/resources/functions/installOpenJDK.sh
@@ -53,6 +53,8 @@ function installOpenJDK() {
           PACKAGE=$(apt-cache search --names-only '^openjdk-.-jdk$' | sort -r | cut -d' ' -f1 | head -1) && \
           [ ! -z "$PACKAGE" ] && \
           {  apt-get-install $PACKAGE-headless || apt-get-install $PACKAGE; }
+    elif which yum &> /dev/null; then
+        yum install -y java-devel
     elif which rpm &> /dev/null; then
       PACKAGE=$(repoquery --qf='%{name}' --pkgnarrow=available 'java-*-openjdk-devel' | sort -r | head -1) && \
         [ ! -z "$PACKAGE" ] && \


### PR DESCRIPTION
Notice `sudo` shouldn't be a problem as `AdminAccess` will add the `web` user to sudoers

Fixes a failing test with `BaseComputeServiceLiveTest.testCreateAndRunAService` on a `CentOS 7.x` image

