### PR TITLE
Fix for FileSystem blob store clearContainer with options

### DIFF
--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/integration/FilesystemContainerIntegrationTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/integration/FilesystemContainerIntegrationTest.java
@@ -196,6 +196,7 @@ public class FilesystemContainerIntegrationTest extends BaseContainerIntegration
 
    @Override
    public void testClearWithOptions() throws InterruptedException {
-      throw new SkipException("filesystem does not support clear with options");
+//      throw new SkipException("filesystem does not support clear with options");
+      super.testClearWithOptions();
    }
 }

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
@@ -182,6 +182,8 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
       try {
          ListContainerOptions options;
 
+         // Should wipe out all objects, as there are empty folders
+         // above
          add5NestedBlobsToContainer(containerName);
          options = new ListContainerOptions();
          options.prefix("path/1/");
@@ -195,7 +197,10 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
          options.prefix("path/1/2/3");
          options.recursive();
          view.getBlobStore().clearContainer(containerName, options);
-         assertConsistencyAwareContainerSize(containerName, 2);
+         view.getBlobStore().countBlobs(containerName);
+         assertConsistencyAwareBlobExists(containerName, "path/1/a");
+         assertConsistencyAwareBlobExists(containerName, "path/1/2/b");
+         assertConsistencyAwareBlobDoesntExist(containerName, "path/1/2/3");
 
          view.getBlobStore().clearContainer(containerName);
          add5NestedBlobsToContainer(containerName);
@@ -203,7 +208,10 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
          options.prefix("path/1/2/3/4/");
          options.recursive();
          view.getBlobStore().clearContainer(containerName, options);
-         assertConsistencyAwareContainerSize(containerName, 4);
+         assertConsistencyAwareBlobExists(containerName, "path/1/a");
+         assertConsistencyAwareBlobExists(containerName, "path/1/2/b");
+         assertConsistencyAwareBlobExists(containerName, "path/1/2/3/5/e");
+         assertConsistencyAwareBlobDoesntExist(containerName, "path/1/2/3/4");
 
          // non-recursive, should not clear anything, as prefix does not match
          view.getBlobStore().clearContainer(containerName);
@@ -211,7 +219,11 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
          options = new ListContainerOptions();
          options.prefix("path/1/2/3");
          view.getBlobStore().clearContainer(containerName, options);
-         assertConsistencyAwareContainerSize(containerName, 5);
+         assertConsistencyAwareBlobExists(containerName, "path/1/a");
+         assertConsistencyAwareBlobExists(containerName, "path/1/2/b");
+         assertConsistencyAwareBlobExists(containerName, "path/1/2/3/c");
+         assertConsistencyAwareBlobExists(containerName, "path/1/2/3/5/e");
+
 
          // non-recursive, should only clear path/1/2/3/c
          view.getBlobStore().clearContainer(containerName);
@@ -219,7 +231,10 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
          options = new ListContainerOptions();
          options.prefix("path/1/2/3/");
          view.getBlobStore().clearContainer(containerName, options);
-         assertConsistencyAwareContainerSize(containerName, 4);
+         assertConsistencyAwareBlobExists(containerName, "path/1/a");
+         assertConsistencyAwareBlobExists(containerName, "path/1/2/b");
+         assertConsistencyAwareBlobExists(containerName, "path/1/2/3/4/d");
+         assertConsistencyAwareBlobDoesntExist(containerName, "path/1/2/3/c");
 
          // non-recursive, should only clear path/1/2/3/c
          view.getBlobStore().clearContainer(containerName);
@@ -227,7 +242,10 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
          options = new ListContainerOptions();
          options.prefix("path/1/2/3/c");
          view.getBlobStore().clearContainer(containerName, options);
-         assertConsistencyAwareContainerSize(containerName, 4);
+         assertConsistencyAwareBlobExists(containerName, "path/1/a");
+         assertConsistencyAwareBlobExists(containerName, "path/1/2/b");
+         assertConsistencyAwareBlobExists(containerName, "path/1/2/3/4/d");
+         assertConsistencyAwareBlobDoesntExist(containerName, "path/1/2/3/c");
       } finally {
          returnContainer(containerName);
       }


### PR DESCRIPTION
- Added a new `isDirEmpty` that uses an iterator to check emptiness, should be more performant for folders with many files
- Modified unit tests, cannot use the count of objects like in S3 for FileSystem blob store as directories are also counted individually
- Modified the logic in `clearContainer` when prefix, inDirectory, recursive are used. Its a bit messy in there, comments appreciated. 