### PR TITLE
Removed check for prefix/delimiter in clearContainer

### DIFF
--- a/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/DeleteAllKeysInList.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/DeleteAllKeysInList.java
@@ -380,9 +380,6 @@ public class DeleteAllKeysInList implements ClearListStrategy, ClearContainerStr
 
    public void execute(final String containerName,
          ListContainerOptions listOptions) {
-      if (listOptions.getDelimiter() != null || listOptions.getPrefix() != null) {
-         throw new IllegalArgumentException("Prefix and delimiter support has not yet been added");
-      }
       final AtomicBoolean deleteFailure = new AtomicBoolean();
       int retries = maxErrors;
 

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobStoreIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobStoreIntegrationTest.java
@@ -80,6 +80,14 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
          String.format(XML_STRING_FORMAT, "candy"), "path/4", String.format(XML_STRING_FORMAT, "dogma"), "path/5",
          String.format(XML_STRING_FORMAT, "emma"));
 
+   protected Map<String, String> fiveNestedStrings = ImmutableMap.of(
+           "path/1/a", String.format(XML_STRING_FORMAT, "apple"),
+           "path/1/2/b", String.format(XML_STRING_FORMAT, "bear"),
+           "path/1/2/3/c", String.format(XML_STRING_FORMAT, "candy"),
+           "path/1/2/3/4/d", String.format(XML_STRING_FORMAT, "dog"),
+           "path/1/2/3/5/e", String.format(XML_STRING_FORMAT, "echo")
+   );
+
    public static long INCONSISTENCY_WINDOW = 10000;
    protected static final AtomicInteger containerIndex = new AtomicInteger(0);
 
@@ -278,6 +286,14 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
       for (Entry<String, String> entry : Iterables.concat(fiveStrings.entrySet(), fiveStringsUnderPath.entrySet())) {
          Blob sourceObject = view.getBlobStore().blobBuilder(entry.getKey()).payload(entry.getValue())
                .contentType("text/xml").build();
+         addBlobToContainer(sourceContainer, sourceObject);
+      }
+   }
+
+   protected void add5NestedBlobsToContainer(String sourceContainer) {
+      for (Entry<String, String> entry : fiveNestedStrings.entrySet()) {
+         Blob sourceObject = view.getBlobStore().blobBuilder(entry.getKey()).payload(entry.getValue())
+                 .contentType("text/xml").build();
          addBlobToContainer(sourceContainer, sourceObject);
       }
    }

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
@@ -177,6 +177,65 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
    }
 
    @Test(groups = { "integration", "live" })
+   public void testClearWithOptions() throws InterruptedException {
+      String containerName = getContainerName();
+      try {
+         ListContainerOptions options;
+
+         add5NestedBlobsToContainer(containerName);
+         options = new ListContainerOptions();
+         options.prefix("path/1/");
+         options.recursive();
+         view.getBlobStore().clearContainer(containerName, options);
+         assertConsistencyAwareContainerSize(containerName, 0);
+
+         view.getBlobStore().clearContainer(containerName);
+         add5NestedBlobsToContainer(containerName);
+         options = new ListContainerOptions();
+         options.prefix("path/1/2/3");
+         options.recursive();
+         view.getBlobStore().clearContainer(containerName, options);
+         assertConsistencyAwareContainerSize(containerName, 2);
+
+         view.getBlobStore().clearContainer(containerName);
+         add5NestedBlobsToContainer(containerName);
+         options = new ListContainerOptions();
+         options.prefix("path/1/2/3/4/");
+         options.recursive();
+         view.getBlobStore().clearContainer(containerName, options);
+         assertConsistencyAwareContainerSize(containerName, 4);
+
+         // non-recursive, should not clear anything, as prefix does not match
+         view.getBlobStore().clearContainer(containerName);
+         add5NestedBlobsToContainer(containerName);
+         options = new ListContainerOptions();
+         options.prefix("path/1/2/3");
+         view.getBlobStore().clearContainer(containerName, options);
+         assertConsistencyAwareContainerSize(containerName, 5);
+
+         // non-recursive, should only clear path/1/2/3/c
+         view.getBlobStore().clearContainer(containerName);
+         add5NestedBlobsToContainer(containerName);
+         options = new ListContainerOptions();
+         options.prefix("path/1/2/3/");
+         view.getBlobStore().clearContainer(containerName, options);
+         assertConsistencyAwareContainerSize(containerName, 4);
+
+         // non-recursive, should only clear path/1/2/3/c
+         view.getBlobStore().clearContainer(containerName);
+         add5NestedBlobsToContainer(containerName);
+         options = new ListContainerOptions();
+         options.prefix("path/1/2/3/c");
+         view.getBlobStore().clearContainer(containerName, options);
+         assertConsistencyAwareContainerSize(containerName, 4);
+
+
+      } finally {
+         returnContainer(containerName);
+      }
+   }
+
+   @Test(groups = { "integration", "live" })
    public void testListContainerMarker() throws InterruptedException {
       String containerName = getContainerName();
       try {


### PR DESCRIPTION
as discussed in this mail thread: https://lists.apache.org/thread.html/e10af185b92545935223cd070a9eabbda2898ba7265a223512c07f3f@%3Cuser.jclouds.apache.org%3E

Also added some tests in BaseContainerIntegrationTest that test clearContainer with prefix etc. 