### PR TITLE
JCLOUDS-1509: read AWS response data with the UTF-8 charset explicitly

### DIFF
--- a/apis/sts/src/main/java/org/jclouds/aws/handlers/ParseAWSErrorFromXmlContent.java
+++ b/apis/sts/src/main/java/org/jclouds/aws/handlers/ParseAWSErrorFromXmlContent.java
@@ -20,6 +20,7 @@ import static org.jclouds.http.HttpUtils.closeClientButKeepContentStream;
 import static org.jclouds.http.HttpUtils.releasePayload;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Resource;
 import javax.inject.Inject;
@@ -65,7 +66,7 @@ public class ParseAWSErrorFromXmlContent implements HttpErrorHandler {
          AWSError error = null;
          // it is important to always read fully and close streams
          byte[] data = closeClientButKeepContentStream(response);
-         String message = data != null ? new String(data) : null;
+         String message = data != null ? new String(data, StandardCharsets.UTF_8) : null;
          if (response.getPayload() != null) {
             String contentType = response.getPayload().getContentMetadata().getContentType();
             if (contentType != null && (contentType.indexOf("xml") != -1 || contentType.indexOf("unknown") != -1)) {


### PR DESCRIPTION
AWS response data is encoded in UTF-8. Creating a String from said data
using the JVM's default charset results in incorrect encoding on
environments in which the JVM's default charset is not UTF-8.

https://issues.apache.org/jira/browse/JCLOUDS-1509