### PR TITLE
Update DomainResourceReferences.java

### DIFF
--- a/providers/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/DomainResourceReferences.java
+++ b/providers/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/DomainResourceReferences.java
@@ -86,6 +86,7 @@ public final class DomainResourceReferences {
       COLDLINE(Tier.ARCHIVE),
       DURABLE_REDUCED_AVAILABILITY(Tier.STANDARD),
       MULTI_REGIONAL(Tier.STANDARD),
+      REGIONAL(Tier.STANDARD),
       NEARLINE(Tier.INFREQUENT),
       STANDARD(Tier.STANDARD);
 


### PR DESCRIPTION
Hi, GCB allows the user to create a bucket with Storage Class REGIONAL however, this jClouds API doesn't have the enum for the Storage class as REGIONAL.  That's the reason I have updated this class.