### PR TITLE
Ignore null StorageMetadata returned from blob store

### DIFF
--- a/core/src/main/java/org/jclouds/concurrent/FutureIterables.java
+++ b/core/src/main/java/org/jclouds/concurrent/FutureIterables.java
@@ -80,7 +80,9 @@ public class FutureIterables {
 
          for (F from : fromIterable) {
             ListenableFuture<? extends T> to = function.apply(from);
-            responses.put(from, to);
+            if (to != null) {
+                responses.put(from, to);
+            }
          }
          try {
             exceptions = awaitCompletion(responses, exec, maxTime, logger, logPrefix);

--- a/core/src/test/java/org/jclouds/concurrent/FutureIterablesTest.java
+++ b/core/src/test/java/org/jclouds/concurrent/FutureIterablesTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.List;
 
 import org.jclouds.logging.Logger;
 import org.jclouds.rest.AuthorizationException;
@@ -37,6 +38,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.collect.Lists;
 
 /**
  * Tests behavior of FutureIterables
@@ -61,6 +63,16 @@ public class FutureIterablesTest {
 
    }
 
+   public void testWithNullResultsInList() {
+       List<String> result = Lists.newArrayList(transformParallel(ImmutableSet.of("hello", "goodbye"), new Function<String, ListenableFuture<? extends String>>() {
+           public ListenableFuture<String> apply(String input) {
+              return null;
+           }
+        }, newDirectExecutorService(), null, Logger.NULL, ""));
+       assertEquals(0, result.size());
+
+    }
+   
    public void testNormalExceptionPropagatesAsTransformParallelExceptionAndTries5XPerElement() {
       final AtomicInteger counter = new AtomicInteger();
 


### PR DESCRIPTION
This is needed because of this issue: https://issues.apache.org/jira/browse/JCLOUDS-1504
The null check will ignore the BlobMetadata which is not found in the blob store and will not be added to the result from the query.

JIRA issue: https://issues.apache.org/jira/browse/JCLOUDS-1504